### PR TITLE
Predecode micro-optimisation

### DIFF
--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -64,16 +64,14 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
     iter = result.first;
   }
 
-  // Retrieve the cached instruction
-  std::shared_ptr<Instruction> uop =
-      std::make_shared<Instruction>(iter->second);
+  output.resize(1);
+  auto& uop = output[0];
+
+  // Retrieve the cached instruction and write to output
+  uop = std::make_shared<Instruction>(iter->second);
 
   uop->setInstructionAddress(instructionAddress);
   uop->setBranchPrediction(prediction);
-
-  // Bundle uop into output macro-op and return
-  output.resize(1);
-  output[0] = uop;
 
   return 4;
 }


### PR DESCRIPTION
Makes some minor tweaks to the pre-decode function (currently the function with the most self-time) to shave ~2-3% off runtime.

Summary of changes:
* Removes a redundant decode cache `count` operation: `find` was always called shortly afterwards, the result of which can also be used to check for the presence of an entry.
* Removes a temporary `shared_ptr` variable: `make_shared` was creating a `shared_ptr`, copying it to the output buffer, and deleting the original upon leaving the scope, with each extra creation/deletion incurring an atomic read/write to the pointer's counter.