### PR TITLE
Improve address generation performance

### DIFF
--- a/src/A64Instruction.cc
+++ b/src/A64Instruction.cc
@@ -88,8 +88,8 @@ void A64Instruction::supplyData(uint64_t address, const RegisterValue& data) {
   }
 }
 
-span<RegisterValue> A64Instruction::getData() const {
-  return {const_cast<RegisterValue*>(memoryData.data()), memoryData.size()};
+span<const RegisterValue> A64Instruction::getData() const {
+  return {memoryData.data(), memoryData.size()};
 }
 
 bool A64Instruction::canExecute() const { return (operandsPending == 0); }
@@ -108,10 +108,9 @@ void A64Instruction::setMemoryAddresses(
   memoryAddresses = addresses;
 }
 
-span<std::pair<uint64_t, uint8_t>> A64Instruction::getGeneratedAddresses()
+span<const std::pair<uint64_t, uint8_t>> A64Instruction::getGeneratedAddresses()
     const {
-  return {const_cast<std::pair<uint64_t, uint8_t>*>(memoryAddresses.data()),
-          memoryAddresses.size()};
+  return {memoryAddresses.data(), memoryAddresses.size()};
 }
 
 std::tuple<bool, uint64_t> A64Instruction::checkEarlyBranchMisprediction()

--- a/src/A64Instruction.hh
+++ b/src/A64Instruction.hh
@@ -78,16 +78,17 @@ class A64Instruction : public Instruction {
   const span<RegisterValue> getResults() const override;
 
   /** Generate memory addresses this instruction wishes to access. */
-  span<std::pair<uint64_t, uint8_t>> generateAddresses() override;
+  span<const std::pair<uint64_t, uint8_t>> generateAddresses() override;
 
   /** Retrieve previously generated memory addresses. */
-  span<std::pair<uint64_t, uint8_t>> getGeneratedAddresses() const override;
+  span<const std::pair<uint64_t, uint8_t>> getGeneratedAddresses()
+      const override;
 
   /** Provide data from a requested memory address. */
   void supplyData(uint64_t address, const RegisterValue& data) override;
 
   /** Retrieve supplied memory data. */
-  span<RegisterValue> getData() const override;
+  span<const RegisterValue> getData() const override;
 
   /** Early misprediction check; see if it's possible to determine whether the
    * next instruction address was mispredicted without executing the

--- a/src/A64Instruction_address.cc
+++ b/src/A64Instruction_address.cc
@@ -3,7 +3,7 @@
 
 namespace simeng {
 
-span<std::pair<uint64_t, uint8_t>> A64Instruction::generateAddresses() {
+span<const std::pair<uint64_t, uint8_t>> A64Instruction::generateAddresses() {
   assert((isLoad() || isStore()) &&
          "generateAddresses called on non-load-or-store instruction");
 

--- a/src/Instruction.hh
+++ b/src/Instruction.hh
@@ -66,16 +66,17 @@ class Instruction {
   virtual const span<RegisterValue> getResults() const = 0;
 
   /** Generate memory addresses this instruction wishes to access. */
-  virtual span<std::pair<uint64_t, uint8_t>> generateAddresses() = 0;
+  virtual span<const std::pair<uint64_t, uint8_t>> generateAddresses() = 0;
 
   /** Provide data from a requested memory address. */
   virtual void supplyData(uint64_t address, const RegisterValue& data) = 0;
 
   /** Retrieve previously generated memory addresses. */
-  virtual span<std::pair<uint64_t, uint8_t>> getGeneratedAddresses() const = 0;
+  virtual span<const std::pair<uint64_t, uint8_t>> getGeneratedAddresses()
+      const = 0;
 
   /** Retrieve supplied memory data. */
-  virtual span<RegisterValue> getData() const = 0;
+  virtual span<const RegisterValue> getData() const = 0;
 
   /** Early misprediction check; see if it's possible to determine whether the
    * next instruction address was mispredicted without executing the

--- a/test/unit/MockInstruction.hh
+++ b/test/unit/MockInstruction.hh
@@ -19,11 +19,11 @@ class MockInstruction : public Instruction {
   MOCK_CONST_METHOD0(canExecute, bool());
   MOCK_METHOD0(execute, void());
   MOCK_CONST_METHOD0(getResults, const span<RegisterValue>());
-  MOCK_METHOD0(generateAddresses, span<std::pair<uint64_t, uint8_t>>());
+  MOCK_METHOD0(generateAddresses, span<const std::pair<uint64_t, uint8_t>>());
   MOCK_METHOD2(supplyData, void(uint64_t address, const RegisterValue& data));
   MOCK_CONST_METHOD0(getGeneratedAddresses,
-                     span<std::pair<uint64_t, uint8_t>>());
-  MOCK_CONST_METHOD0(getData, span<RegisterValue>());
+                     span<const std::pair<uint64_t, uint8_t>>());
+  MOCK_CONST_METHOD0(getData, span<const RegisterValue>());
 
   MOCK_CONST_METHOD0(checkEarlyBranchMisprediction,
                      std::tuple<bool, uint64_t>());

--- a/test/unit/pipeline/ReorderBufferTest.cc
+++ b/test/unit/pipeline/ReorderBufferTest.cc
@@ -147,11 +147,15 @@ TEST_F(ReorderBufferTest, CommitLoad) {
 // Tests that the reorder buffer correctly triggers a store upon commit
 TEST_F(ReorderBufferTest, CommitStore) {
   std::vector<std::pair<uint64_t, uint8_t>> addresses = {{0, 1}};
+  span<const std::pair<uint64_t, uint8_t>> addressesSpan = {addresses.data(),
+                                                            addresses.size()};
+
   std::vector<RegisterValue> data = {static_cast<uint8_t>(1)};
+  span<const RegisterValue> dataSpan = {data.data(), data.size()};
 
   ON_CALL(*uop, isStore()).WillByDefault(Return(true));
-  ON_CALL(*uop, getGeneratedAddresses()).WillByDefault(Return(addresses));
-  ON_CALL(*uop, getData()).WillByDefault(Return(data));
+  ON_CALL(*uop, getGeneratedAddresses()).WillByDefault(Return(addressesSpan));
+  ON_CALL(*uop, getData()).WillByDefault(Return(dataSpan));
 
   lsq.addStore(uopPtr);
 


### PR DESCRIPTION
Replaces instances of `std::vector` with alternatives for address-generation related functions in the `Instruction` class. Improves performance of memory-heavy simulations (such as STREAM) by 15-20%

Summary of changes:
* All functions related to retrieving addresses or memory data from an instruction now use `span`, for consistency with other similar functions, and to prevent unnecessary memory allocations 
* The private `A64Instruction::setMemoryAddresses` now accepts a `std::initializer_list` argument to prevent memory allocations for temporary vectors