### PR TITLE
[AArch64] Implement 64-bit ldaxr instruction

### DIFF
--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -15,6 +15,10 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses({{operands[0].get<uint64_t>(), 4}});
       break;
     }
+    case Opcode::AArch64_LDAXRX: {  // ldaxr xd, [xn]
+      setMemoryAddresses({{operands[0].get<uint64_t>(), 8}});
+      break;
+    }
     case Opcode::AArch64_LDRBBpre: {  // ldrb wt, [xn, #imm]!
       setMemoryAddresses(
           {{operands[0].get<uint64_t>() + metadata.operands[1].mem.disp, 1}});

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -557,6 +557,10 @@ void Instruction::execute() {
       results[0] = memoryData[0].zeroExtend(4, 8);
       return;
     }
+    case Opcode::AArch64_LDAXRX: {  // ldaxr xd, [xn]
+      results[0] = memoryData[0];
+      return;
+    }
     case Opcode::AArch64_LDPQi: {  // ldp qt1, qt2, [xn, #imm]
       results[0] = memoryData[0];
       results[1] = memoryData[1];


### PR DESCRIPTION
Implementing the correct memory ordering and atomic behaviour is left
for a future patch (hence the lack of tests here).