### PR TITLE
Fix RAW violation check in LSQ

### DIFF
--- a/src/include/simeng/pipeline/LoadStoreQueue.hh
+++ b/src/include/simeng/pipeline/LoadStoreQueue.hh
@@ -3,6 +3,7 @@
 #include <deque>
 #include <functional>
 #include <queue>
+#include <unordered_set>
 
 #include "simeng/Instruction.hh"
 #include "simeng/MemoryInterface.hh"
@@ -84,6 +85,9 @@ class LoadStoreQueue {
 
   /** Slots to write completed load instructions into for writeback. */
   span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots_;
+
+  /** The set of uncommitted loads that have already requested their data. */
+  std::unordered_set<std::shared_ptr<Instruction>> pendingLoads_;
 
   /** A function handler to call to forward the results of a completed load. */
   std::function<void(span<Register>, span<RegisterValue>)> forwardOperands_;

--- a/test/regression/aarch64/CMakeLists.txt
+++ b/test/regression/aarch64/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(regression-aarch64
                AArch64RegressionTest.cc
                AArch64RegressionTest.hh
+               LoadStoreQueue.cc
                SmokeTest.cc
                instructions/arithmetic.cc
                instructions/divide.cc

--- a/test/regression/aarch64/LoadStoreQueue.cc
+++ b/test/regression/aarch64/LoadStoreQueue.cc
@@ -1,0 +1,29 @@
+#include "AArch64RegressionTest.hh"
+
+namespace {
+
+using LoadStoreQueue = AArch64RegressionTest;
+
+// Test reading from an address immediately after storing to it.
+TEST_P(LoadStoreQueue, RAW) {
+  initialHeapData_.resize(8);
+  reinterpret_cast<uint64_t*>(initialHeapData_.data())[0] = -1;
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    # Write a value and try to read it immediately.
+    mov x1, #42
+    str x1, [x0]
+    ldr x2, [x0]
+  )");
+  EXPECT_EQ(getGeneralRegister<uint64_t>(2), 42u);
+}
+
+INSTANTIATE_TEST_SUITE_P(AArch64, LoadStoreQueue, ::testing::Values(OUTOFORDER),
+                         coreTypeToString);
+
+}  // namespace


### PR DESCRIPTION
When a store is committed, the code was previously only checking loads
that have executed (i.e. received all of their data). This meant that
loads which have started prior to the store committing (but not yet
received all of their data) would not be checked.

The fix is to add a hash set to track uncommitted loads that have
started, regardless of whether they have received their data or not,
and check all of them when a store commits.

This seemed to have the nice side effect of a slight performance
improvement as well, since we're now only iterating over
started+uncommitted loads, rather than all loads in the queue.