### PR TITLE
Update predecode function to take a macro-op as an output parameter

### DIFF
--- a/src/A64Architecture.cc
+++ b/src/A64Architecture.cc
@@ -6,9 +6,10 @@ namespace simeng {
 
 std::unordered_map<uint32_t, A64Instruction> A64Architecture::decodeCache;
 
-std::tuple<MacroOp, uint8_t> A64Architecture::predecode(
-    const void* ptr, uint8_t bytesAvailable, uint64_t instructionAddress,
-    BranchPrediction prediction) const {
+uint8_t A64Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
+                                   uint64_t instructionAddress,
+                                   BranchPrediction prediction,
+                                   MacroOp& output) const {
   assert(bytesAvailable >= 4 && "Fewer than 4 bytes supplied to A64 decoder");
 
   // Dereference the instruction pointer to obtain the instruction word
@@ -27,8 +28,11 @@ std::tuple<MacroOp, uint8_t> A64Architecture::predecode(
   uop->setInstructionAddress(instructionAddress);
   uop->setBranchPrediction(prediction);
 
-  // Bundle into a macro-op and return
-  return {{uop}, 4};
+  // Bundle uop into output macro-op and return
+  output.resize(1);
+  output[0] = uop;
+
+  return 4;
 }
 
 std::vector<RegisterFileStructure> A64Architecture::getRegisterFileStructure()

--- a/src/A64Architecture.hh
+++ b/src/A64Architecture.hh
@@ -12,11 +12,11 @@ namespace simeng {
 class A64Architecture : public Architecture {
  public:
   /** Pre-decode instruction memory into a macro-op of `A64Instruction`
-   * instances. Returns the macro-op generated and the number of bytes consumed
-   * to produce it (always 4). */
-  std::tuple<MacroOp, uint8_t> predecode(
-      const void* ptr, uint8_t bytesAvailable, uint64_t instructionAddress,
-      BranchPrediction prediction) const override;
+   * instances. Returns the number of bytes consumed to produce it (always 4),
+   * and writes into the supplied macro-op vector. */
+  uint8_t predecode(const void* ptr, uint8_t bytesAvailable,
+                    uint64_t instructionAddress, BranchPrediction prediction,
+                    MacroOp& output) const override;
 
   /** Returns an ARMv8-a register file structure description. */
   std::vector<RegisterFileStructure> getRegisterFileStructure() const override;

--- a/src/Architecture.hh
+++ b/src/Architecture.hh
@@ -18,12 +18,13 @@ class Architecture {
   virtual ~Architecture(){};
 
   /** Attempt to pre-decode from `bytesAvailable` bytes of instruction memory.
-   * Returns the macro-op generated and the number of bytes consumed to produce
-   * it; a value of 0 indicates too few bytes were present for a valid decoding.
-   */
-  virtual std::tuple<MacroOp, uint8_t> predecode(
-      const void* ptr, uint8_t bytesAvailable, uint64_t instructionAddress,
-      BranchPrediction prediction) const = 0;
+   * Writes into the supplied macro-op vector, and returns the number of bytes
+   * consumed to produce it; a value of 0 indicates too few bytes were present
+   * for a valid decoding. */
+  virtual uint8_t predecode(const void* ptr, uint8_t bytesAvailable,
+                            uint64_t instructionAddress,
+                            BranchPrediction prediction,
+                            MacroOp& output) const = 0;
 
   /** Returns a vector of {size, number} pairs describing the available
    * registers. */

--- a/src/emulation/Core.cc
+++ b/src/emulation/Core.cc
@@ -20,12 +20,12 @@ void Core::tick() {
   }
 
   // Fetch
-  auto [macroop, bytesRead] = isa.predecode(insnPtr + pc, 4, pc, {false, 0});
+  auto bytesRead = isa.predecode(insnPtr + pc, 4, pc, {false, 0}, macroOp);
 
   pc += bytesRead;
 
   // Decode
-  auto uop = macroop[0];
+  auto uop = macroOp[0];
 
   // Issue
   auto registers = uop->getOperandRegisters();

--- a/src/emulation/Core.hh
+++ b/src/emulation/Core.hh
@@ -49,6 +49,9 @@ class Core : public simeng::Core {
 
   /** Whether or not the core has halted. */
   bool hasHalted_ = false;
+
+  /** A reusable macro-op vector to fill with uops. */
+  MacroOp macroOp;
 };
 
 }  // namespace emulation

--- a/src/inorder/FetchUnit.cc
+++ b/src/inorder/FetchUnit.cc
@@ -22,8 +22,10 @@ void FetchUnit::tick() {
     return;
   }
 
+  auto& macroOp = toDecode.getTailSlots()[0];
+
   auto prediction = branchPredictor.predict(pc);
-  auto [macroop, bytesRead] = isa.predecode(insnPtr + pc, 4, pc, prediction);
+  auto bytesRead = isa.predecode(insnPtr + pc, 4, pc, prediction, macroOp);
 
   if (!prediction.taken) {
     // Predicted as not taken; increment PC to next instruction
@@ -32,9 +34,6 @@ void FetchUnit::tick() {
     // Predicted as taken; set PC to predicted target address
     pc = prediction.target;
   }
-
-  auto out = toDecode.getTailSlots();
-  out[0] = macroop;
 
   if (pc >= programByteLength) {
     hasHalted_ = true;

--- a/src/outoforder/FetchUnit.cc
+++ b/src/outoforder/FetchUnit.cc
@@ -22,8 +22,10 @@ void FetchUnit::tick() {
     return;
   }
 
+  auto& macroOp = toDecode.getTailSlots()[0];
+
   auto prediction = branchPredictor.predict(pc);
-  auto [macroop, bytesRead] = isa.predecode(insnPtr + pc, 4, pc, prediction);
+  auto bytesRead = isa.predecode(insnPtr + pc, 4, pc, prediction, macroOp);
 
   if (!prediction.taken) {
     // Predicted as not taken; increment PC to next instruction
@@ -32,8 +34,6 @@ void FetchUnit::tick() {
     // Predicted as taken; set PC to predicted target address
     pc = prediction.target;
   }
-
-  toDecode.getTailSlots()[0] = macroop;
 
   if (pc >= programByteLength) {
     hasHalted_ = true;


### PR DESCRIPTION
Modifies the `Architecture::predecode` interface to take a macro-op reference(`std::vector<std::shared_ptr<Instruction>>&`) as an argument, into which it places the decoded uop(s).

This prevents constantly allocating/freeing temporary vectors each fetch tick, and provides an 8-15% performance benefit, depending on platform.