### PR TITLE
Replace instruction rename with vector-less version for performance

### DIFF
--- a/src/A64Instruction.cc
+++ b/src/A64Instruction.cc
@@ -53,10 +53,11 @@ bool A64Instruction::isOperandReady(int index) const {
   return static_cast<bool>(operands[index]);
 }
 
-void A64Instruction::rename(const std::vector<Register>& destinations,
-                            const std::vector<Register>& operands) {
-  destinationRegisters = destinations;
-  sourceRegisters = operands;
+void A64Instruction::renameSource(uint8_t i, Register renamed) {
+  sourceRegisters[i] = renamed;
+}
+void A64Instruction::renameDestination(uint8_t i, Register renamed) {
+  destinationRegisters[i] = renamed;
 }
 
 void A64Instruction::supplyOperand(const Register& reg,

--- a/src/A64Instruction.hh
+++ b/src/A64Instruction.hh
@@ -96,10 +96,13 @@ class A64Instruction : public Instruction {
   /** Check whether the operand at index `i` has had a value supplied. */
   bool isOperandReady(int index) const override;
 
-  /** Override the destination and operand registers with renamed physical
-   * register tags. */
-  void rename(const std::vector<Register>& destinations,
-              const std::vector<Register>& operands) override;
+  /** Override the specified source register with a renamed physical register.
+   */
+  void renameSource(uint8_t i, Register renamed) override;
+
+  /** Override the specified destination register with a renamed physical
+   * register. */
+  void renameDestination(uint8_t i, Register renamed) override;
 
   /** Provide a value for the specified physical register. */
   void supplyOperand(const Register& reg, const RegisterValue& value) override;

--- a/src/Instruction.hh
+++ b/src/Instruction.hh
@@ -27,10 +27,13 @@ class Instruction {
    * renamed. */
   virtual const std::vector<Register>& getDestinationRegisters() const = 0;
 
-  /** Override the destination and operand registers with renamed physical
-   * register tags. */
-  virtual void rename(const std::vector<Register>& destinations,
-                      const std::vector<Register>& operands) = 0;
+  /** Override the specified source register with a renamed physical register.
+   */
+  virtual void renameSource(uint8_t i, Register renamed) = 0;
+
+  /** Override the specified destination register with a renamed physical
+   * register. */
+  virtual void renameDestination(uint8_t i, Register renamed) = 0;
 
   /** Provide a value for the specified physical register. */
   virtual void supplyOperand(const Register& reg,

--- a/src/outoforder/RenameUnit.cc
+++ b/src/outoforder/RenameUnit.cc
@@ -52,25 +52,18 @@ void RenameUnit::tick() {
 
   // Allocate source registers
   auto& sourceRegisters = uop->getOperandRegisters();
-  std::vector<Register> renamedSources(sourceRegisters.size());
   for (size_t i = 0; i < sourceRegisters.size(); i++) {
     const auto& reg = sourceRegisters[i];
     if (!uop->isOperandReady(i)) {
-      renamedSources[i] = rat.getMapping(reg);
-    } else {
-      renamedSources[i] = reg;
+      uop->renameSource(i, rat.getMapping(reg));
     }
   }
 
   // Allocate destination registers
-  std::vector<Register> renamedDestinations(destinationRegisters.size());
   for (size_t i = 0; i < destinationRegisters.size(); i++) {
     const auto& reg = destinationRegisters[i];
-    renamedDestinations[i] = rat.allocate(reg);
+    uop->renameDestination(i, rat.allocate(reg));
   }
-
-  // Supply uop with renamed registers
-  uop->rename(renamedDestinations, renamedSources);
 
   // Reserve a slot in the ROB for this uop
   reorderBuffer.reserve(uop);


### PR DESCRIPTION
Replaces the current `Instruction::rename` function, which requires two vector arguments, with a pair of `renameSource` and `renameDestination` functions, each taking an index and a `Register`. This removes the need to generate temporary vectors to hold renamed values, preventing the need for memory allocation and increasing performance as a result.

Performance gain from this change was measured at between 8-15%, depending on platform.