### PR TITLE
Fix port deallocation when flushing instructions

### DIFF
--- a/src/include/simeng/pipeline/DispatchIssueUnit.hh
+++ b/src/include/simeng/pipeline/DispatchIssueUnit.hh
@@ -31,8 +31,7 @@ class DispatchIssueUnit {
       std::vector<PipelineBuffer<std::shared_ptr<Instruction>>>& issuePorts,
       const RegisterFileSet& registerFileSet, PortAllocator& portAllocator,
       const std::vector<uint16_t>& physicalRegisterStructure,
-      unsigned int maxReservationStationSize,
-      unsigned int maxInFlightInstructions);
+      unsigned int maxReservationStationSize);
 
   /** Ticks the dispatch/issue unit. Reads available input operands for
    * instructions and sets scoreboard flags for destination registers. */
@@ -85,10 +84,6 @@ class DispatchIssueUnit {
   /** The maximum reservation station size. */
   unsigned int maxReservationStationSize_;
 
-  /** The reservation station. Holds instructions until operands become
-   * available. */
-  std::vector<ReservationStationEntry> reservationStation_;
-
   /** A dependency matrix, containing all the instructions waiting on an
    * operand. For a register `{type,tag}`, the vector of dependents may be found
    * at `dependencyMatrix[type][tag]`. */
@@ -100,9 +95,6 @@ class DispatchIssueUnit {
 
   /** The queues of ready instructions for each port. */
   std::vector<std::deque<std::shared_ptr<Instruction>>> readyQueues_;
-
-  /** The index of the next available RS slot. */
-  size_t rsHead_ = 0;
 
   /** The number of items currently in the RS. */
   size_t rsSize_ = 0;

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -57,8 +57,7 @@ Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
                   reorderBuffer_, registerAliasTable_, loadStoreQueue_,
                   physicalRegisterStructures.size()),
       dispatchIssueUnit_(renameToDispatchBuffer_, issuePorts_, registerFileSet_,
-                         portAllocator, physicalRegisterQuantities, rsSize,
-                         robSize),
+                         portAllocator, physicalRegisterQuantities, rsSize),
       writebackUnit_(completionSlots_, registerFileSet_) {
   for (size_t i = 0; i < executionUnitCount; i++) {
     executionUnits_.emplace_back(

--- a/src/lib/pipeline/BalancedPortAllocator.cc
+++ b/src/lib/pipeline/BalancedPortAllocator.cc
@@ -47,7 +47,10 @@ uint8_t BalancedPortAllocator::allocate(uint16_t instructionGroup) {
   return bestPort;
 }
 
-void BalancedPortAllocator::issued(uint8_t port) { weights[port]--; }
+void BalancedPortAllocator::issued(uint8_t port) {
+  assert(weights[port] > 0);
+  weights[port]--;
+}
 void BalancedPortAllocator::deallocate(uint8_t port) { issued(port); };
 
 }  // namespace pipeline


### PR DESCRIPTION
The circular buffer used to hold entries in the reservation station has been removed, since the RS is not a FIFO structure and this was causing problems. It was also redundant; all instructions in the RS will either be in one of the ready queues or in the dependency matrix, so process them there during flushing instead.

This doesn't seem to have a significant performance impact since it only adds potential overhead during flushes, which will hopefully be (relatively) infrequent.

The core issue fixed by these changes is one whereby the RS deallocated a port for the same flushed instruction more than once if it was in the ready queue. This lead to incorrect port weights in the balanced port allocator, which meant that all integer instructions were being allocated the same port.

This makes the TX2 model *much* more accurate for the STREAM Triad L1 cache benchmark (currently within 4% of real hardware).