### PR TITLE
[AArch64] Implement 32-bit madd instruction

### DIFF
--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -669,6 +669,13 @@ void Instruction::execute() {
       results[0] = a + (x * y);
       return;
     }
+    case Opcode::AArch64_MADDWrrr: {  // madd wd, wn, wm, wa
+      auto x = operands[0].get<uint32_t>();
+      auto y = operands[1].get<uint32_t>();
+      auto a = operands[2].get<uint32_t>();
+      results[0] = static_cast<uint64_t>(a + (x * y));
+      return;
+    }
     case Opcode::AArch64_MOVIv2d_ns: {  // movi vd.2d, #imm
       uint64_t bits = static_cast<uint64_t>(metadata.operands[1].imm);
       uint64_t vector[2] = {bits, bits};

--- a/test/regression/aarch64/CMakeLists.txt
+++ b/test/regression/aarch64/CMakeLists.txt
@@ -2,7 +2,10 @@ add_executable(regression-aarch64
                AArch64RegressionTest.cc
                AArch64RegressionTest.hh
                SmokeTest.cc
+               instructions/multiply.cc
                )
+target_include_directories(regression-aarch64 PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(regression-aarch64 regression-test-base)
 
 add_test(NAME regression-aarch64-test COMMAND regression-aarch64)

--- a/test/regression/aarch64/instructions/multiply.cc
+++ b/test/regression/aarch64/instructions/multiply.cc
@@ -1,0 +1,29 @@
+#include "AArch64RegressionTest.hh"
+
+namespace {
+
+using InstMul = AArch64RegressionTest;
+
+TEST_P(InstMul, maddw) {
+  RUN_AARCH64(R"(
+    movz w0, #7
+    movz w1, #6
+    movz w2, #5
+    madd w3, w0, w1, w2
+  )");
+  EXPECT_EQ(getGeneralRegister<uint32_t>(3), 47u);
+}
+
+TEST_P(InstMul, mulw) {
+  RUN_AARCH64(R"(
+    movz w0, #7
+    movz w1, #6
+    mul w2, w0, w1
+  )");
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 42u);
+}
+
+INSTANTIATE_TEST_SUITE_P(AArch64, InstMul, ::testing::Values(EMULATION),
+                         coreTypeToString);
+
+}  // namespace


### PR DESCRIPTION
For all new instructions going forward, I'm going to add a least one simple regression test covering its semantics. This also makes developing easier, since one can test the instruction they are trying to add in isolation, rather than having to wait until they've implemented all of the instructions needed for their target application to see if they all work.