### PR TITLE
Operand supplying micro-optimisation

### DIFF
--- a/src/include/simeng/Instruction.hh
+++ b/src/include/simeng/Instruction.hh
@@ -38,9 +38,8 @@ class Instruction {
    * register. */
   virtual void renameDestination(uint8_t i, Register renamed) = 0;
 
-  /** Provide a value for the specified physical register. */
-  virtual void supplyOperand(const Register& reg,
-                             const RegisterValue& value) = 0;
+  /** Provide a value for the operand at the specified index. */
+  virtual void supplyOperand(uint8_t i, const RegisterValue& value) = 0;
 
   /** Check whether the operand at index `i` has had a value supplied. */
   virtual bool isOperandReady(int i) const = 0;

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -74,8 +74,8 @@ class Instruction : public simeng::Instruction {
    * register. */
   void renameDestination(uint8_t i, Register renamed) override;
 
-  /** Provide a value for the specified physical register. */
-  void supplyOperand(const Register& reg, const RegisterValue& value) override;
+  /** Provide a value for the operand at the specified index. */
+  virtual void supplyOperand(uint8_t i, const RegisterValue& value) override;
 
   /** Check whether all operand values have been supplied, and the instruction
    * is ready to execute. */

--- a/src/include/simeng/pipeline/DispatchIssueUnit.hh
+++ b/src/include/simeng/pipeline/DispatchIssueUnit.hh
@@ -16,6 +16,8 @@ struct ReservationStationEntry {
   std::shared_ptr<Instruction> uop;
   /** The port to issue to. */
   uint8_t port;
+  /** The operand waiting on a value. */
+  uint8_t operandIndex;
 };
 
 /** A dispatch/issue unit for an out-of-order pipelined processor. Reads

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -68,22 +68,14 @@ void Instruction::renameDestination(uint8_t i, Register renamed) {
   destinationRegisters[i] = renamed;
 }
 
-void Instruction::supplyOperand(const Register& reg,
-                                const RegisterValue& value) {
+void Instruction::supplyOperand(uint8_t i, const RegisterValue& value) {
   assert(!canExecute() &&
          "Attempted to provide an operand to a ready-to-execute instruction");
   assert(value.size() > 0 &&
          "Attempted to provide an uninitialised RegisterValue");
 
-  // Iterate over operand registers, and copy value if the provided register
-  // matches
-  for (size_t i = 0; i < sourceRegisterCount; i++) {
-    if (sourceRegisters[i] == reg && !isOperandReady(i)) {
-      operands[i] = value;
-      operandsPending--;
-      break;
-    }
-  }
+  operands[i] = value;
+  operandsPending--;
 }
 
 void Instruction::supplyData(uint64_t address, const RegisterValue& data) {

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -100,7 +100,7 @@ void Core::tick() {
   for (size_t i = 0; i < registers.size(); i++) {
     auto reg = registers[i];
     if (!uop->isOperandReady(i)) {
-      uop->supplyOperand(reg, registerFileSet_.get(reg));
+      uop->supplyOperand(i, registerFileSet_.get(reg));
     }
   }
 

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -228,16 +228,9 @@ void Core::forwardOperands(const span<Register>& registers,
       }
       if (sourceReg == registers[i] && !uop->isOperandReady(operand)) {
         // Supply the operand
-        uop->supplyOperand(registers[i], values[i]);
+        uop->supplyOperand(operand, values[i]);
       }
     }
-  }
-
-  for (size_t i = 0; i < registers.size(); i++) {
-    if (uop->canExecute()) {
-      return;
-    }
-    uop->supplyOperand(registers[i], values[i]);
   }
 }
 
@@ -253,7 +246,7 @@ void Core::readRegisters() {
   for (size_t i = 0; i < sourceRegisters.size(); i++) {
     const auto& reg = sourceRegisters[i];
     if (!uop->isOperandReady(i)) {
-      uop->supplyOperand(reg, registerFileSet_.get(reg));
+      uop->supplyOperand(i, registerFileSet_.get(reg));
     }
   }
 }

--- a/test/unit/MockInstruction.hh
+++ b/test/unit/MockInstruction.hh
@@ -13,8 +13,7 @@ class MockInstruction : public Instruction {
   MOCK_CONST_METHOD0(getDestinationRegisters, const span<Register>());
   MOCK_METHOD2(renameSource, void(uint8_t i, Register renamed));
   MOCK_METHOD2(renameDestination, void(uint8_t i, Register renamed));
-  MOCK_METHOD2(supplyOperand,
-               void(const Register& reg, const RegisterValue& value));
+  MOCK_METHOD2(supplyOperand, void(uint8_t i, const RegisterValue& value));
   MOCK_CONST_METHOD1(isOperandReady, bool(int i));
   MOCK_CONST_METHOD0(canExecute, bool());
   MOCK_METHOD0(execute, void());


### PR DESCRIPTION
Updates `Instruction::supplyOperand` to accept an operand index rather than a `Register`. This removes the need to search for the matching operand before supplying it.

This only provides a minor performance benefit (1-2%), as some of the performance gained by removing the need to search the operands is lost in the additional overhead of recording operand indices.

Additionally, this removes an unnecessary operand forwarding loop that was resupplying registers to guaranteed-ready instructions in the in-order model, resulting in a ~10% performance gain.

Resolves #56 