### PR TITLE
Merge execute branch into master

### DIFF
--- a/src/include/simeng/pipeline/ExecuteUnit.hh
+++ b/src/include/simeng/pipeline/ExecuteUnit.hh
@@ -33,7 +33,8 @@ class ExecuteUnit {
       std::function<void(const std::shared_ptr<Instruction>&)> handleLoad,
       std::function<void(const std::shared_ptr<Instruction>&)> handleStore,
       std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
-      BranchPredictor& predictor, bool pipelined = true);
+      BranchPredictor& predictor, bool pipelined = true,
+      uint16_t blockingGroup = 0);
 
   /** Tick the execute unit. Places incoming instructions into the pipeline and
    * executes an instruction that has reached the head of the pipeline, if
@@ -60,6 +61,9 @@ class ExecuteUnit {
 
   /** Retrieve the number of branch mispredictions. */
   uint64_t getBranchMispredictedCount() const;
+
+  /** Retrieve the number of active execution cycles. */
+  uint64_t getCycles() const;
 
  private:
   /** Execute the supplied uop, write it into the output buffer, and forward
@@ -96,6 +100,14 @@ class ExecuteUnit {
    * be calculated and forwarded. */
   std::deque<ExecutionUnitPipelineEntry> pipeline_;
 
+  /** A group of operation types that are blocked whilst a similar operation
+   * is being executed. */
+  uint16_t blockingGroup_;
+
+  /** A queue to hold blocked instructions of a similar group type to
+   * blockingGroup_. */
+  std::deque<std::shared_ptr<Instruction>> operationsStalled_;
+
   /** Whether the core should be flushed after this cycle. */
   bool shouldFlush_;
 
@@ -118,6 +130,9 @@ class ExecuteUnit {
 
   /** The number of branch mispredictions that were observed. */
   uint64_t branchMispredicts_ = 0;
+
+  /** The number of active execution cycles that were observed. */
+  uint64_t cycles_ = 0;
 };
 
 }  // namespace pipeline

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -80,7 +80,7 @@ Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
           dispatchIssueUnit_.forwardOperands(regs, values);
         },
         [this](auto uop) { loadStoreQueue_.startLoad(uop); }, [](auto uop) {},
-        [](auto uop) { uop->setCommitReady(); }, branchPredictor);
+        [](auto uop) { uop->setCommitReady(); }, branchPredictor, true, 0);
   }
   // Provide reservation size getter to A64FX port allocator
   portAllocator.setRSSizeGetter([this](std::vector<uint64_t>& sizeVec) {


### PR DESCRIPTION
Within these commits, the notion of operation stalling found in the A64FX processor has been implemented. Unlike pipeline stalling at execution where all instructions flowing into an execution unit are stalled whilst another instruction's operation is executed (e.g. DIV instruction), an operation stall will only stall instructions of similar operations to that of the instruction currently being executed. Such functionality is defined through the use of a parameterised value called a `blockingGroup_`. This value denotes an instruction group and if an instruction belonging to this group flows into the execute unit, whilst an instruction belonging to that same group is executing, it is appended to an `operationsStalled_` queue. Instructions are taken from this queue individually once the previous instruction belonging to the `blockingGroup_` group has finished executing.