### PR TITLE
 [AArch64] Implement set_tid_address syscall

### DIFF
--- a/src/include/simeng/kernel/Linux.hh
+++ b/src/include/simeng/kernel/Linux.hh
@@ -17,6 +17,11 @@ struct LinuxProcessState {
   uint64_t currentBrk;
   /** The initial stack pointer. */
   uint64_t initialStackPointer;
+
+  // Thread state
+  // TODO: Support multiple threads per process
+  /** The clear_child_tid value. */
+  uint64_t clearChildTid = 0;
 };
 
 /** A Linux kernel syscall emulation implementation, which mimics the responses
@@ -47,6 +52,9 @@ class Linux {
   /** readlinkat syscall: read value of a symbolic link. */
   int64_t readlinkat(int64_t dirfd, const std::string pathname, char* buf,
                      size_t bufsize) const;
+
+  /** set_tid_address syscall: set clear_child_tid value for calling thread. */
+  int64_t setTidAddress(uint64_t tidptr);
 
   /** The maximum size of a filesystem path. */
   static const size_t LINUX_PATH_MAX = 4096;

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -55,6 +55,11 @@ bool ExceptionHandler::init() {
                   << exitCode << std::endl;
         return fatal();
       }
+      case 96: {  // set_tid_address
+        uint64_t ptr = registerFileSet_.get(R0).get<uint64_t>();
+        stateChange = {{R0}, {linux_.setTidAddress(ptr)}};
+        break;
+      }
       case 160: {  // uname
         const uint64_t base = registerFileSet_.get(R0).get<uint64_t>();
         const uint8_t len =

--- a/src/lib/kernel/Linux.cc
+++ b/src/lib/kernel/Linux.cc
@@ -61,5 +61,11 @@ int64_t Linux::readlinkat(int64_t dirfd, const std::string pathname, char* buf,
   return -1;
 }
 
+int64_t Linux::setTidAddress(uint64_t tidptr) {
+  assert(processStates_.size() > 0);
+  processStates_[0].clearChildTid = tidptr;
+  return processStates_[0].pid;
+}
+
 }  // namespace kernel
 }  // namespace simeng


### PR DESCRIPTION
With this and the other outstanding pull requests, we can now execute empty programs linked against musl.