### PR TITLE
Add Core::getArchitecturalRegisterFileSet() method

### DIFF
--- a/src/lib/Core.hh
+++ b/src/lib/Core.hh
@@ -5,6 +5,8 @@
 
 namespace simeng {
 
+class ArchitecturalRegisterFileSet;
+
 /** An abstract core model. */
 class Core {
  public:
@@ -15,6 +17,10 @@ class Core {
 
   /** Check whether the program has halted. */
   virtual bool hasHalted() const = 0;
+
+  /** Retrieve the architectural register file set. */
+  virtual const ArchitecturalRegisterFileSet& getArchitecturalRegisterFileSet()
+      const = 0;
 
   /** Retrieve a map of statistics to report. */
   virtual std::map<std::string, std::string> getStats() const = 0;

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -202,6 +202,11 @@ void Core::applyStateChange(const ProcessStateChange& change) {
 
 bool Core::hasHalted() const { return hasHalted_; }
 
+const ArchitecturalRegisterFileSet& Core::getArchitecturalRegisterFileSet()
+    const {
+  return architecturalRegisterFileSet_;
+}
+
 std::map<std::string, std::string> Core::getStats() const { return {}; };
 
 }  // namespace emulation

--- a/src/lib/models/emulation/Core.hh
+++ b/src/lib/models/emulation/Core.hh
@@ -30,6 +30,10 @@ class Core : public simeng::Core {
   /** Check whether the program has halted. */
   bool hasHalted() const override;
 
+  /** Retrieve the architectural register file set. */
+  const ArchitecturalRegisterFileSet& getArchitecturalRegisterFileSet()
+      const override;
+
   /** Retrieve a map of statistics to report. */
   std::map<std::string, std::string> getStats() const override;
 

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -116,6 +116,11 @@ bool Core::hasHalted() const {
           !executePending);
 }
 
+const ArchitecturalRegisterFileSet& Core::getArchitecturalRegisterFileSet()
+    const {
+  return architecturalRegisterFileSet_;
+}
+
 std::map<std::string, std::string> Core::getStats() const {
   auto retired = writebackUnit_.getInstructionsWrittenCount();
   auto ipc = retired / static_cast<float>(ticks_);

--- a/src/lib/models/inorder/Core.hh
+++ b/src/lib/models/inorder/Core.hh
@@ -33,6 +33,10 @@ class Core : public simeng::Core {
   /** Check whether the program has halted. */
   bool hasHalted() const override;
 
+  /** Retrieve the architectural register file set. */
+  const ArchitecturalRegisterFileSet& getArchitecturalRegisterFileSet()
+      const override;
+
   /** Generate a map of statistics to report. */
   std::map<std::string, std::string> getStats() const override;
 

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -282,6 +282,11 @@ void Core::applyStateChange(const ProcessStateChange& change) {
   }
 }
 
+const ArchitecturalRegisterFileSet& Core::getArchitecturalRegisterFileSet()
+    const {
+  return mappedRegisterFileSet_;
+}
+
 std::map<std::string, std::string> Core::getStats() const {
   auto retired = writebackUnit_.getInstructionsWrittenCount();
   auto ipc = retired / static_cast<float>(ticks_);

--- a/src/lib/models/outoforder/Core.hh
+++ b/src/lib/models/outoforder/Core.hh
@@ -39,6 +39,10 @@ class Core : public simeng::Core {
   /** Check whether the program has halted. */
   bool hasHalted() const override;
 
+  /** Retrieve the architectural register file set. */
+  const ArchitecturalRegisterFileSet& getArchitecturalRegisterFileSet()
+      const override;
+
   /** Generate a map of statistics to report. */
   std::map<std::string, std::string> getStats() const override;
 


### PR DESCRIPTION
Allows external entities to inspect the state of the architectural
registers, which is needed for the regression testing framework.