### PR TITLE
Raise exception for failed data reads

### DIFF
--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -37,6 +37,7 @@ enum class InstructionException {
   EncodingUnallocated,
   EncodingNotYetImplemented,
   ExecutionNotYetImplemented,
+  DataAbort,
   SupervisorCall,
   HypervisorCall,
   SecureMonitorCall

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -223,6 +223,9 @@ void ExceptionHandler::printException(const Instruction& insn) const {
     case InstructionException::ExecutionNotYetImplemented:
       std::cout << "execution not-yet-implemented";
       break;
+    case InstructionException::DataAbort:
+      std::cout << "data abort";
+      break;
     case InstructionException::SupervisorCall:
       std::cout << "supervisor call";
       break;

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -89,7 +89,16 @@ void Instruction::supplyOperand(const Register& reg,
 void Instruction::supplyData(uint64_t address, const RegisterValue& data) {
   for (size_t i = 0; i < memoryAddresses.size(); i++) {
     if (memoryAddresses[i].address == address && !memoryData[i]) {
-      memoryData[i] = data;
+      if (!data) {
+        // Raise exception for failed read
+        // TODO: Move this logic to caller and distinguish between different
+        // memory faults (e.g. bus error, page fault, seg fault)
+        exception = InstructionException::DataAbort;
+        exceptionEncountered_ = true;
+        memoryData[i] = RegisterValue(0, memoryAddresses[i].size);
+      } else {
+        memoryData[i] = data;
+      }
       dataPending_--;
       return;
     }

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -157,8 +157,7 @@ void LoadStoreQueue::tick() {
     auto address = response.first.address;
     const auto& data = response.second;
 
-    // TODO: Detect and handle any faults
-    assert(response.second && "Memory read failed");
+    // TODO: Detect and handle non-fatal faults (e.g. page fault)
 
     // TODO: Create a data structure to allow direct lookup of requests waiting
     // on a read, rather than iterating over the queue (see DispatchIssueQueue's


### PR DESCRIPTION
This allows programs that speculatively execute invalid loads to
execute properly, as the abort will only trigger if the instruction
retires.