### PR TITLE
[AArch64] Implement tst with immediate

### DIFF
--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -341,8 +341,11 @@ void InstructionMetadata::revertAliasing() {
       return aliasNYI();
     case ARM64_INS_TST:
       if (opcode == Opcode::AArch64_ANDSWrs ||
-          opcode == Opcode::AArch64_ANDSXrs) {
+          opcode == Opcode::AArch64_ANDSXrs ||
+          opcode == Opcode::AArch64_ANDSWri ||
+          opcode == Opcode::AArch64_ANDSXri) {
         // tst rn, rm; alias for: ands zr, rn, rm
+        // tst rn, #imm; alias for: ands zr, rn, #imm
         operandCount = 3;
         operands[2] = operands[1];
         operands[1] = operands[0];
@@ -350,7 +353,8 @@ void InstructionMetadata::revertAliasing() {
 
         operands[0].type = ARM64_OP_REG;
         operands[0].access = CS_AC_WRITE;
-        if (opcode == Opcode::AArch64_ANDSWrs) {
+        if (opcode == Opcode::AArch64_ANDSWrs ||
+            opcode == Opcode::AArch64_ANDSWri) {
           operands[0].reg = ARM64_REG_WZR;
         } else {
           operands[0].reg = ARM64_REG_XZR;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -252,14 +252,21 @@ void Instruction::execute() {
       results[0] = (instructionAddress_ & ~(0xFFF)) + metadata.operands[1].imm;
       return;
     }
+    case Opcode::AArch64_ANDSWri: {  // ands wd, wn, #imm
+      auto x = operands[0].get<uint32_t>();
+      auto y = static_cast<uint32_t>(metadata.operands[2].imm);
+      uint32_t result = x & y;
+      results[0] = nzcv(result >> 31, result == 0, false, false);
+      results[1] = result;
+      return;
+    }
     case Opcode::AArch64_ANDSWrs: {  // ands wd, wn, wm{, shift #amount}
       auto x = operands[0].get<uint32_t>();
       auto y = shiftValue(operands[1].get<uint32_t>(),
                           metadata.operands[2].shift.type,
                           metadata.operands[2].shift.value);
       uint32_t result = x & y;
-      results[0] =
-          nzcv(static_cast<int32_t>(result) < 0, result == 0, false, false);
+      results[0] = nzcv(result >> 31, result == 0, false, false);
       if (destinationRegisterCount > 1) {
         results[1] = static_cast<uint64_t>(result);
       }
@@ -269,8 +276,7 @@ void Instruction::execute() {
       auto x = operands[0].get<uint64_t>();
       auto y = metadata.operands[2].imm;
       uint64_t result = x & y;
-      results[0] =
-          nzcv(static_cast<int64_t>(result) < 0, result == 0, false, false);
+      results[0] = nzcv(result >> 63, result == 0, false, false);
       results[1] = result;
       return;
     }
@@ -280,8 +286,7 @@ void Instruction::execute() {
                           metadata.operands[2].shift.type,
                           metadata.operands[2].shift.value);
       uint64_t result = x & y;
-      results[0] =
-          nzcv(static_cast<int64_t>(result) < 0, result == 0, false, false);
+      results[0] = nzcv(result >> 63, result == 0, false, false);
       if (destinationRegisterCount > 1) {
         results[1] = result;
       }

--- a/test/regression/aarch64/CMakeLists.txt
+++ b/test/regression/aarch64/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(regression-aarch64
                AArch64RegressionTest.hh
                SmokeTest.cc
                instructions/arithmetic.cc
+               instructions/comparison.cc
                instructions/divide.cc
                instructions/load.cc
                instructions/multiply.cc

--- a/test/regression/aarch64/instructions/comparison.cc
+++ b/test/regression/aarch64/instructions/comparison.cc
@@ -1,0 +1,58 @@
+#include "AArch64RegressionTest.hh"
+
+namespace {
+
+using InstComparison = AArch64RegressionTest;
+
+// Test that NZCV flags are set correctly by 32-bit tst
+TEST_P(InstComparison, tstw) {
+  // tst 0, 1 = false
+  RUN_AARCH64(R"(
+    tst wzr, #0x1
+  )");
+  EXPECT_EQ(getNZCV(), 0b0100);
+
+  // tst 0b0110, 0b0010 = true
+  RUN_AARCH64(R"(
+    movk w0, #0x6
+    tst w0, #0x2
+  )");
+  EXPECT_EQ(getNZCV(), 0b0000);
+
+  // tst -1, 0b1000... = true, negative
+  RUN_AARCH64(R"(
+    mov w0, wzr
+    sub w0, w0, #1
+    tst w0, #0x80000000
+  )");
+  EXPECT_EQ(getNZCV(), 0b1000);
+}
+
+// Test that NZCV flags are set correctly by 64-bit tst
+TEST_P(InstComparison, tstx) {
+  // tst 0, 1 = false
+  RUN_AARCH64(R"(
+    tst xzr, #0x1
+  )");
+  EXPECT_EQ(getNZCV(), 0b0100);
+
+  // tst 0b0110, 0b0010 = true
+  RUN_AARCH64(R"(
+    movk x0, #0b0110
+    tst x0, #0b0010
+  )");
+  EXPECT_EQ(getNZCV(), 0b0000);
+
+  // tst -1, 0b1000... = true, negative
+  RUN_AARCH64(R"(
+    mov x0, xzr
+    sub x0, x0, #1
+    tst x0, #0x8000000000000000
+  )");
+  EXPECT_EQ(getNZCV(), 0b1000);
+}
+
+INSTANTIATE_TEST_SUITE_P(AArch64, InstComparison, ::testing::Values(EMULATION),
+                         coreTypeToString);
+
+}  // namespace


### PR DESCRIPTION
Use shift to determine sign bit for all ANDS instructions.