### PR TITLE
Adds parameterised tests for PipelineBuffer

### DIFF
--- a/test/unit/PipelineBufferTest.cc
+++ b/test/unit/PipelineBufferTest.cc
@@ -3,40 +3,62 @@
 
 namespace {
 
+class PipelineBufferTest : public ::testing::TestWithParam<size_t> {};
+
 // Test that we can create a pipeline buffer with a specified initial value
-TEST(PipelineBufferTest, Create) {
-  auto pipelineBuffer = simeng::PipelineBuffer<int>(1, 1);
-  EXPECT_EQ(pipelineBuffer.getTailSlots()[0], 1);
-  EXPECT_EQ(pipelineBuffer.getHeadSlots()[0], 1);
+TEST_P(PipelineBufferTest, Create) {
+  auto pipelineBuffer = simeng::PipelineBuffer<int>(GetParam(), 1);
+  for (size_t i = 0; i < GetParam(); i++) {
+    EXPECT_EQ(pipelineBuffer.getTailSlots()[i], 1);
+    EXPECT_EQ(pipelineBuffer.getHeadSlots()[i], 1);
+  }
 }
 
 // Test that values move when ticked
-TEST(PipelineBufferTest, Tick) {
-  auto pipelineBuffer = simeng::PipelineBuffer<int>(1, 0);
-  pipelineBuffer.getTailSlots()[0] = 1;
+TEST_P(PipelineBufferTest, Tick) {
+  auto pipelineBuffer = simeng::PipelineBuffer<int>(GetParam(), 0);
+  for (size_t i = 0; i < GetParam(); i++) {
+    pipelineBuffer.getTailSlots()[i] = i;
+  }
+
   pipelineBuffer.tick();
-  EXPECT_EQ(pipelineBuffer.getHeadSlots()[0], 1);
+
+  for (size_t i = 0; i < GetParam(); i++) {
+    EXPECT_EQ(pipelineBuffer.getTailSlots()[i], 0);
+    EXPECT_EQ(pipelineBuffer.getHeadSlots()[i], i);
+  }
 }
 
 // Test that values don't move once stalled
-TEST(PipelineBufferTest, Stall) {
-  auto pipelineBuffer = simeng::PipelineBuffer<int>(1, 0);
-  pipelineBuffer.getTailSlots()[0] = 1;
+TEST_P(PipelineBufferTest, Stall) {
+  auto pipelineBuffer = simeng::PipelineBuffer<int>(GetParam(), 0);
+  for (size_t i = 0; i < GetParam(); i++) {
+    pipelineBuffer.getTailSlots()[i] = i;
+  }
 
   pipelineBuffer.stall(true);
   EXPECT_TRUE(pipelineBuffer.isStalled());
-
   pipelineBuffer.tick();
-  EXPECT_EQ(pipelineBuffer.getHeadSlots()[0], 0);
+
+  for (size_t i = 0; i < GetParam(); i++) {
+    EXPECT_EQ(pipelineBuffer.getTailSlots()[i], i);
+    EXPECT_EQ(pipelineBuffer.getHeadSlots()[i], 0);
+  }
 }
 
 // Test that filling the buffer works
-TEST(PipelineBufferTest, Fill) {
-  auto pipelineBuffer = simeng::PipelineBuffer<int>(1, 1);
+TEST_P(PipelineBufferTest, Fill) {
+  auto pipelineBuffer = simeng::PipelineBuffer<int>(GetParam(), 1);
 
   pipelineBuffer.fill(0);
-  EXPECT_EQ(pipelineBuffer.getTailSlots()[0], 0);
-  EXPECT_EQ(pipelineBuffer.getHeadSlots()[0], 0);
+
+  for (size_t i = 0; i < GetParam(); i++) {
+    EXPECT_EQ(pipelineBuffer.getTailSlots()[i], 0);
+    EXPECT_EQ(pipelineBuffer.getHeadSlots()[i], 0);
+  }
 }
+
+INSTANTIATE_TEST_SUITE_P(PipelineBufferTests, PipelineBufferTest,
+                         ::testing::Range<size_t>(1, 9, 1));
 
 }  // namespace


### PR DESCRIPTION
Modifies the existing `PipelineBuffer` test suite to use parameterised tests, and tests across buffers of width 1 through 8 inclusive. The range of widths to test may be easily modified at a later date.

Resolves #47 