### PR TITLE
Add local byte array to RegisterValue for storing smaller data values

### DIFF
--- a/src/RegisterValue.cc
+++ b/src/RegisterValue.cc
@@ -5,8 +5,6 @@
 namespace simeng {
 
 RegisterValue::RegisterValue() : bytes(0) {}
-RegisterValue::RegisterValue(std::shared_ptr<char> ptr, uint8_t bytes)
-    : bytes(bytes), ptr(ptr) {}
 
 RegisterValue::operator bool() const { return (bytes > 0); }
 
@@ -26,7 +24,5 @@ RegisterValue RegisterValue::zeroExtend(uint8_t fromBytes,
 
   return extended;
 }
-
-bool RegisterValue::isLocal() const { return bytes <= threshold; }
 
 }  // namespace simeng

--- a/src/RegisterValue.hh
+++ b/src/RegisterValue.hh
@@ -2,20 +2,18 @@
 #pragma once
 
 #include <cassert>
+#include <cstring>
 #include <memory>
 
 namespace simeng {
 
-/** A class that holds an arbitrary region of immitable data, providing casting
- * and data accessor functions. For values smaller than or equal to `threshold`,
- * this data is held in a local value, otherwise memory is allocated and the
- * data is stored there. */
+/** A class that holds an arbitrary region of immutable data, providing casting
+ * and data accessor functions. For values smaller than or equal to
+ * `MAX_LOCAL_BYTES`, this data is held in a local value, otherwise memory is
+ * allocated and the data is stored there. */
 class RegisterValue {
  public:
   RegisterValue();
-
-  /** Create a RegisterValue from an existing type. */
-  RegisterValue(std::shared_ptr<char> ptr, uint8_t bytes);
 
   /** Create a new RegisterValue from a value of arbitrary type, zero-extending
    * the allocated memory space to the specified number of bytes (defaulting to
@@ -35,14 +33,27 @@ class RegisterValue {
     }
   }
 
+  /** Create a new RegisterValue of size `bytes`, copying data from `ptr`.
+   */
+  RegisterValue(const char* ptr, uint8_t bytes) : bytes(bytes) {
+    char* dest;
+    if (isLocal()) {
+      dest = this->value;
+    } else {
+      dest = static_cast<char*>(malloc(bytes));
+      this->ptr = std::shared_ptr<char>(dest, free);
+    }
+    std::memcpy(dest, ptr, bytes);
+  }
+
   /** Read the encapsulated raw memory as a specified datatype. */
   template <class T>
   T get() const {
     return *getAsVector<T>();
   }
 
-  /** Retrieve a pointer to the encapsulated raw memory, reinterpreted as the
-   * specified datatype. */
+  /** Retrieve a pointer to the encapsulated raw memory, reinterpreted as
+   * the specified datatype. */
   template <class T>
   const T* getAsVector() const {
     assert(bytes > 0 && "Attempted to access an uninitialised RegisterValue");
@@ -60,16 +71,16 @@ class RegisterValue {
   operator bool() const;
 
   /** Create a new RegisterValue of size `toBytes`, copying the first
-   * `fromBytes` bytes of this one. The remaining bytes of the new RegisterValue
-   * are zeroed. */
+   * `fromBytes` bytes of this one. The remaining bytes of the new
+   * RegisterValue are zeroed. */
   RegisterValue zeroExtend(uint8_t fromBytes, uint8_t toBytes) const;
 
  private:
   /** Check whether the value is held locally or behind a pointer. */
-  bool isLocal() const;
+  bool isLocal() const { return bytes <= MAX_LOCAL_BYTES; }
 
   /** The maximum number of bytes that can be held locally. */
-  static const uint8_t threshold = 8;
+  static const uint8_t MAX_LOCAL_BYTES = 8;
 
   /** The number of bytes held. */
   uint8_t bytes = 0;
@@ -77,9 +88,9 @@ class RegisterValue {
   /** The underlying pointer each instance references. */
   std::shared_ptr<char> ptr;
 
-  /** The underlying local member value. Aligned to 8 bytes to prevent potential
-   * alignment issue when casting. */
-  alignas(8) char value[threshold];
+  /** The underlying local member value. Aligned to 8 bytes to prevent
+   * potential alignment issue when casting. */
+  alignas(8) char value[MAX_LOCAL_BYTES];
 };
 
 }  // namespace simeng

--- a/src/emulation/Core.cc
+++ b/src/emulation/Core.cc
@@ -40,13 +40,8 @@ void Core::tick() {
   if (uop->isLoad()) {
     auto addresses = uop->generateAddresses();
     for (auto const& request : addresses) {
-      // Pointer manipulation to generate a RegisterValue from an arbitrary
-      // memory address
-      auto buffer = malloc(request.second);
-      memcpy(buffer, memory + request.first, request.second);
-
-      auto ptr = std::shared_ptr<uint8_t>((uint8_t*)buffer, free);
-      auto data = simeng::RegisterValue(ptr, request.second);
+      // Copy the data at the requested memory address into a RegisterValue
+      auto data = simeng::RegisterValue(memory + request.first, request.second);
 
       uop->supplyData(request.first, data);
     }

--- a/src/inorder/ExecuteUnit.cc
+++ b/src/inorder/ExecuteUnit.cc
@@ -29,13 +29,8 @@ void ExecuteUnit::tick() {
   if (uop->isLoad()) {
     auto addresses = uop->generateAddresses();
     for (auto const& request : addresses) {
-      // Pointer manipulation to generate a RegisterValue from an arbitrary
-      // memory address
-      auto buffer = malloc(request.second);
-      memcpy(buffer, memory + request.first, request.second);
-
-      auto ptr = std::shared_ptr<uint8_t>((uint8_t*)buffer, free);
-      auto data = RegisterValue(ptr, request.second);
+      // Copy the data at the requested memory address into a RegisterValue
+      auto data = RegisterValue(memory + request.first, request.second);
 
       uop->supplyData(request.first, data);
     }

--- a/src/outoforder/ExecuteUnit.cc
+++ b/src/outoforder/ExecuteUnit.cc
@@ -61,13 +61,8 @@ void ExecuteUnit::execute(std::shared_ptr<Instruction>& uop) {
   if (uop->isLoad()) {
     auto addresses = uop->generateAddresses();
     for (auto const& request : addresses) {
-      // Pointer manipulation to generate a RegisterValue from an arbitrary
-      // memory address
-      auto buffer = malloc(request.second);
-      memcpy(buffer, memory + request.first, request.second);
-
-      auto ptr = std::shared_ptr<uint8_t>((uint8_t*)buffer, free);
-      auto data = RegisterValue(ptr, request.second);
+      // Copy the data at the requested memory address into a RegisterValue
+      auto data = RegisterValue(memory + request.first, request.second);
 
       uop->supplyData(request.first, data);
     }


### PR DESCRIPTION
Adds a local 8-byte array to `RegisterValue`, used for 64-bit or smaller values, and tracks the number of bytes held. This reduces the frequency of memory allocations and increases performance by approximately 11-18%, depending on platform.

Resolves #31 