### PR TITLE
Merge instruction branch into master

### DIFF
--- a/src/include/simeng/Instruction.hh
+++ b/src/include/simeng/Instruction.hh
@@ -104,6 +104,23 @@ class Instruction {
   /** Is this a branch operation? */
   virtual bool isBranch() const = 0;
 
+  /** Is this a arithmetic simd operation? */
+  virtual bool isASIMD() const = 0;
+
+  /** Is this a return instruction? */
+  virtual bool isRET() const = 0;
+
+  /** Is this a branch and link instruction? */
+  virtual bool isBL() const = 0;
+
+  /** Is this a SVE instruction? */
+  /** Maybe remove as aarch64 exclusive? */
+  virtual bool isSVE() const = 0;
+
+  /** Is this a predicate setting instruction? */
+  /** Maybe remove as aarch64 exclusive? */
+  virtual bool isPredicate() const = 0;
+
   /** Set this instruction's instruction memory address. */
   void setInstructionAddress(uint64_t address);
 

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -31,10 +31,14 @@ const uint8_t SYSTEM = 4;
 /** The IDs of the instruction groups for AArch64 instructions. */
 namespace InstructionGroups {
 const uint8_t ARITHMETIC = 0;
-const uint8_t LOAD = 1;
-const uint8_t STORE = 2;
-const uint8_t BRANCH = 3;
+const uint8_t SHIFT = 1;
+const uint8_t MULTIPLY = 2;
+const uint8_t DIVIDE = 3;
 const uint8_t ASIMD = 4;
+const uint8_t LOAD = 5;
+const uint8_t STORE = 6;
+const uint8_t BRANCH = 7;
+const uint8_t PREDICATE = 8;
 }  // namespace InstructionGroups
 
 enum class InstructionException {
@@ -125,6 +129,21 @@ class Instruction : public simeng::Instruction {
   /** Is this a branch operation? */
   bool isBranch() const override;
 
+  /** Is this a arithmetic simd operation? */
+  bool isASIMD() const override;
+
+  /** Is this a return instruction? */
+  bool isRET() const override;
+
+  /** Is this a branch and link instruction? */
+  bool isBL() const override;
+
+  /** Is this a SVE instruction? */
+  bool isSVE() const override;
+
+  /** Is this a predicate setting instruction? */
+  bool isPredicate() const override;
+
   /** Retrieve the instruction group this instruction belongs to. */
   uint16_t getGroup() const override;
 
@@ -207,11 +226,22 @@ class Instruction : public simeng::Instruction {
   bool isLoad_ = false;
   /** Is this a branch operation? */
   bool isBranch_ = false;
-
   /** Is this an ASIMD operation? */
   bool isASIMD_ = false;
+  /** Is this a multilpy operation? */
+  bool isMultiply_ = false;
+  /** Is this a divide operation? */
+  bool isDivide_ = false;
+  /** Is this a shift operation? */
+  bool isShift_ = false;
+  /** Is this a return instruction? */
+  bool isRET_ = false;
+  /** Is this a branch and link instruction? */
+  bool isBL_ = false;
   /** Is this a SVE instruction? */
   bool isSVE_ = false;
+  /** Is this a Predicate instruction? */
+  bool isPredicate_ = false;
 
   // Memory
   /** Set the accessed memory addresses, and create a corresponding memory data

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -119,6 +119,11 @@ const span<RegisterValue> Instruction::getResults() const {
 bool Instruction::isStore() const { return isStore_; }
 bool Instruction::isLoad() const { return isLoad_; }
 bool Instruction::isBranch() const { return isBranch_; }
+bool Instruction::isASIMD() const { return isASIMD_; }
+bool Instruction::isRET() const { return isRET_; }
+bool Instruction::isBL() const { return isBL_; }
+bool Instruction::isSVE() const { return isSVE_; }
+bool Instruction::isPredicate() const { return isPredicate_; }
 
 void Instruction::setMemoryAddresses(
     const std::vector<MemoryAccessTarget>& addresses) {

--- a/src/lib/arch/aarch64/Instruction_decode.cc
+++ b/src/lib/arch/aarch64/Instruction_decode.cc
@@ -171,6 +171,15 @@ void Instruction::decode() {
             RegisterType::VECTOR) {
           isASIMD_ = true;
         }
+        if (destinationRegisters[destinationRegisterCount].type ==
+            RegisterType::PREDICATE) {
+          isPredicate_ = true;
+          if (metadata.id == ARM64_INS_FCMGE ||
+              metadata.id == ARM64_INS_FCMGT ||
+              metadata.id == ARM64_INS_FCMLT) {
+            isPredicate_ = false;
+          }
+        }
 
         destinationRegisterCount++;
       }
@@ -230,7 +239,11 @@ void Instruction::decode() {
         operandsPending++;
       }
     }
+
+    if (op.shift.value > 0) isShift_ = true;  // Identify shift operations
   }
+
+  if (metadata.setsFlags) isShift_ = true;
 
   // Identify branches
   for (size_t i = 0; i < metadata.groupCount; i++) {
@@ -258,6 +271,35 @@ void Instruction::decode() {
     // Literal loads aren't flagged as having a memory operand, so these must be
     // marked as loads manually
     isLoad_ = true;
+  }
+  if ((1189 < metadata.opcode && metadata.opcode < 1204) ||
+      (1605 < metadata.opcode && metadata.opcode < 1617) ||
+      (2906 < metadata.opcode && metadata.opcode < 2913) ||
+      (4045 < metadata.opcode && metadata.opcode < 4052)) {
+    isDivide_ = true;
+  }
+  if ((1210 < metadata.opcode && metadata.opcode < 1214) ||
+      (1329 < metadata.opcode && metadata.opcode < 1367) ||
+      (1393 < metadata.opcode && metadata.opcode < 1444) ||
+      (1454 < metadata.opcode && metadata.opcode < 1458) ||
+      (1469 < metadata.opcode && metadata.opcode < 1476) ||
+      (2502 < metadata.opcode && metadata.opcode < 2505) ||
+      (2578 < metadata.opcode && metadata.opcode < 2599) ||
+      (2992 == metadata.opcode) ||
+      (3076 < metadata.opcode && metadata.opcode < 3093) ||
+      (3148 < metadata.opcode && metadata.opcode < 3197) ||
+      (4072 == metadata.opcode) ||
+      (4154 < metadata.opcode && metadata.opcode < 4171)) {
+    isMultiply_ = true;
+  }
+  if (metadata.opcode == 2756) {
+    isRET_ = true;
+  }
+  if (metadata.opcode == 325 || metadata.opcode == 326) {
+    isBL_ = true;
+  }
+  if (metadata.id == ARM64_INS_PTEST) {
+    isPredicate_ = true;
   }
   if (metadata.id == ARM64_INS_ADDVL || metadata.id == ARM64_INS_FDUP ||
       metadata.id == ARM64_INS_FMSB || metadata.id == ARM64_INS_LD1RD ||

--- a/test/unit/MockInstruction.hh
+++ b/test/unit/MockInstruction.hh
@@ -29,6 +29,11 @@ class MockInstruction : public Instruction {
   MOCK_CONST_METHOD0(isStore, bool());
   MOCK_CONST_METHOD0(isLoad, bool());
   MOCK_CONST_METHOD0(isBranch, bool());
+  MOCK_CONST_METHOD0(isASIMD, bool());
+  MOCK_CONST_METHOD0(isRET, bool());
+  MOCK_CONST_METHOD0(isBL, bool());
+  MOCK_CONST_METHOD0(isSVE, bool());
+  MOCK_CONST_METHOD0(isPredicate, bool());
   MOCK_CONST_METHOD0(getGroup, uint16_t());
 
   void setBranchResults(bool wasTaken, uint64_t targetAddress) {


### PR DESCRIPTION
Within these commits, the primary changes made are concerned with new instruction groups. `SHIFT`, `MULTIPLY`, `DIVIDE`, and `PREDICATE` groups are added to the `InstructionGroups` namespace and `BL`/`BLR`/`RET` aarch64 instruction identifiers are also added to the aarch64 instruction class. Further decoding logic is added to `Instruction_decode.cc` to assign these new groups and `MockInstruction.hh` is updated with new functions added to the base instruction class.