### PR TITLE
Add support for command-line arguments

### DIFF
--- a/src/include/simeng/kernel/LinuxProcess.hh
+++ b/src/include/simeng/kernel/LinuxProcess.hh
@@ -25,8 +25,10 @@ namespace kernel {
  */
 class LinuxProcess {
  public:
-  /** Construct a Linux process from an ELF file at `path`. */
-  LinuxProcess(std::string path);
+  /** Construct a Linux process from a vector of command-line arguments.
+   *
+   * The first argument is a path to an executable ELF file. */
+  LinuxProcess(const std::vector<std::string>& commandLine);
 
   /** Construct a Linux process from region of instruction memory, with the
    * entry point fixed at 0. */
@@ -80,8 +82,8 @@ class LinuxProcess {
   /** The process image size. */
   uint64_t size_;
 
-  /** The path of the process executable. */
-  std::string path_;
+  /** The process command and its arguments. */
+  std::vector<std::string> commandLine_;
 
   /** Whether the process image was created successfully. */
   bool isValid_ = false;

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -61,8 +61,9 @@ int main(int argc, char** argv) {
   std::unique_ptr<simeng::kernel::LinuxProcess> process;
 
   if (executablePath.length() > 0) {
-    // Attempt to create the process image from the specified file
-    process = std::make_unique<simeng::kernel::LinuxProcess>(argv[2]);
+    // Attempt to create the process image from the specified command-line
+    std::vector<std::string> commandLine(argv + 2, argv + argc);
+    process = std::make_unique<simeng::kernel::LinuxProcess>(commandLine);
     if (!process->isValid()) {
       std::cerr << "Could not read/parse " << argv[2] << std::endl;
       exit(1);


### PR DESCRIPTION
The argument strings are pushed to the stack before the initial stack frame. Had to make some small changes to how the initial stack frame was constructed.

Tested with the BUDE benchmark.