### PR TITLE
[AArch64] Raise exception on misaligned PC

### DIFF
--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -37,6 +37,7 @@ enum class InstructionException {
   EncodingUnallocated,
   EncodingNotYetImplemented,
   ExecutionNotYetImplemented,
+  MisalignedPC,
   DataAbort,
   SupervisorCall,
   HypervisorCall,
@@ -50,6 +51,10 @@ class Instruction : public simeng::Instruction {
    */
   Instruction(const InstructionMetadata& metadata, uint8_t latency,
               uint8_t stallCycles);
+
+  /** Construct an instruction instance that raises an exception. */
+  Instruction(const InstructionMetadata& metadata,
+              InstructionException exception);
 
   /** Retrieve the identifier for the first exception that occurred during
    * processing this instruction. */

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -343,6 +343,9 @@ void ExceptionHandler::printException(const Instruction& insn) const {
     case InstructionException::ExecutionNotYetImplemented:
       std::cout << "execution not-yet-implemented";
       break;
+    case InstructionException::MisalignedPC:
+      std::cout << "misaligned program counter";
+      break;
     case InstructionException::DataAbort:
       std::cout << "data abort";
       break;

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -22,6 +22,13 @@ Instruction::Instruction(const InstructionMetadata& metadata, uint8_t latency,
   decode();
 }
 
+Instruction::Instruction(const InstructionMetadata& metadata,
+                         InstructionException exception)
+    : metadata(metadata) {
+  exception_ = exception;
+  exceptionEncountered_ = true;
+}
+
 InstructionException Instruction::getException() const { return exception_; }
 
 void Instruction::setSourceRegisters(const std::vector<Register>& registers) {

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -1,5 +1,6 @@
 #include "InstructionMetadata.hh"
 
+#include <cassert>
 #include <cstring>
 
 namespace simeng {
@@ -87,7 +88,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
   revertAliasing();
 }
 
-InstructionMetadata::InstructionMetadata(const uint8_t* invalidEncoding)
+InstructionMetadata::InstructionMetadata(const uint8_t* invalidEncoding,
+                                         uint8_t bytes)
     : id(ARM64_INS_INVALID),
       opcode(Opcode::AArch64_INSTRUCTION_LIST_END),
       implicitSourceCount(0),
@@ -96,7 +98,8 @@ InstructionMetadata::InstructionMetadata(const uint8_t* invalidEncoding)
       setsFlags(false),
       writeback(false),
       operandCount(0) {
-  std::memcpy(encoding, invalidEncoding, sizeof(encoding));
+  assert(bytes <= sizeof(encoding));
+  std::memcpy(encoding, invalidEncoding, bytes);
   mnemonic[0] = '\0';
   operandStr[0] = '\0';
 }

--- a/src/lib/arch/aarch64/InstructionMetadata.hh
+++ b/src/lib/arch/aarch64/InstructionMetadata.hh
@@ -20,7 +20,7 @@ struct InstructionMetadata {
   InstructionMetadata(const cs_insn& insn);
 
   /** Constructs an invalid metadata object containing the invalid encoding. */
-  InstructionMetadata(const uint8_t* invalidEncoding);
+  InstructionMetadata(const uint8_t* invalidEncoding, uint8_t bytes = 4);
 
   static const size_t MAX_OPERAND_STR_LENGTH =
       sizeof(cs_insn::op_str) / sizeof(char);

--- a/test/regression/aarch64/CMakeLists.txt
+++ b/test/regression/aarch64/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(regression-aarch64
                AArch64RegressionTest.cc
                AArch64RegressionTest.hh
+               Exception.cc
                LoadStoreQueue.cc
                SmokeTest.cc
                Syscall.cc

--- a/test/regression/aarch64/Exception.cc
+++ b/test/regression/aarch64/Exception.cc
@@ -1,0 +1,21 @@
+#include "AArch64RegressionTest.hh"
+
+namespace {
+
+using Exception = AArch64RegressionTest;
+
+// Test that branching to an address that is misaligned raises an exception.
+TEST_P(Exception, misaligned_pc) {
+  RUN_AARCH64(R"(
+    mov x0, 5
+    br x0
+  )");
+  const char err[] = "\nEncountered misaligned program counter exception";
+  EXPECT_EQ(stdout_.substr(0, sizeof(err) - 1), err);
+}
+
+INSTANTIATE_TEST_SUITE_P(AArch64, Exception,
+                         ::testing::Values(EMULATION, INORDER, OUTOFORDER),
+                         coreTypeToString);
+
+}  // namespace


### PR DESCRIPTION
Without this, programs that speculatively execute invalid instructions were sometimes crashing during fetch, as they'd speculatively branch to misaligned addresses.