### PR TITLE
[AArch64] Implement 64-bit stlxr instruction

### DIFF
--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -144,6 +144,10 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses({{operands[1].get<uint64_t>(), 4}});
       break;
     }
+    case Opcode::AArch64_STLXRX: {  // stlxr ws, xt, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
     case Opcode::AArch64_STPDi: {  // stp dt1, dt2, [xn, #imm]
       uint64_t base =
           operands[2].get<uint64_t>() + metadata.operands[2].mem.disp;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -833,6 +833,12 @@ void Instruction::execute() {
       results[0] = static_cast<uint64_t>(0);
       return;
     }
+    case Opcode::AArch64_STLXRX: {  // stlxr ws, xt, [xn]
+      memoryData[0] = operands[0];
+      // TODO: Implement atomic memory access
+      results[0] = static_cast<uint64_t>(0);
+      return;
+    }
     case Opcode::AArch64_STPDi: {  // stp dt1, dt2, [xn, #imm]
       memoryData[0] = operands[0];
       memoryData[1] = operands[1];


### PR DESCRIPTION
Implementing the correct memory ordering and atomic behaviour is left
for a future patch (hence the lack of tests here).