### PR TITLE
Adds fixed-latency memory interface

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SIMENG_SOURCES
     BTBPredictor.cc
     CMakeLists.txt
     Elf.cc
+    FixedLatencyMemoryInterface.cc
     FlatMemoryInterface.cc
     Instruction.cc
     RegisterFileSet.cc
@@ -63,6 +64,7 @@ set(SIMENG_HEADERS
     BTBPredictor.hh
     Core.hh
     Elf.hh
+    FixedLatencyMemoryInterface.hh
     FlatMemoryInterface.hh
     Instruction.hh
     MemoryInterface.hh

--- a/src/lib/FixedLatencyMemoryInterface.cc
+++ b/src/lib/FixedLatencyMemoryInterface.cc
@@ -1,0 +1,72 @@
+#include "FixedLatencyMemoryInterface.hh"
+
+#include <cassert>
+
+namespace simeng {
+
+FixedLatencyMemoryInterface::FixedLatencyMemoryInterface(char* memory,
+                                                         size_t size,
+                                                         uint16_t latency)
+    : memory_(memory), size_(size), latency_(latency) {}
+
+void FixedLatencyMemoryInterface::tick() {
+  tickCounter_++;
+
+  while (pendingRequests_.size() > 0) {
+    const auto& request = pendingRequests_.front();
+
+    if (request.readyAt > tickCounter_) {
+      // Head of queue isn't ready yet; end cycle
+      break;
+    }
+
+    const auto& target = request.target;
+
+    if (request.write) {
+      // Write: write data directly to memory
+      assert(target.address + target.size <= size_ &&
+             "Attempted to write beyond memory limit");
+
+      auto ptr = memory_ + target.address;
+      // Copy the data from the RegisterValue to memory
+      memcpy(ptr, request.data.getAsVector<char>(), target.size);
+    } else {
+      // Read: read data into `completedReads`
+      if (target.address + target.size > size_) {
+        // Read outside of memory; return an invalid value to signal a fault
+        completedReads_.push_back({target, RegisterValue()});
+      } else {
+        const char* ptr = memory_ + target.address;
+
+        // Copy the data at the requested memory address into a RegisterValue
+        completedReads_.push_back({target, RegisterValue(ptr, target.size)});
+      }
+    }
+
+    // Remove the request from the queue
+    pendingRequests_.pop();
+  }
+}
+
+void FixedLatencyMemoryInterface::requestRead(
+    const MemoryAccessTarget& target) {
+  pendingRequests_.push({target, tickCounter_ + latency_ - 1});
+}
+
+void FixedLatencyMemoryInterface::requestWrite(const MemoryAccessTarget& target,
+                                               const RegisterValue& data) {
+  pendingRequests_.push({target, data, tickCounter_ + latency_ - 1});
+}
+
+const span<std::pair<MemoryAccessTarget, RegisterValue>>
+FixedLatencyMemoryInterface::getCompletedReads() const {
+  return {const_cast<std::pair<MemoryAccessTarget, RegisterValue>*>(
+              completedReads_.data()),
+          completedReads_.size()};
+}
+
+void FixedLatencyMemoryInterface::clearCompletedReads() {
+  completedReads_.clear();
+}
+
+}  // namespace simeng

--- a/src/lib/FixedLatencyMemoryInterface.hh
+++ b/src/lib/FixedLatencyMemoryInterface.hh
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "MemoryInterface.hh"
+
+#include <queue>
+#include <vector>
+
+namespace simeng {
+
+/** A fixed-latency memory interface request. */
+struct FixedLatencyMemoryInterfaceRequest {
+  /** Is this a write request? */
+  bool write;
+
+  /** The memory target to access. */
+  const MemoryAccessTarget target;
+
+  /** The value to write to the target (writes only) */
+  const RegisterValue data;
+
+  /** The cycle count this request will be ready at. */
+  uint64_t readyAt;
+
+  /** Construct a write request. */
+  FixedLatencyMemoryInterfaceRequest(const MemoryAccessTarget& target,
+                                     const RegisterValue& data,
+                                     uint64_t readyAt)
+      : write(true), target(target), data(data), readyAt(readyAt) {}
+
+  /** Construct a read request. */
+  FixedLatencyMemoryInterfaceRequest(const MemoryAccessTarget& target,
+                                     uint64_t readyAt)
+      : write(false), target(target), readyAt(readyAt) {}
+};
+
+/** A memory interface where all requests respond with a fixed latency. */
+class FixedLatencyMemoryInterface : public MemoryInterface {
+ public:
+  FixedLatencyMemoryInterface(char* memory, size_t size, uint16_t latency);
+
+  /** Queue a read request from the supplied target location. */
+  void requestRead(const MemoryAccessTarget& target) override;
+  /** Queue a write request of `data` to the target location. */
+  void requestWrite(const MemoryAccessTarget& target,
+                    const RegisterValue& data) override;
+  /** Retrieve all completed requests. */
+  const span<std::pair<MemoryAccessTarget, RegisterValue>> getCompletedReads()
+      const override;
+
+  /** Clear the completed reads. */
+  void clearCompletedReads() override;
+
+  /** Tick the memory model to process the request queue. */
+  void tick() override;
+
+ private:
+  /** The array representing the memory system to access. */
+  char* memory_;
+  /** The size of accessible memory. */
+  size_t size_;
+  /** A vector containing all completed read requests. */
+  std::vector<std::pair<MemoryAccessTarget, RegisterValue>> completedReads_;
+
+  /** A queue containing all pending memory requests. */
+  std::queue<FixedLatencyMemoryInterfaceRequest> pendingRequests_;
+
+  /** The latency all requests are completed after. */
+  uint16_t latency_;
+
+  /** The number of times this interface has been ticked. */
+  uint64_t tickCounter_ = 0;
+};
+
+}  // namespace simeng

--- a/src/lib/FlatMemoryInterface.cc
+++ b/src/lib/FlatMemoryInterface.cc
@@ -39,4 +39,6 @@ FlatMemoryInterface::getCompletedReads() const {
 
 void FlatMemoryInterface::clearCompletedReads() { completedReads_.clear(); }
 
+void FlatMemoryInterface::tick() {}
+
 }  // namespace simeng

--- a/src/lib/FlatMemoryInterface.hh
+++ b/src/lib/FlatMemoryInterface.hh
@@ -23,6 +23,9 @@ class FlatMemoryInterface : public MemoryInterface {
   /** Clear the completed reads. */
   void clearCompletedReads() override;
 
+  /** Tick: do nothing */
+  void tick() override;
+
  private:
   /** The array representing the flat memory system to access. */
   char* memory_;

--- a/src/lib/MemoryInterface.hh
+++ b/src/lib/MemoryInterface.hh
@@ -38,6 +38,13 @@ class MemoryInterface {
 
   /** Clear the completed reads. */
   virtual void clearCompletedReads() = 0;
+
+  /** Tick the memory interface to allow it to process internal tasks.
+   *
+   * TODO: Move ticking out of the memory interface and into a central "memory
+   * system" covering a set of related interfaces.
+   */
+  virtual void tick() = 0;
 };
 
 }  // namespace simeng

--- a/test/unit/MockMemoryInterface.hh
+++ b/test/unit/MockMemoryInterface.hh
@@ -18,6 +18,8 @@ class MockMemoryInterface : public MemoryInterface {
       const span<std::pair<MemoryAccessTarget, RegisterValue>>());
 
   MOCK_METHOD0(clearCompletedReads, void());
+
+  MOCK_METHOD0(tick, void());
 };
 
 }  // namespace simeng


### PR DESCRIPTION
Adds a fixed-latency memory interface implementation, which waits for a specified number of cycles before handling memory requests.

Summary of changes:
* Adds `tick` method to `MemoryInterface`. References to the used memory interfaces are passed to the `simulate` method in `main.cc` and interfaces are ticked alongside the core model.
* Adds `FixedLatencyMemoryInterface` memory interface implementation. This keeps an internal queue of requests alongside a counter representing the cycle they should be handled during. Once that cycle is reached, the read/write is made; for reads, the response is placed into the completed loads for the core to retrieve.
* `main.cc` has been modified to supply the out-of-order core with a fixed-latency memory interface for data access, with latency currently set to 4 cycles.