### PR TITLE
Reverse register rename rewinding order on flush

### DIFF
--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -79,7 +79,9 @@ void ReorderBuffer::flush(uint64_t afterSeqId) {
       break;
     }
 
-    for (const auto& reg : uop->getDestinationRegisters()) {
+    auto destinations = uop->getDestinationRegisters();
+    for (int i = destinations.size() - 1; i >= 0; i--) {
+      const auto& reg = destinations[i];
       rat_.rewind(reg);
     }
     uop->setFlushed();

--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -79,6 +79,8 @@ void ReorderBuffer::flush(uint64_t afterSeqId) {
       break;
     }
 
+    // To rewind destination registers in correct history order, rewinding of
+    // register renaming is done backwards
     auto destinations = uop->getDestinationRegisters();
     for (int i = destinations.size() - 1; i >= 0; i--) {
       const auto& reg = destinations[i];


### PR DESCRIPTION
When SimEng flushes an instruction that sets multiple destinations as
same register, the rewinding of register renaming fails.
This is because the order of applying rewinding by historyTable_ is
in the wrong way.
Ultimately, it keeps the wrong physical register (which was freed) in mappingTable_.
Therefore, the order of calling rewind() was reversed to have the correct
order of updating mappingTable_ with historyTable_.