### PR TITLE
Replaces vectors with spans in Instruction interface

### DIFF
--- a/src/A64Instruction.hh
+++ b/src/A64Instruction.hh
@@ -85,13 +85,13 @@ class A64Instruction : public Instruction {
    * decoding or execution. */
   InstructionException getException() const override;
 
-  /** Retrieve a vector of source registers this instruction reads. */
-  const std::vector<Register>& getOperandRegisters() const override;
+  /** Retrieve the source registers this instruction reads. */
+  const span<Register> getOperandRegisters() const override;
 
-  /** Retrieve a vector of destination registers this instruction will write to.
+  /** Retrieve the destination registers this instruction will write to.
    * A register value of -1 signifies a Zero Register read, and should not be
    * renamed. */
-  const std::vector<Register>& getDestinationRegisters() const override;
+  const span<Register> getDestinationRegisters() const override;
 
   /** Check whether the operand at index `i` has had a value supplied. */
   bool isOperandReady(int index) const override;
@@ -126,7 +126,7 @@ class A64Instruction : public Instruction {
   bool canCommit() const override;
 
   /** Retrieve register results. */
-  const std::vector<RegisterValue>& getResults() const override;
+  const span<RegisterValue> getResults() const override;
 
   /** Generate memory addresses this instruction wishes to access. */
   std::vector<std::pair<uint64_t, uint8_t>> generateAddresses() override;
@@ -185,6 +185,13 @@ class A64Instruction : public Instruction {
   static const Register ZERO_REGISTER;
 
  private:
+  /** The maximum number of source registers any supported A64 instruction can
+   * have. */
+  static const size_t MAX_SOURCE_REGISTERS = 4;
+  /** The maximum number of destination registers any supported A64 instruction
+   * can have. */
+  static const size_t MAX_DESTINATION_REGISTERS = 3;
+
   /** This instruction's opcode. */
   A64Opcode opcode;
 
@@ -194,19 +201,23 @@ class A64Instruction : public Instruction {
   /** Metadata for this instruction; used for operation logic */
   A64DecodeMetadata metadata;
 
-  /** A vector of source registers. */
-  std::vector<Register> sourceRegisters;
+  /** An array of source registers. */
+  std::array<Register, MAX_SOURCE_REGISTERS> sourceRegisters;
+  /** The number of source registers this instruction reads from. */
+  size_t sourceRegisterCount = 0;
 
-  /** A vector of destination registers. */
-  std::vector<Register> destinationRegisters;
+  /** An array of destination registers. */
+  std::array<Register, MAX_DESTINATION_REGISTERS> destinationRegisters;
+  /** The number of destination registers this instruction writes to. */
+  size_t destinationRegisterCount = 0;
 
-  /** A vector of provided operand values. Each entry corresponds to a
+  /** An array of provided operand values. Each entry corresponds to a
    * `sourceRegisters` entry. */
-  std::vector<RegisterValue> operands;
+  std::array<RegisterValue, MAX_SOURCE_REGISTERS> operands;
 
-  /** A vector of generated output results. Each entry corresponds to a
+  /** An array of generated output results. Each entry corresponds to a
    * `destinationRegisters` entry. */
-  std::vector<RegisterValue> results;
+  std::array<RegisterValue, MAX_DESTINATION_REGISTERS> results;
 
   /** The current exception state of this instruction. */
   A64InstructionException exception = A64InstructionException::None;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SIMENG_SOURCES
     RegisterFile.hh
     RegisterValue.cc
     RegisterValue.hh
+    span.hh
     main.cc
     )
 

--- a/src/Instruction.hh
+++ b/src/Instruction.hh
@@ -2,6 +2,7 @@
 
 #include "RegisterFile.hh"
 #include "RegisterValue.hh"
+#include "span.hh"
 
 #include <vector>
 
@@ -19,13 +20,13 @@ class Instruction {
    * decoding or execution. */
   virtual InstructionException getException() const = 0;
 
-  /** Retrieve a vector of source registers this instruction reads. */
-  virtual const std::vector<Register>& getOperandRegisters() const = 0;
+  /** Retrieve the source registers this instruction reads. */
+  virtual const span<Register> getOperandRegisters() const = 0;
 
-  /** Retrieve a vector of destination registers this instruction will write to.
+  /** Retrieve the destination registers this instruction will write to.
    * A register value of -1 signifies a Zero Register read, and should not be
    * renamed. */
-  virtual const std::vector<Register>& getDestinationRegisters() const = 0;
+  virtual const span<Register> getDestinationRegisters() const = 0;
 
   /** Override the specified source register with a renamed physical register.
    */
@@ -61,7 +62,7 @@ class Instruction {
   virtual bool canCommit() const = 0;
 
   /** Retrieve register results. */
-  virtual const std::vector<RegisterValue>& getResults() const = 0;
+  virtual const span<RegisterValue> getResults() const = 0;
 
   /** Generate memory addresses this instruction wishes to access. */
   virtual std::vector<std::pair<uint64_t, uint8_t>> generateAddresses() = 0;

--- a/src/inorder/DecodeUnit.cc
+++ b/src/inorder/DecodeUnit.cc
@@ -57,8 +57,8 @@ void DecodeUnit::tick() {
   fromFetchBuffer.getHeadSlots()[0].clear();
 }
 
-void DecodeUnit::forwardOperands(const std::vector<Register>& registers,
-                                 const std::vector<RegisterValue>& values) {
+void DecodeUnit::forwardOperands(const span<Register>& registers,
+                                 const span<RegisterValue>& values) {
   assert(registers.size() == values.size() &&
          "Mismatched register and value vector sizes");
 

--- a/src/inorder/DecodeUnit.hh
+++ b/src/inorder/DecodeUnit.hh
@@ -22,8 +22,8 @@ class DecodeUnit {
 
   /** Forwards operands and performs register reads for the currently queued
    * instruction. */
-  void forwardOperands(const std::vector<Register>& destinations,
-                       const std::vector<RegisterValue>& values);
+  void forwardOperands(const span<Register>& destinations,
+                       const span<RegisterValue>& values);
 
   /** Check whether the core should be flushed this cycle. */
   bool shouldFlush() const;

--- a/src/outoforder/DispatchIssueUnit.cc
+++ b/src/outoforder/DispatchIssueUnit.cc
@@ -106,9 +106,8 @@ void DispatchIssueUnit::issue() {
   }
 }
 
-void DispatchIssueUnit::forwardOperands(
-    const std::vector<Register>& registers,
-    const std::vector<RegisterValue>& values) {
+void DispatchIssueUnit::forwardOperands(const span<Register>& registers,
+                                        const span<RegisterValue>& values) {
   assert(registers.size() == values.size() &&
          "Mismatched register and value vector sizes");
 

--- a/src/outoforder/DispatchIssueUnit.hh
+++ b/src/outoforder/DispatchIssueUnit.hh
@@ -32,8 +32,8 @@ class DispatchIssueUnit {
 
   /** Forwards operands and performs register reads for the currently queued
    * instruction. */
-  void forwardOperands(const std::vector<Register>& destinations,
-                       const std::vector<RegisterValue>& values);
+  void forwardOperands(const span<Register>& destinations,
+                       const span<RegisterValue>& values);
 
   /** Set the scoreboard entry for the provided register as ready. */
   void setRegisterReady(Register reg);

--- a/src/span.hh
+++ b/src/span.hh
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <iterator>
+
+namespace simeng {
+
+/** A partial implementation of the C++20 `std::span`. Provides an iterable
+ * wrapper around a pointer of type T, with a known number of elements.
+ *
+ * https://en.cppreference.com/w/cpp/container/span */
+template <class T>
+class span {
+ public:
+  using pointer = T*;
+  using index_type = size_t;
+  using reference = T&;
+  using iterator = pointer;
+  using const_iterator = const iterator;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  constexpr span() noexcept : pointer_(nullptr), size_(0) {}
+  constexpr span(pointer ptr, index_type count) : pointer_(ptr), size_(count) {}
+
+  template <std::size_t N>
+  constexpr span(std::array<T, N>& arr) : pointer_(arr.data()), size_(N) {}
+
+  constexpr index_type size() const { return size_; }
+  [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
+
+  constexpr iterator begin() const noexcept { return pointer_; }
+  constexpr const_iterator cbegin() const noexcept { return begin(); }
+
+  constexpr reverse_iterator rbegin() const noexcept {
+    return reverse_iterator(end());
+  }
+  constexpr const_reverse_iterator crbegin() const noexcept {
+    return const_reverse_iterator(cend());
+  }
+
+  constexpr iterator end() const noexcept { return pointer_ + size_; }
+  constexpr const_iterator cend() const noexcept { return end(); }
+
+  constexpr reverse_iterator rend() const noexcept {
+    return reverse_iterator(begin());
+  }
+  constexpr const_reverse_iterator crend() const noexcept {
+    return const_reverse_iterator(cbegin());
+  }
+
+  constexpr reference front() const { return pointer_[0]; }
+  constexpr reference back() const { return pointer_[size_ - 1]; }
+  constexpr pointer data() const noexcept { return pointer_; }
+
+  constexpr reference operator[](index_type idx) const {
+    return pointer_[idx];
+  };
+
+ private:
+  T* pointer_;
+  index_type size_;
+};
+
+}  // namespace simeng


### PR DESCRIPTION
Updates the `Instruction` interface to replace returns of `std::vector` with a custom `span` class (based off C++20's `std::span`) for several frequently called functions. This allows the `A64Instruction` implementation to store source/destination registers, operands, and results as fixed-length arrays with element counters, rather than as vectors. This reduces the number of memory allocation calls required each time an `A64Instruction` instance is created/destroyed, and increases performance by 20-30% depending on platform.

Note that memory-related functions (`generateAddresses`, `getGeneratedAddresses`, `getData`) still use `std::vector`. While most memory instructions will only generate 1-2 addresses, it's possible for SVE instructions to generate up to 64 independent memory access requests (2048-bit SVE, gather/scatter, scalar base + 32-bit vector of offsets). This is larger than is reasonable to allocate by default, and will require a more complex solution in future.