### PR TITLE
Optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,19 @@ FetchContent_MakeAvailable_Args(yaml-cpp EXCLUDE_FROM_ALL)
 option(SIMENG_ENABLE_TESTS "Whether to enable testing for SimEng" OFF)
 option(SIMENG_USE_EXTERNAL_LLVM "Use an external LLVM rather than building it as a submodule" OFF)
 option(SIMENG_SANITIZE "Enable compiler sanitizers" OFF)
+option(SIMENG_OPTIMIZE "Enable Extra Compiler Optimizatoins" OFF)
+
+if(SIMENG_OPTIMIZE)
+  # Turn on link time optimization for all targets.
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+
+  check_cxx_compiler_flag(-march=native X86)
+
+  if(X86)
+    add_compile_options(-march=native -mtune=native)
+    add_link_options(-march=native -mtune=native)
+  endif()
+endif()
 
 set(SANITIZE_OPTIONS -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover=address,undefined)
 if (SIMENG_SANITIZE)

--- a/src/include/simeng/AlwaysNotTakenPredictor.hh
+++ b/src/include/simeng/AlwaysNotTakenPredictor.hh
@@ -10,11 +10,11 @@ class AlwaysNotTakenPredictor : public BranchPredictor {
  public:
   /** Generate a branch prediction for the specified instruction address; will
    * always predict not taken. */
-  BranchPrediction predict(std::shared_ptr<Instruction> uop) override;
+  BranchPrediction predict(std::shared_ptr<Instruction>& uop) override;
 
   /** Provide branch results to update the prediction model for the specified
    * instruction address. As this model is static, this does nothing. */
-  void update(std::shared_ptr<Instruction> uop, bool taken,
+  void update(std::shared_ptr<Instruction>& uop, bool taken,
               uint64_t targetAddress) override;
 };
 

--- a/src/include/simeng/BTBPredictor.hh
+++ b/src/include/simeng/BTBPredictor.hh
@@ -16,11 +16,11 @@ class BTBPredictor : public BranchPredictor {
   /** Generate a branch prediction for the supplied instruction address. Finds
    * the corresponding BTB entry and returns a "taken" prediction with the
    * stored target. If no entry is found, predicts "not taken". */
-  BranchPrediction predict(std::shared_ptr<Instruction> uop) override;
+  BranchPrediction predict(std::shared_ptr<Instruction>& uop) override;
 
   /** Update the BTB entry for the supplied instruction address with the taken
    * state and targt address. */
-  void update(std::shared_ptr<Instruction> uop, bool taken,
+  void update(std::shared_ptr<Instruction>& uop, bool taken,
               uint64_t targetAddress) override;
 
  private:

--- a/src/include/simeng/BTB_BWTPredictor.hh
+++ b/src/include/simeng/BTB_BWTPredictor.hh
@@ -21,11 +21,11 @@ class BTB_BWTPredictor : public BranchPredictor {
   /** Generate a branch prediction for the supplied instruction address.
    * Use a combination of a BTB entry, a global history, and an agreement
    * policy. */
-  BranchPrediction predict(std::shared_ptr<Instruction> uop) override;
+  BranchPrediction predict(std::shared_ptr<Instruction>& uop) override;
 
   /** Update the BTB entry for the supplied instruction address with the taken
    * state and targt address. Also update the global state of the predictor*/
-  void update(std::shared_ptr<Instruction> uop, bool taken,
+  void update(std::shared_ptr<Instruction>& uop, bool taken,
               uint64_t targetAddress) override;
 
  private:

--- a/src/include/simeng/BranchPredictor.hh
+++ b/src/include/simeng/BranchPredictor.hh
@@ -13,11 +13,11 @@ class BranchPredictor {
   virtual ~BranchPredictor(){};
 
   /** Generate a branch prediction for the specified instruction address. */
-  virtual BranchPrediction predict(std::shared_ptr<Instruction> uop) = 0;
+  virtual BranchPrediction predict(std::shared_ptr<Instruction>& uop) = 0;
 
   /** Provide branch results to update the prediction model for the specified
    * instruction address. */
-  virtual void update(std::shared_ptr<Instruction> uop, bool taken,
+  virtual void update(std::shared_ptr<Instruction>& uop, bool taken,
                       uint64_t targetAddress) = 0;
 };
 

--- a/src/include/simeng/Instruction.hh
+++ b/src/include/simeng/Instruction.hh
@@ -159,7 +159,7 @@ class Instruction {
   uint16_t getStallCycles() const;
 
   /** Get this instruction's supported set of ports. */
-  virtual std::vector<uint8_t> getSupportedPorts() = 0;
+  virtual const std::vector<uint8_t>& getSupportedPorts() = 0;
 
   bool shouldSplitRequests() const;
 

--- a/src/include/simeng/ModelConfig.hh
+++ b/src/include/simeng/ModelConfig.hh
@@ -75,27 +75,27 @@ class ModelConfig {
    * expressions. */
   // Set of values requirement, no default value
   template <typename T>
-  int nodeChecker(YAML::Node node, std::string field,
+  int nodeChecker(const YAML::Node& node, const std::string& field,
                   const std::vector<T>& value_set, uint8_t expected);
   // Set of values requirement, with default value
   template <typename T>
-  int nodeChecker(YAML::Node node, std::string field,
+  int nodeChecker(YAML::Node node, const std::string& field,
                   const std::vector<T>& value_set, uint8_t expected,
                   T default_value);
   // Pair of inclusive bounds requirement, no default value
   template <typename T>
-  int nodeChecker(YAML::Node node, std::string field,
+  int nodeChecker(const YAML::Node& node, const std::string& field,
                   const std::pair<T, T>& bounds, uint8_t expected);
   // Pair of inclusive bounds requirement, with default value
   template <typename T>
-  int nodeChecker(YAML::Node node, std::string field,
+  int nodeChecker(YAML::Node node, const std::string& field,
                   const std::pair<T, T>& bounds, uint8_t expected,
-                  T default_value);
+                  const T& default_value);
 
   /** Given a set of values (value_set), ensure the supplied node is on of
    * these options. */
   template <typename T>
-  int setChecker(YAML::Node node, std::string field,
+  int setChecker(YAML::Node node, const std::string& field,
                  const std::vector<T>& value_set, uint8_t expected) {
     // Ensure node value can be read as specified type
     try {
@@ -125,7 +125,7 @@ class ModelConfig {
   /** Given a set of bounds (bounds) ensure the supplied node is betwene these
    * value inclusively. */
   template <typename T>
-  int boundChecker(YAML::Node node, std::string field,
+  int boundChecker(YAML::Node node, const std::string& field,
                    const std::pair<T, T>& bounds, uint8_t expected) {
     // Ensure node value can be read as specified type
     try {

--- a/src/include/simeng/Pool.hh
+++ b/src/include/simeng/Pool.hh
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <utility>
+#include <vector>
+
+namespace simeng {
+
+/** A class that builds a memory pool with fixed `chunk_size`. It uses a free
+ * list to keep track of free memory. The list is stored within the memory used
+ * by the pool. */
+template <std::size_t chunk_size, std::size_t initial_size = 2>
+class fixedPool_ {
+  static_assert(initial_size && (initial_size & (initial_size - 1)) == 0 &&
+                "initial_size is not a power of 2");
+
+ public:
+  ~fixedPool_() {
+    for (auto& ptr : ptrs) operator delete(ptr);
+  }
+
+  /** Allocate `chunk_size` bytes. If allocation fails, it returns nullptr. */
+  void* allocate() noexcept {
+    if (head) {
+      return std::exchange(head, *reinterpret_cast<void**>(head));
+    } else {
+      return grow() ? allocate() : head;
+    }
+  }
+
+  /** Return memory at `ptr` of size `chunk_size` bytes to the memory pool.
+   * Passing nullptr is a nop. */
+  void deallocate(void* ptr) noexcept {
+    if (ptr) {
+      *reinterpret_cast<void**>(ptr) = head;
+      head = ptr;
+    }
+  }
+
+ private:
+  /** Allocate more memory and add new chunks to the free list. */
+  bool grow() noexcept {
+    // The space in bytes needed to fit `n_allocated` aligned chunks.
+    std::size_t space = sizeof(chunk) * n_allocated;
+
+    void* ptr = operator new(space, std::nothrow);
+    if (!ptr) return ptr;
+
+    ptrs.push_back(ptr);
+
+    // Go through each chunk and add a new free list node. The node consists of
+    // an address to the next free chunk (nullptr if it is the last node).
+    while (std::align(alignof(std::max_align_t), chunk_size, ptr, space)) {
+      auto temp = std::exchange(head, ptr);
+      *reinterpret_cast<void**>(ptr) = temp;
+      ptr = (char*)ptr + chunk_size;
+      space -= chunk_size;
+    }
+
+    n_allocated = n_allocated << 1;
+
+    return head;
+  }
+
+  // A helper struct used to calculate how much padding is needed to
+  // allocate aligned chunks.
+  struct chunk {
+    alignas(std::max_align_t) unsigned char data[chunk_size];
+  };
+
+  // Pointer to the head of the free list.
+  void* head = nullptr;
+
+  // No. of chunks to allocate in the next block.
+  std::size_t n_allocated = initial_size;
+
+  // Vector of all the pointers returned from operator new.
+  std::vector<void*> ptrs;
+};
+
+/** The class Pool is general-purpose memory pool implementation. It consists of
+ * a collection of pools that serve requests for different chunk sizes.
+ *
+ * Allocations requests that exceed the largest chunk size supported are served
+ * from the free store directly. Currently the largest chunk size supported is
+ * 512 bytes.
+ *
+ * All memory is freed on destruction even if deallocate has not been
+ * called. If memory is exhausted, a block of memory is allocated. The size of
+ * blocks increases by a factor of 2. */
+class Pool {
+ public:
+  /** Allocates `bytes` with alignment `alignof(std::max_align_t)`. If memory in
+   * the pool is exhausted, a block of memory is allocated from the free
+   * store. */
+  void* allocate(std::uint32_t bytes) {
+    switch (roundUp(bytes)) {
+      case 32:
+        return pool32.allocate();
+      case 64:
+        return pool64.allocate();
+      case 128:
+        return pool128.allocate();
+      case 256:
+        return pool256.allocate();
+      case 512:
+        return pool512.allocate();
+      default:
+        return ::operator new(bytes);
+    };
+  }
+
+  /** Returns the memory at `ptr` to the memory pool. If `ptr` is a nullptr, it
+   * is a nop. */
+  void deallocate(void* ptr, std::uint32_t bytes) noexcept {
+    switch (roundUp(bytes)) {
+      case 32:
+        pool32.deallocate(ptr);
+        break;
+      case 64:
+        pool64.deallocate(ptr);
+        break;
+      case 128:
+        pool128.deallocate(ptr);
+        break;
+      case 256:
+        pool256.deallocate(ptr);
+        break;
+      case 512:
+        pool512.deallocate(ptr);
+        break;
+      default:
+        ::operator delete(ptr);
+        break;
+    };
+  }
+
+ private:
+  /** Round up to the nearest power of 2 that is greater than or equal to v. */
+  std::uint32_t roundUp(std::uint32_t v) {
+    --v;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    return ++v;
+  }
+
+  fixedPool_<32> pool32;
+  fixedPool_<128> pool128;
+  fixedPool_<512> pool512;
+  fixedPool_<64, 1024> pool64;
+  fixedPool_<256, 1024> pool256;
+};
+
+}  // namespace simeng

--- a/src/include/simeng/RegisterValue.hh
+++ b/src/include/simeng/RegisterValue.hh
@@ -37,7 +37,6 @@ class RegisterValue {
                                    0);
       }
     } else {
-      // void* data = calloc(1, bytes);
       void* data = pool.allocate(bytes);
       std::memset(data, 0, bytes);
 

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -405,6 +405,8 @@ class Instruction : public simeng::Instruction {
    * vector. */
   void setMemoryAddresses(const std::vector<MemoryAccessTarget>& addresses);
 
+  void setMemoryAddresses(std::vector<MemoryAccessTarget>&& addresses);
+
   /** The memory addresses this instruction accesses, as a vector of {offset,
    * width} pairs. */
   std::vector<MemoryAccessTarget> memoryAddresses;

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -294,7 +294,7 @@ class Instruction : public simeng::Instruction {
   void setExecutionInfo(const executionInfo& info);
 
   /** Get this instruction's supported set of ports. */
-  std::vector<uint8_t> getSupportedPorts() override;
+  const std::vector<uint8_t>& getSupportedPorts() override;
 
   /** Retrieve the instruction's metadata. */
   const InstructionMetadata& getMetadata() const;

--- a/src/include/simeng/kernel/Linux.hh
+++ b/src/include/simeng/kernel/Linux.hh
@@ -163,7 +163,7 @@ class Linux {
                  uint16_t mode);
 
   /** readlinkat syscall: read value of a symbolic link. */
-  int64_t readlinkat(int64_t dirfd, const std::string pathname, char* buf,
+  int64_t readlinkat(int64_t dirfd, const std::string& pathname, char* buf,
                      size_t bufsize) const;
 
   /** get a process's CPU affinity mask. */

--- a/src/include/simeng/models/outoforder/Core.hh
+++ b/src/include/simeng/models/outoforder/Core.hh
@@ -30,7 +30,7 @@ class Core : public simeng::Core {
        uint64_t processMemorySize, uint64_t entryPoint,
        const arch::Architecture& isa, BranchPredictor& branchPredictor,
        pipeline::PortAllocator& portAllocator,
-       std::vector<std::pair<uint8_t, uint64_t>> rsArrangment,
+       const std::vector<std::pair<uint8_t, uint64_t>>& rsArrangment,
        YAML::Node config);
 
   /** Tick the core. Ticks each of the pipeline stages sequentially, then ticks

--- a/src/include/simeng/pipeline/A64FXPortAllocator.hh
+++ b/src/include/simeng/pipeline/A64FXPortAllocator.hh
@@ -21,7 +21,7 @@ const uint8_t BR = 5;
  * described in the A64FX Microarchitecture manual. */
 class A64FXPortAllocator : public PortAllocator {
  public:
-  A64FXPortAllocator(std::vector<std::vector<uint16_t>> portArrangement);
+  A64FXPortAllocator(const std::vector<std::vector<uint16_t>>& portArrangement);
 
   uint8_t allocate(std::vector<uint8_t> ports) override;
 
@@ -30,7 +30,7 @@ class A64FXPortAllocator : public PortAllocator {
   void deallocate(uint8_t port) override;
 
   /** A mapping from issye ports to instruction attribute */
-  uint8_t attributeMapping(std::vector<uint8_t> ports);
+  uint8_t attributeMapping(const std::vector<uint8_t>& ports);
 
   /** Set function from DispatchIssueUnit to retrieve reservation
    * station sizes during execution. */

--- a/src/include/simeng/pipeline/A64FXPortAllocator.hh
+++ b/src/include/simeng/pipeline/A64FXPortAllocator.hh
@@ -23,7 +23,7 @@ class A64FXPortAllocator : public PortAllocator {
  public:
   A64FXPortAllocator(const std::vector<std::vector<uint16_t>>& portArrangement);
 
-  uint8_t allocate(std::vector<uint8_t> ports) override;
+  uint8_t allocate(const std::vector<uint8_t>& ports) override;
 
   void issued(uint8_t port) override;
 

--- a/src/include/simeng/pipeline/A64FXPortAllocator.hh
+++ b/src/include/simeng/pipeline/A64FXPortAllocator.hh
@@ -64,6 +64,17 @@ class A64FXPortAllocator : public PortAllocator {
   uint8_t RSAm_;
   /** RSA with least free entries. */
   uint8_t RSAf_;
+
+  const std::vector<uint8_t> EXA_EXB_EAGA_EAGB = {2, 4, 5, 6};
+  const std::vector<uint8_t> EXA_EXB = {2, 4};
+  const std::vector<uint8_t> FLA_FLB = {0, 3};
+  const std::vector<uint8_t> EAGA_EAGB = {5, 6};
+  const std::vector<uint8_t> EXA = {2};
+  const std::vector<uint8_t> FLA = {0};
+  const std::vector<uint8_t> PR = {1};
+  const std::vector<uint8_t> EXB = {4};
+  const std::vector<uint8_t> FLB = {3};
+  const std::vector<uint8_t> BR = {7};
 };
 
 }  // namespace pipeline

--- a/src/include/simeng/pipeline/BalancedPortAllocator.hh
+++ b/src/include/simeng/pipeline/BalancedPortAllocator.hh
@@ -23,7 +23,7 @@ class BalancedPortAllocator : public PortAllocator {
   /** Allocate the lowest weighted port available for the specified instruction
    * group. Returns the allocated port, and increases the weight of the port.
    */
-  uint8_t allocate(std::vector<uint8_t> ports) override;
+  uint8_t allocate(const std::vector<uint8_t>& ports) override;
 
   /** Decrease the weight for the specified port. */
   void issued(uint8_t port) override;

--- a/src/include/simeng/pipeline/BalancedPortAllocator.hh
+++ b/src/include/simeng/pipeline/BalancedPortAllocator.hh
@@ -17,7 +17,8 @@ class BalancedPortAllocator : public PortAllocator {
    * port, and contain a list of the instruction groups that port supports and
    * a port type which denotes the matching requirements of said instruction
    * groups. */
-  BalancedPortAllocator(std::vector<std::vector<uint16_t>> portArrangement);
+  BalancedPortAllocator(
+      const std::vector<std::vector<uint16_t>>& portArrangement);
 
   /** Allocate the lowest weighted port available for the specified instruction
    * group. Returns the allocated port, and increases the weight of the port.

--- a/src/include/simeng/pipeline/DispatchIssueUnit.hh
+++ b/src/include/simeng/pipeline/DispatchIssueUnit.hh
@@ -110,6 +110,10 @@ class DispatchIssueUnit {
   /** Reservation stations */
   std::vector<ReservationStation> reservationStations_;
 
+  /** Stores the number of instructions dispatched each cycle, for each
+  reservation station. */
+  std::vector<uint8_t> dispatches = {};
+
   /** A mapping from port to RS port */
   std::vector<std::pair<uint8_t, uint8_t>> portMapping_;
 

--- a/src/include/simeng/pipeline/DispatchIssueUnit.hh
+++ b/src/include/simeng/pipeline/DispatchIssueUnit.hh
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <deque>
+#include <initializer_list>
 #include <queue>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "simeng/Instruction.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
@@ -121,6 +124,10 @@ class DispatchIssueUnit {
    * operand. For a register `{type,tag}`, the vector of dependents may be found
    * at `dependencyMatrix[type][tag]`. */
   std::vector<std::vector<std::vector<dependencyEntry>>> dependencyMatrix_;
+
+  /** A map to collect flushed instructions for each reservation station. */
+  std::unordered_map<uint8_t, std::unordered_set<std::shared_ptr<Instruction>>>
+      flushed_;
 
   /** A reference to the execution port allocator. */
   PortAllocator& portAllocator_;

--- a/src/include/simeng/pipeline/ExecuteUnit.hh
+++ b/src/include/simeng/pipeline/ExecuteUnit.hh
@@ -34,7 +34,7 @@ class ExecuteUnit {
       std::function<void(const std::shared_ptr<Instruction>&)> handleStore,
       std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
       BranchPredictor& predictor, bool pipelined = true,
-      std::vector<uint16_t> blockingGroups = {});
+      const std::vector<uint16_t>& blockingGroups = {});
 
   /** Tick the execute unit. Places incoming instructions into the pipeline and
    * executes an instruction that has reached the head of the pipeline, if

--- a/src/include/simeng/pipeline/PortAllocator.hh
+++ b/src/include/simeng/pipeline/PortAllocator.hh
@@ -20,7 +20,7 @@ class PortAllocator {
 
   /** Allocate a port for the specified instruction group; returns the allocated
    * port. */
-  virtual uint8_t allocate(std::vector<uint8_t> ports) = 0;
+  virtual uint8_t allocate(const std::vector<uint8_t>& ports) = 0;
 
   /** Inform the allocator that an instruction was issued to the specified port.
    */

--- a/src/lib/AlwaysNotTakenPredictor.cc
+++ b/src/lib/AlwaysNotTakenPredictor.cc
@@ -3,11 +3,11 @@
 namespace simeng {
 
 BranchPrediction AlwaysNotTakenPredictor::predict(
-    std::shared_ptr<Instruction> uop) {
+    std::shared_ptr<Instruction>& uop) {
   return {false, 0};
 }
 
-void AlwaysNotTakenPredictor::update(std::shared_ptr<Instruction> uop,
+void AlwaysNotTakenPredictor::update(std::shared_ptr<Instruction>& uop,
                                      bool taken, uint64_t targetAddress) {}
 
 }  // namespace simeng

--- a/src/lib/BTBPredictor.cc
+++ b/src/lib/BTBPredictor.cc
@@ -5,7 +5,7 @@ namespace simeng {
 BTBPredictor::BTBPredictor(uint8_t bits)
     : bits(bits), btb(1 << bits), hasValue(1 << bits, false) {}
 
-BranchPrediction BTBPredictor::predict(std::shared_ptr<Instruction> uop) {
+BranchPrediction BTBPredictor::predict(std::shared_ptr<Instruction>& uop) {
   auto instructionAddress = uop->getInstructionAddress();
   // Simple hash; lowest `bits` bits of address
   auto addressHash = hash(instructionAddress);
@@ -13,7 +13,7 @@ BranchPrediction BTBPredictor::predict(std::shared_ptr<Instruction> uop) {
   return {hasValue[addressHash], btb[addressHash]};
 }
 
-void BTBPredictor::update(std::shared_ptr<Instruction> uop, bool taken,
+void BTBPredictor::update(std::shared_ptr<Instruction>& uop, bool taken,
                           uint64_t targetAddress) {
   auto instructionAddress = uop->getInstructionAddress();
   auto addressHash = hash(instructionAddress);

--- a/src/lib/BTB_BWTPredictor.cc
+++ b/src/lib/BTB_BWTPredictor.cc
@@ -18,7 +18,7 @@ BTB_BWTPredictor::BTB_BWTPredictor(uint8_t bits, uint8_t associative)
   ghrUnsigned = 0;
 }
 
-BranchPrediction BTB_BWTPredictor::predict(std::shared_ptr<Instruction> uop) {
+BranchPrediction BTB_BWTPredictor::predict(std::shared_ptr<Instruction>& uop) {
   auto instructionAddress = uop->getInstructionAddress();
   std::pair<uint64_t, uint8_t>& btbIndex = mappings[instructionAddress];
 
@@ -64,7 +64,7 @@ BranchPrediction BTB_BWTPredictor::predict(std::shared_ptr<Instruction> uop) {
   return prediction;
 }
 
-void BTB_BWTPredictor::update(std::shared_ptr<Instruction> uop, bool taken,
+void BTB_BWTPredictor::update(std::shared_ptr<Instruction>& uop, bool taken,
                               uint64_t targetAddress) {
   auto instructionAddress = uop->getInstructionAddress();
   std::pair<uint64_t, uint8_t>& btbIndex = mappings[instructionAddress];

--- a/src/lib/BTB_BWTPredictor.cc
+++ b/src/lib/BTB_BWTPredictor.cc
@@ -10,12 +10,12 @@ BTB_BWTPredictor::BTB_BWTPredictor(uint8_t bits, uint8_t associative)
       mask((1 << bits) - 1),
       btb(1 << bits, *(new std::vector<std::tuple<uint64_t, uint64_t, int64_t>>(
                          associative))),
-      pht(1 << bits, 1) {
+      pht(1 << bits, 1),
+      touched(std::vector<std::vector<uint64_t>>(
+          1 << bits, *(new std::vector<uint64_t>(associative)))),
+      associativeIndex(1 << 11, 0) {
   thr = 0;
   ghrUnsigned = 0;
-  touched = std::vector<std::vector<uint64_t>>(
-      1 << bits, *(new std::vector<uint64_t>(associative)));
-  associativeIndex = std::vector<uint8_t>(1 << 11, 0);
 }
 
 BranchPrediction BTB_BWTPredictor::predict(std::shared_ptr<Instruction> uop) {

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -445,7 +445,7 @@ void ModelConfig::createGroupMapping() {
 }
 
 template <typename T>
-int ModelConfig::nodeChecker(YAML::Node node, std::string field,
+int ModelConfig::nodeChecker(const YAML::Node& node, const std::string& field,
                              const std::vector<T>& value_set,
                              uint8_t expected) {
   // Check for the existance of the given node
@@ -458,7 +458,7 @@ int ModelConfig::nodeChecker(YAML::Node node, std::string field,
 }
 
 template <typename T>
-int ModelConfig::nodeChecker(YAML::Node node, std::string field,
+int ModelConfig::nodeChecker(YAML::Node node, const std::string& field,
                              const std::vector<T>& value_set, uint8_t expected,
                              T default_value) {
   // Check for the existance of the given node
@@ -471,7 +471,7 @@ int ModelConfig::nodeChecker(YAML::Node node, std::string field,
 }
 
 template <typename T>
-int ModelConfig::nodeChecker(YAML::Node node, std::string field,
+int ModelConfig::nodeChecker(const YAML::Node& node, const std::string& field,
                              const std::pair<T, T>& bounds, uint8_t expected) {
   // Check for the existance of the given node
   if (!(node.IsDefined()) || node.IsNull()) {
@@ -483,9 +483,9 @@ int ModelConfig::nodeChecker(YAML::Node node, std::string field,
 }
 
 template <typename T>
-int ModelConfig::nodeChecker(YAML::Node node, std::string field,
+int ModelConfig::nodeChecker(YAML::Node node, const std::string& field,
                              const std::pair<T, T>& bounds, uint8_t expected,
-                             T default_value) {
+                             const T& default_value) {
   // Check for the existance of the given node
   if (!(node.IsDefined()) || node.IsNull()) {
     node = default_value;

--- a/src/lib/RegisterValue.cc
+++ b/src/lib/RegisterValue.cc
@@ -4,6 +4,8 @@
 
 namespace simeng {
 
+RegisterValue::RegisterValue() : bytes(0) {}
+
 RegisterValue::operator bool() const { return (bytes > 0); }
 
 RegisterValue RegisterValue::zeroExtend(uint16_t fromBytes,
@@ -15,8 +17,8 @@ RegisterValue RegisterValue::zeroExtend(uint16_t fromBytes,
   auto extended = RegisterValue(0, toBytes);
 
   // Get the appropriate source/destination pointers and copy the data
-  const char* src = (isLocal() ? value : ptr);
-  char* dest = (extended.isLocal() ? extended.value : extended.ptr);
+  const char* src = (isLocal() ? value : ptr.get());
+  char* dest = (extended.isLocal() ? extended.value : extended.ptr.get());
 
   std::memcpy(dest, src, fromBytes);
 

--- a/src/lib/RegisterValue.cc
+++ b/src/lib/RegisterValue.cc
@@ -4,11 +4,6 @@
 
 namespace simeng {
 
-std::pmr::unsynchronized_pool_resource mem_pool =
-    std::pmr::unsynchronized_pool_resource();
-
-RegisterValue::RegisterValue() : bytes(0) {}
-
 RegisterValue::operator bool() const { return (bytes > 0); }
 
 RegisterValue RegisterValue::zeroExtend(uint16_t fromBytes,
@@ -20,8 +15,8 @@ RegisterValue RegisterValue::zeroExtend(uint16_t fromBytes,
   auto extended = RegisterValue(0, toBytes);
 
   // Get the appropriate source/destination pointers and copy the data
-  const char* src = (isLocal() ? value : ptr.get());
-  char* dest = (extended.isLocal() ? extended.value : extended.ptr.get());
+  const char* src = (isLocal() ? value : ptr);
+  char* dest = (extended.isLocal() ? extended.value : extended.ptr);
 
   std::memcpy(dest, src, fromBytes);
 

--- a/src/lib/RegisterValue.cc
+++ b/src/lib/RegisterValue.cc
@@ -4,6 +4,9 @@
 
 namespace simeng {
 
+std::pmr::unsynchronized_pool_resource mem_pool =
+    std::pmr::unsynchronized_pool_resource();
+
 RegisterValue::RegisterValue() : bytes(0) {}
 
 RegisterValue::operator bool() const { return (bytes > 0); }

--- a/src/lib/RegisterValue.cc
+++ b/src/lib/RegisterValue.cc
@@ -4,6 +4,8 @@
 
 namespace simeng {
 
+Pool pool = Pool();
+
 RegisterValue::RegisterValue() : bytes(0) {}
 
 RegisterValue::operator bool() const { return (bytes > 0); }

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 
 #include "InstructionMetadata.hh"
 
@@ -153,7 +152,6 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
 
   // Dereference the instruction pointer to obtain the instruction word
   const uint32_t insn = *static_cast<const uint32_t*>(ptr);
-  const uint8_t* encoding = reinterpret_cast<const uint8_t*>(ptr);
 
   // Try to find the decoding in the decode cache
   auto iter = decodeCache.find(insn);
@@ -166,6 +164,8 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
     size_t size = 4;
     uint64_t address = 0;
 
+    const uint8_t* encoding = reinterpret_cast<const uint8_t*>(ptr);
+
     bool success =
         cs_disasm_iter(capstoneHandle, &encoding, &size, &address, &rawInsn);
 
@@ -176,14 +176,10 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
     metadataCache.emplace_front(metadata);
 
     // Create and cache an instruction using the metadata
-    Instruction newInstruction = Instruction(*this, metadataCache.front());
+    iter = decodeCache.try_emplace(insn, *this, metadataCache.front()).first;
 
     // Set execution information for this instruction
-    newInstruction.setExecutionInfo(getExecutionInfo(newInstruction));
-
-    auto result = decodeCache.insert({insn, newInstruction});
-
-    iter = result.first;
+    iter->second.setExecutionInfo(getExecutionInfo(iter->second));
   }
 
   output.resize(1);

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -115,9 +115,8 @@ Architecture::Architecture(kernel::Linux& kernel, YAML::Node config)
         // If latency information hasn't been defined, set to zero as to inform
         // later access to use group defined latencies instead
         uint16_t opcode = opcode_node[j].as<uint16_t>();
-        if (opcodeExecutionInfo_.find(opcode) == opcodeExecutionInfo_.end()) {
-          opcodeExecutionInfo_[opcode] = {0, 0, {}};
-        }
+        opcodeExecutionInfo_.try_emplace(
+            opcode, simeng::arch::aarch64::executionInfo{0, 0, {}});
         opcodeExecutionInfo_[opcode].ports.push_back(static_cast<uint8_t>(i));
       }
     }

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -121,9 +121,16 @@ bool Instruction::isSVE() const { return isSVEData_; }
 
 void Instruction::setMemoryAddresses(
     const std::vector<MemoryAccessTarget>& addresses) {
-  memoryData = std::vector<RegisterValue>(addresses.size());
+  memoryData.resize(addresses.size());
   memoryAddresses = addresses;
   dataPending_ = addresses.size();
+}
+
+void Instruction::setMemoryAddresses(
+    std::vector<MemoryAccessTarget>&& addresses) {
+  dataPending_ = addresses.size();
+  memoryData.resize(addresses.size());
+  memoryAddresses = std::move(addresses);
 }
 
 span<const MemoryAccessTarget> Instruction::getGeneratedAddresses() const {

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -181,7 +181,7 @@ void Instruction::setExecutionInfo(const executionInfo& info) {
   stallCycles_ = info.stallCycles;
   supportedPorts_ = info.ports;
 }
-std::vector<uint8_t> Instruction::getSupportedPorts() {
+const std::vector<uint8_t>& Instruction::getSupportedPorts() {
   if (supportedPorts_.size() == 0) {
     exception_ = InstructionException::NoAvailablePort;
     exceptionEncountered_ = true;

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -76,6 +76,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       const uint64_t offset = operands[2].get<uint64_t>();
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = std::pow(2, i);
@@ -84,7 +85,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         }
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_LD1D: {  // ld1d {zt.d}, pg/z, [xn, xm, lsl #3]
@@ -96,6 +97,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       const uint64_t offset = operands[2].get<uint64_t>();
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = std::pow(2, (i * 8));
@@ -104,7 +106,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         }
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_LD1D_IMM_REAL: {  // ld1d {zt.d}, pg/z, [xn{, #imm, mul
@@ -118,6 +120,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
           static_cast<uint64_t>(metadata.operands[2].mem.disp);
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       uint64_t addr = base + (offset * partition_num * 8);
 
@@ -129,7 +132,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 8;
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_LD1W: {  // ld1w {zt.s}, pg/z, [xn, xm, lsl #2]
@@ -141,6 +144,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       const uint64_t offset = operands[2].get<uint64_t>();
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = std::pow(2, (i * 4));
@@ -149,7 +153,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         }
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_LD1W_IMM_REAL: {  // ld1w {zt.s}, pg/z, [xn{, #imm, mul
@@ -163,6 +167,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
           static_cast<uint64_t>(metadata.operands[2].mem.disp);
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       uint64_t addr = base + (offset * partition_num * 4);
 
@@ -174,7 +179,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 4;
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_LD2Twov4s_POST: {  // ld2 {vt1.4s, vt2.4s}, [xn], #imm
@@ -398,7 +403,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 1;
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_LDR_ZXI: {  // ldr zt, [xn{, #imm, mul vl}]
@@ -417,7 +422,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 1;
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_LDNPSi: {  // ldnp st1, st2, [xn, #imm]
@@ -611,6 +616,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       const uint64_t offset = operands[3].get<uint64_t>();
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = std::pow(2, i);
@@ -619,7 +625,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         }
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_ST1D: {  // st1d {zt.d}, pg, [xn, xm, lsl #3]
@@ -631,6 +637,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       const uint64_t offset = operands[3].get<uint64_t>();
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = std::pow(2, (i * 8));
@@ -652,6 +659,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
           static_cast<uint64_t>(metadata.operands[2].mem.disp);
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       uint64_t addr = base + (offset * partition_num * 8);
 
@@ -663,7 +671,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 8;
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_ST1W: {  // st1w {zt.s}, pg, [xn, xm, lsl #2]
@@ -675,6 +683,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       const uint64_t offset = operands[3].get<uint64_t>();
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = std::pow(2, (i * 4));
@@ -683,7 +692,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         }
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_ST1W_IMM: {  // st1w {zt.s}, pg, [xn{, #imm, mul vl}]
@@ -696,6 +705,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
           static_cast<uint64_t>(metadata.operands[2].mem.disp);
 
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(partition_num);
 
       uint64_t addr = base + (offset * partition_num * 4);
 
@@ -706,16 +716,18 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         }
         addr += 4;
       }
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_ST1Twov16b: {  // st1v {vt.16b, vt2.16b}, [xn]
       const uint64_t base = operands[2].get<uint64_t>();
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(32);
+
       for (int i = 0; i < 32; i++) {
         addresses.push_back({base + i, 1});
       }
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_ST1i8_POST:
@@ -745,10 +757,11 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     case Opcode::AArch64_ST2Twov4s_POST: {  // st2 {vt1.4s, vt2.4s}, [xn], #imm
       const uint64_t base = operands[2].get<uint64_t>();
       std::vector<MemoryAccessTarget> addresses;
+      addresses.reserve(8);
       for (int i = 0; i < 8; i++) {
         addresses.push_back({base + 4 * i, 4});
       }
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_STLRB: {  // stlrb wt, [xn]
@@ -1038,7 +1051,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 1;
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_STR_ZXI: {  // str zt, [xn{, #imm, mul vl}]
@@ -1057,7 +1070,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 1;
       }
 
-      setMemoryAddresses(addresses);
+      setMemoryAddresses(std::move(addresses));
       break;
     }
     case Opcode::AArch64_STURBBi: {  // sturb wd, [xn, #imm]

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -854,8 +854,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active =
-            p[i / 16] & (uint64_t)std::pow(2, ((i % 16) * 4));
+        uint64_t shifted_active = p[i / 16] & 1ull << ((i % 16) * 4);
         if (shifted_active) {
           out[i / 16] =
               (n[i] != m) ? (out[i / 16] | shifted_active) : out[i / 16];
@@ -865,11 +864,10 @@ void Instruction::execute() {
       uint8_t N = (out[0] & 1);
       uint8_t Z = 1;
       // (int)(VL_bits - 1)/512 derives which block of 64-bits within the
-      // predicate register we're working in. std::pow(2, (VL_bits / 8) - 1)
+      // predicate register we're working in. 1ull << (VL_bits / 8) - 1)
       // derives a 1 in the last position of the current predicate. Both
       // dictated by vector length.
-      uint8_t C =
-          !(out[(int)((VL_bits - 1) / 512)] & (uint64_t)std::pow(2, 64 - 4));
+      uint8_t C = !(out[(int)((VL_bits - 1) / 512)] & 1ull << (64 - 4));
       for (int i = 0; i < (int)((VL_bits - 1) / 512) + 1; i++) {
         if (out[i]) {
           Z = 0;
@@ -1250,7 +1248,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = ::fabs(n[i]);
         } else {
@@ -1282,7 +1280,7 @@ void Instruction::execute() {
       double out[2] = {operands[2].get<double>(), 0.0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[0] += m[i];
         }
@@ -1388,7 +1386,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = b[i] + c[i];
         } else {
@@ -1477,8 +1475,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active =
-            p[i / 8] & (uint64_t)std::pow(2, ((i % 8) * 8));
+        uint64_t shifted_active = p[i / 8] & 1ull << ((i % 8) * 8);
         if (shifted_active) {
           out[i / 8] = (n[i] >= m) ? (out[i / 8] | shifted_active) : out[i / 8];
         }
@@ -1497,8 +1494,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active =
-            p[i / 16] & (uint64_t)std::pow(2, ((i % 16) * 4));
+        uint64_t shifted_active = p[i / 16] & 1ull << ((i % 16) * 4);
         if (shifted_active) {
           out[i / 16] =
               (n[i] >= m) ? (out[i / 16] | shifted_active) : out[i / 16];
@@ -1534,8 +1530,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active =
-            p[i / 8] & (uint64_t)std::pow(2, ((i % 8) * 8));
+        uint64_t shifted_active = p[i / 8] & 1ull << ((i % 8) * 8);
         if (shifted_active) {
           out[i / 8] =
               (n[i] > m[i]) ? (out[i / 8] | shifted_active) : out[i / 8];
@@ -1555,8 +1550,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active =
-            p[i / 16] & (uint64_t)std::pow(2, ((i % 16) * 4));
+        uint64_t shifted_active = p[i / 16] & 1ull << ((i % 16) * 4);
         if (shifted_active) {
           out[i / 16] =
               (n[i] > m[i]) ? (out[i / 16] | shifted_active) : out[i / 16];
@@ -1586,8 +1580,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active =
-            p[i / 16] & (uint64_t)std::pow(2, ((i % 16) * 4));
+        uint64_t shifted_active = p[i / 16] & 1ull << ((i % 16) * 4);
         if (shifted_active) {
           out[i / 16] =
               (n[i] < m) ? (out[i / 16] | shifted_active) : out[i / 16];
@@ -1780,7 +1773,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           if (b[i] > 2147483647) {
             out[(2 * i)] = 2147483647;
@@ -1832,7 +1825,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = b[i] / c[i];
         } else {
@@ -1903,7 +1896,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = c[i] + (a[i] * b[i]);
         } else {
@@ -2005,7 +1998,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = a[i] + (b[i] * c[i]);
         } else {
@@ -2026,7 +2019,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = a[i] + (b[i] * c[i]);
         } else {
@@ -2074,7 +2067,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = a[i] + (-b[i] * c[i]);
         } else {
@@ -2177,7 +2170,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = c[i] + (-a[i] * b[i]);
         } else {
@@ -2277,7 +2270,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = n[i] * fp;
         } else {
@@ -2297,7 +2290,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = n[i] * fp;
         } else {
@@ -2317,7 +2310,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = n[i] * m[i];
         } else {
@@ -2337,7 +2330,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = n[i] * m[i];
         } else {
@@ -2367,7 +2360,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = -n[i];
         } else {
@@ -2387,7 +2380,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = -n[i];
         } else {
@@ -2549,7 +2542,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = ::sqrt(n[i]);
         } else {
@@ -2754,8 +2747,7 @@ void Instruction::execute() {
       if (active) {
         uint64_t data = memoryData[0].get<uint64_t>();
         for (int i = 0; i < partition_num; i++) {
-          uint64_t shifted_active =
-              p[index / 8] & (uint64_t)std::pow(2, ((index % 8) * 8));
+          uint64_t shifted_active = p[index / 8] & 1ull << ((index % 8) * 8);
           out[i] = shifted_active ? data : 0;
           index++;
         }
@@ -2782,8 +2774,7 @@ void Instruction::execute() {
       if (active) {
         uint32_t data = memoryData[0].get<uint32_t>();
         for (int i = 0; i < partition_num; i++) {
-          uint64_t shifted_active =
-              p[index / 16] & (uint64_t)std::pow(2, ((index % 16) * 4));
+          uint64_t shifted_active = p[index / 16] & 1ull << ((index % 16) * 4);
           out[i] = shifted_active ? data : 0;
           index++;
         }
@@ -2813,7 +2804,7 @@ void Instruction::execute() {
       uint8_t out[256] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << i;
         if (p[i / 64] & shifted_active) {
           out[i] = memoryData[index].get<uint8_t>();
           index++;
@@ -2833,7 +2824,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = memoryData[index].get<uint64_t>();
           index++;
@@ -2854,7 +2845,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = memoryData[index].get<uint64_t>();
           index++;
@@ -2874,7 +2865,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = memoryData[index].get<uint32_t>();
           index++;
@@ -2895,7 +2886,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = memoryData[index].get<uint32_t>();
           index++;
@@ -3241,8 +3232,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         uint8_t data = memoryData[i].get<uint8_t>();
         for (int j = 0; j < 8; j++) {
-          out[i / 8] |=
-              (data & (1 << j)) ? (uint64_t)std::pow(2, (j + (i * 8))) : 0;
+          out[i / 8] |= (data & (1 << j)) ? 1ull << (j + (i * 8)) : 0;
         }
       }
 
@@ -3603,11 +3593,10 @@ void Instruction::execute() {
       uint8_t n = (masked_n[0] & 1);
       uint8_t z = 1;
       // (int)(VL_bits - 1)/512 derives which block of 64-bits within the
-      // predicate register we're working in. std::pow(2, (VL_bits / 8) - 1)
+      // predicate register we're working in. 1ull << (VL_bits / 8) - 1)
       // derives a 1 in the last position of the current predicate. Both
       // dictated by vector length.
-      uint8_t c = !(masked_n[(int)((VL_bits - 1) / 512)] &
-                    (uint64_t)std::pow(2, 64 - 1));
+      uint8_t c = !(masked_n[(int)((VL_bits - 1) / 512)] & 1ull << (64 - 1));
       for (int i = 0; i < (int)((VL_bits - 1) / 512) + 1; i++) {
         if (masked_n[i]) {
           z = 0;
@@ -3623,7 +3612,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << i;
         out[i / 64] |= shifted_active;
       }
 
@@ -3636,7 +3625,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         out[i / 8] |= shifted_active;
       }
 
@@ -3649,7 +3638,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         out[i / 16] |= shifted_active;
       }
       results[0] = out;
@@ -3663,8 +3652,8 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = partition_num / 2; i < partition_num; i++) {
-        if (n[i / 64] & ((uint64_t)std::pow(2, (i % 64)))) {
-          out[index / 32] |= (uint64_t)std::pow(2, (index * 2));
+        if (n[i / 64] & 1ull << i % 64) {
+          out[index / 32] |= 1ull << index * 2;
         }
         index++;
       }
@@ -3679,8 +3668,8 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num / 2; i++) {
-        if (n[i / 64] & ((uint64_t)std::pow(2, (i % 64)))) {
-          out[i / 32] |= (uint64_t)std::pow(2, (i * 2));
+        if (n[i / 64] & 1ull << i % 64) {
+          out[i / 32] |= 1ull << i * 2;
         }
       }
 
@@ -3832,7 +3821,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = n[i];
         } else {
@@ -3852,7 +3841,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = n[i];
         } else {
@@ -3898,7 +3887,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = std::max(n[i], m[i]);
         } else {
@@ -3928,7 +3917,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = std::min(n[i], m[i]);
         } else {
@@ -3948,7 +3937,7 @@ void Instruction::execute() {
       int32_t out = INT32_MAX;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           out = std::min(out, n[i]);
         }
@@ -4014,7 +4003,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << i;
         if (p[i / 64] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -4031,7 +4020,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -4048,7 +4037,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << (i * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -4065,7 +4054,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -4082,7 +4071,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << (i * 4);
         if (p[i / 16] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -4699,15 +4688,16 @@ void Instruction::execute() {
       const uint8_t imm = metadata.operands[1].imm;
       const uint64_t VL_bits = 512;
 
-      int64_t out = d - (imm * (VL_bits / 64));
-      // Saturate output
-      if (out > (std::pow(2, 64) - 1)) {
-        out = std::pow(2, 64) - 1;
-      } else if (out < 0) {
-        out = 0;
+      // The range of possible values is [-128, UINT64_MAX - 8]
+      // Since this range does not fit in any integral type,
+      // a double is used as an intermediate value.
+      // The end result must be saturated to fit in uint64_t.
+      auto intermediate = double(d) - (imm * (VL_bits / 64u));
+      if (intermediate < 0) {
+        results[0] = 0ull;
+      } else {
+        results[0] = d - (imm * (VL_bits / 64u));
       }
-
-      results[0] = out;
       break;
     }
     case Opcode::AArch64_UQDECH_XPiI: {  // uqdech xd{, pattern{, MUL #imm}}
@@ -4715,15 +4705,16 @@ void Instruction::execute() {
       const uint8_t imm = metadata.operands[1].imm;
       const uint64_t VL_bits = 512;
 
-      int64_t out = d - (imm * (VL_bits / 16));
-      // Saturate output
-      if (out > (std::pow(2, 64) - 1)) {
-        out = std::pow(2, 64) - 1;
-      } else if (out < 0) {
-        out = 0;
+      // The range of possible values is [-512, UINT64_MAX - 32]
+      // Since this range does not fit in any integral type,
+      // a double is used as an intermediate value.
+      // The end result must be saturated to fit in uint64_t.
+      auto intermediate = double(d) - (imm * (VL_bits / 16u));
+      if (intermediate < 0) {
+        results[0] = 0ull;
+      } else {
+        results[0] = d - (imm * (VL_bits / 16u));
       }
-
-      results[0] = out;
       break;
     }
     case Opcode::AArch64_UQDECW_XPiI: {  // uqdecw xd{, pattern{, MUL #imm}}
@@ -4731,15 +4722,16 @@ void Instruction::execute() {
       const uint8_t imm = metadata.operands[1].imm;
       const uint64_t VL_bits = 512;
 
-      int64_t out = d - (imm * (VL_bits / 32));
-      // Saturate output
-      if (out > (std::pow(2, 64) - 1)) {
-        out = std::pow(2, 64) - 1;
-      } else if (out < 0) {
-        out = 0;
+      // The range of possible values is [-256, UINT64_MAX - 16]
+      // Since this range does not fit in any integral type,
+      // a double is used as an intermediate value.
+      // The end result must be saturated to fit in uint64_t.
+      auto intermediate = double(d) - (imm * (VL_bits / 32u));
+      if (intermediate < 0) {
+        results[0] = 0ull;
+      } else {
+        results[0] = d - (imm * (VL_bits / 32u));
       }
-
-      results[0] = out;
       break;
     }
     case Opcode::AArch64_UCVTFUWDri: {  // ucvtf dd, wn
@@ -4868,7 +4860,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? std::pow(2, i) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << i : 0;
         out[index / 64] = out[index / 64] | shifted_active;
         index++;
       }
@@ -4876,11 +4868,10 @@ void Instruction::execute() {
       uint8_t N = (out[0] & 1);
       uint8_t Z = 1;
       // (int)(VL_bits - 1)/512 derives which block of 64-bits within the
-      // predicate register we're working in. std::pow(2, (VL_bits / 8) - 1)
+      // predicate register we're working in. 1ull << (VL_bits / 8) - 1)
       // derives a 1 in the last position of the current predicate. Both
       // dictated by vector length.
-      uint8_t C =
-          !(out[(int)((VL_bits - 1) / 512)] & (uint64_t)std::pow(2, 64 - 1));
+      uint8_t C = !(out[(int)((VL_bits - 1) / 512)] & 1ull << (64 - 1));
       for (int i = 0; i < (int)((VL_bits - 1) / 512) + 1; i++) {
         if (out[i]) {
           Z = 0;
@@ -4902,7 +4893,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? std::pow(2, (i * 8)) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << (i * 8) : 0;
         out[index / 8] = out[index / 8] | shifted_active;
         index++;
       }
@@ -4910,11 +4901,10 @@ void Instruction::execute() {
       uint8_t N = (out[0] & 1);
       uint8_t Z = 1;
       // (int)(VL_bits - 1)/512 derives which block of 64-bits within the
-      // predicate register we're working in. std::pow(2, (VL_bits / 8) - 1)
+      // predicate register we're working in. 1ull << (VL_bits / 8) - 1)
       // derives a 1 in the last position of the current predicate. Both
       // dictated by vector length.
-      uint8_t C =
-          !(out[(int)((VL_bits - 1) / 512)] & (uint64_t)std::pow(2, 64 - 8));
+      uint8_t C = !(out[(int)((VL_bits - 1) / 512)] & 1ull << (64 - 8));
       for (int i = 0; i < (int)((VL_bits - 1) / 512) + 1; i++) {
         if (out[i]) {
           Z = 0;
@@ -4936,7 +4926,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? std::pow(2, (i * 4)) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << (i * 4) : 0;
         out[index / 16] = out[index / 16] | shifted_active;
         index++;
       }
@@ -4944,11 +4934,10 @@ void Instruction::execute() {
       uint8_t N = (out[0] & 1);
       uint8_t Z = 1;
       // (int)(VL_bits - 1)/512 derives which block of 64-bits within the
-      // predicate register we're working in. std::pow(2, (VL_bits / 8) - 1)
+      // predicate register we're working in. 1ull << (VL_bits / 8) - 1)
       // derives a 1 in the last position of the current predicate. Both
       // dictated by vector length.
-      uint8_t C =
-          !(out[(int)((VL_bits - 1) / 512)] & (uint64_t)std::pow(2, 64 - 4));
+      uint8_t C = !(out[(int)((VL_bits - 1) / 512)] & 1ull << (64 - 4));
       for (int i = 0; i < (int)((VL_bits - 1) / 512) + 1; i++) {
         if (out[i]) {
           Z = 0;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -2,6 +2,11 @@
 #include <limits>
 #include <tuple>
 
+// Temporary; until execute has been verified to work correctly.
+#ifndef NDEBUG
+#include <iostream>
+#endif
+
 #include "InstructionMetadata.hh"
 #include "simeng/arch/aarch64/Instruction.hh"
 
@@ -199,8 +204,7 @@ void Instruction::execute() {
     case Opcode::AArch64_ADDv1i64: {  // add dd, dn, dm
       const uint64_t n = operands[0].get<uint64_t>();
       const uint64_t m = operands[1].get<uint64_t>();
-      uint64_t out[2] = {static_cast<uint64_t>(n + m), 0};
-      results[0] = out;
+      results[0] = {n + m, 256};
       break;
     }
     case Opcode::AArch64_ADDv4i32: {  // add vd.4s, vn.4s, vm.4s
@@ -210,7 +214,7 @@ void Instruction::execute() {
                          static_cast<uint32_t>(n[1] + m[1]),
                          static_cast<uint32_t>(n[2] + m[2]),
                          static_cast<uint32_t>(n[3] + m[3])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADCXr: {  // adc xd, xn, xm
@@ -240,27 +244,26 @@ void Instruction::execute() {
                          static_cast<uint8_t>(m[10] + m[11]),
                          static_cast<uint8_t>(m[12] + m[13]),
                          static_cast<uint8_t>(m[14] + m[15])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDPv2i64: {  // addp vd.2d, vn.2d, vm.2d
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
       uint64_t out[2] = {n[0] + n[1], m[0] + m[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDPv2i64p: {  // addp dd, vn.2d
       const uint64_t* a = operands[0].getAsVector<uint64_t>();
-      uint64_t out[2] = {a[0] + a[1], 0};
-      results[0] = out;
+      results[0] = {a[0] + a[1], 256};
       break;
     }
     case Opcode::AArch64_ADDPv4i32: {  // addp vd.4s, vn.4s, vm.4s
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint32_t* m = operands[1].getAsVector<uint32_t>();
       uint32_t out[4] = {n[0] + n[1], n[2] + n[3], m[0] + m[1], m[2] + m[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDPv8i16: {  // addp vd.8h, vn.8h, vm.8h
@@ -274,7 +277,7 @@ void Instruction::execute() {
                          static_cast<uint16_t>(m[2] + m[3]),
                          static_cast<uint16_t>(m[4] + m[5]),
                          static_cast<uint16_t>(m[6] + m[7])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDSWri: {  // adds wd, wn, #imm{, shift}
@@ -362,7 +365,7 @@ void Instruction::execute() {
       for (int i = 0; i < 8; i++) {
         out[0] += n[i];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDWri: {  // add wd, wn, #imm{, shift}
@@ -525,14 +528,14 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
       uint64_t out[2] = {n[0] & m[0], n[1] & m[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ANDv8i8: {  // and vd.8b, vn.8b, vm.8b
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint32_t* m = operands[1].getAsVector<uint32_t>();
       uint32_t out[4] = {n[0] & m[0], n[1] & m[1], 0, 0};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ASRVWr: {  // asrv wd, wn, wm
@@ -615,7 +618,7 @@ void Instruction::execute() {
       for (int i = 0; i < 16; i++) {
         out[i] = n[i] & ~m[i];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_BICv4i32: {  // bic vd.4s, #imm{, lsl #shift}
@@ -624,7 +627,7 @@ void Instruction::execute() {
           static_cast<uint32_t>(metadata.operands[1].imm),
           metadata.operands[1].shift.type, metadata.operands[1].shift.value);
       uint32_t out[4] = {d[0] & imm, d[1] & imm, d[2] & imm, d[3] & imm};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_BICv8i8: {  // bic vd.8b, vn.8b, vm.8b
@@ -634,7 +637,7 @@ void Instruction::execute() {
       for (int i = 0; i < 8; i++) {
         out[i] = n[i] & ~m[i];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_Bcc: {  // b.cond label
@@ -653,7 +656,7 @@ void Instruction::execute() {
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
       uint64_t out[2] = {(d[0] & m[0]) | (n[0] & ~m[0]),
                          (d[1] & m[1]) | (n[1] & ~m[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_BITv16i8: {  // bit vd.16b, vn.16b, vm.16b
@@ -662,7 +665,7 @@ void Instruction::execute() {
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
       uint64_t out[2] = {(d[0] & ~m[0]) | (n[0] & m[0]),
                          (d[1] & ~m[1]) | (n[1] & m[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_BL: {  // bl #imm
@@ -688,7 +691,7 @@ void Instruction::execute() {
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
       uint64_t out[2] = {(d[0] & n[0]) | ((~d[0]) & m[0]),
                          (d[1] & n[1]) | ((~d[1]) & m[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_CBNZW: {  // cbnz wn, #imm
@@ -822,7 +825,7 @@ void Instruction::execute() {
       for (int i = 0; i < 16; i++) {
         out[i] = (n[i] == m[i]) ? 0xFF : 0;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_CMEQv16i8rz: {  // cmeq vd.16b, vn.16b, #0
@@ -831,7 +834,7 @@ void Instruction::execute() {
       for (int i = 0; i < 16; i++) {
         out[i] = (n[i] == 0) ? 0xFF : 0;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_CMHIv4i32: {  // cmhi vd.4s, vn.4s, vm.4s
@@ -841,7 +844,7 @@ void Instruction::execute() {
       for (int i = 0; i < 4; i++) {
         out[i] = (n[i] > m[i]) ? 0xFFFFFFFF : 0;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_CMPNE_PPzZI_S: {  // cmpne pd.s, pg/z. zn.s, #imm
@@ -905,19 +908,19 @@ void Instruction::execute() {
           out[i] += ((n[i] >> j) & 1);
         }
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_CPYi32: {  // dup vd, vn.s[index]
       const uint32_t* vec = operands[0].getAsVector<uint32_t>();
-      uint32_t out[4] = {vec[metadata.operands[1].vector_index], 0, 0, 0};
-      results[0] = out;
+      uint32_t out[1] = {vec[metadata.operands[1].vector_index]};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_CPYi64: {  // dup vd, vn.d[index]
       const uint64_t* vec = operands[0].getAsVector<uint64_t>();
-      uint64_t out[2] = {vec[metadata.operands[1].vector_index], 0};
-      results[0] = out;
+      uint64_t out[1] = {vec[metadata.operands[1].vector_index]};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_CSELWr: {  // csel wd, wn, wm, cc
@@ -1099,26 +1102,26 @@ void Instruction::execute() {
     case Opcode::AArch64_DUPv16i8gpr: {  // dup vd.16b, wn
       uint8_t out[16];
       std::fill(std::begin(out), std::end(out), operands[0].get<uint8_t>());
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DUPv2i32gpr: {  // dup vd.2s, wn
       uint32_t element = operands[0].get<uint32_t>();
-      uint32_t out[4] = {element, element, 0, 0};
-      results[0] = out;
+      uint32_t out[2] = {element, element};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DUPv2i32lane: {  // dup vd.2s, vn.s[index]
       int index = metadata.operands[1].vector_index;
       uint32_t element = operands[0].getAsVector<uint32_t>()[index];
-      uint32_t out[4] = {element, element, 0, 0};
-      results[0] = out;
+      uint32_t out[2] = {element, element};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DUPv2i64gpr: {  // dup vd.2d, xn
       uint64_t out[2];
       std::fill(std::begin(out), std::end(out), operands[0].get<uint64_t>());
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DUPv2i64lane: {  // dup vd.2d, vn.d[index]
@@ -1126,19 +1129,19 @@ void Instruction::execute() {
       uint64_t element = operands[0].getAsVector<uint64_t>()[index];
       uint64_t out[2];
       std::fill(std::begin(out), std::end(out), element);
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DUPv4i16gpr: {  // dup vd.4h, wn
       uint16_t element = operands[0].get<uint16_t>();
-      uint16_t out[8] = {element, element, element, element, 0, 0, 0, 0};
-      results[0] = out;
+      uint16_t out[4] = {element, element, element, element};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DUPv4i32gpr: {  // dup vd.4s, wn
       uint32_t out[4];
       std::fill(std::begin(out), std::end(out), operands[0].get<uint32_t>());
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DUPv4i32lane: {  // dup vd.4s, vn.s[index]
@@ -1146,7 +1149,7 @@ void Instruction::execute() {
       uint32_t element = operands[0].getAsVector<uint32_t>()[index];
       uint32_t out[4];
       std::fill(std::begin(out), std::end(out), element);
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_DMB: {  // dmb option|#imm
@@ -1188,7 +1191,7 @@ void Instruction::execute() {
       for (int i = 0; i < 16; i++) {
         out[i] = n[i] ^ m[i];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_EXTRWrri: {  // extr wd, wn, wm, #lsb
@@ -1216,27 +1219,23 @@ void Instruction::execute() {
     case Opcode::AArch64_FABD32: {  // fabd sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {std::fabs(n - m), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {std::fabs(n - m), 256};
       break;
     }
     case Opcode::AArch64_FABD64: {  // fabd dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {std::fabs(n - m), 0.0};
-      results[0] = out;
+      results[0] = {std::fabs(n - m), 256};
       break;
     }
     case Opcode::AArch64_FABSDr: {  // fabs dd, dn
       double n = operands[0].get<double>();
-      double out[2] = {std::fabs(n), 0.0};
-      results[0] = out;
+      results[0] = {std::fabs(n), 256};
       break;
     }
     case Opcode::AArch64_FABSSr: {  // fabs sd, sn
       float n = operands[0].get<float>();
-      float out[4] = {std::fabs(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {std::fabs(n), 256};
       break;
     }
     case Opcode::AArch64_FABS_ZPmZ_S: {  // fabs zd.s, pg/m, zn.s
@@ -1262,14 +1261,14 @@ void Instruction::execute() {
     case Opcode::AArch64_FABSv2f64: {  // fabs vd.2d, vn.2d
       const double* n = operands[0].getAsVector<double>();
       double out[2] = {std::fabs(n[0]), std::fabs(n[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FABSv4f32: {  // fabs vd.4s, vn.4s
       const float* n = operands[0].getAsVector<float>();
       float out[4] = {std::fabs(n[0]), std::fabs(n[1]), std::fabs(n[2]),
                       std::fabs(n[3])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FADDA_VPZ_D: {  // fadda dd, pg/m, dn, zm.d
@@ -1286,41 +1285,38 @@ void Instruction::execute() {
         }
       }
 
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FADDDrr: {  // fadd dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {n + m, 0.0};
-      results[0] = out;
+      results[0] = {n + m, 256};
       break;
     }
     case Opcode::AArch64_FADDSrr: {  // fadd sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {n + m, 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {n + m, 256};
       break;
     }
     case Opcode::AArch64_FADDv2f64: {  // fadd vd.2d, vn.2d, vm.2d
       const double* a = operands[0].getAsVector<double>();
       const double* b = operands[1].getAsVector<double>();
       double out[2] = {a[0] + b[0], a[1] + b[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FADDv4f32: {  // fadd vd.4s, vn.4s, vm.4s
       const float* a = operands[0].getAsVector<float>();
       const float* b = operands[1].getAsVector<float>();
       float out[4] = {a[0] + b[0], a[1] + b[1], a[2] + b[2], a[3] + b[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FADDPv2i64p: {  // faddp dd, vn.2d
       const double* a = operands[0].getAsVector<double>();
-      double out[2] = {a[0] + a[1], 0.0};
-      results[0] = out;
+      results[0] = {a[0] + a[1], 256};
       break;
     }
     case Opcode::AArch64_FADDPv4f32: {  // faddp vd.4s, vn.4s, vm.4s
@@ -1336,7 +1332,7 @@ void Instruction::execute() {
       for (int i = 0; i < 4; i++) {
         out[i] = concat[2 * i] + concat[2 * i + 1];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FADDPv2f32: {  // faddp vd.2s, vn.2s, vm.2s
@@ -1352,7 +1348,7 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = concat[2 * i] + concat[2 * i + 1];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FADDPv2f64: {  // faddp vd.2d, vn.2d, vm.2d
@@ -1368,7 +1364,7 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = concat[2 * i] + concat[2 * i + 1];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FADDPv8f16:  // faddp vd.8h, vn.8h, vm.8h
@@ -1508,7 +1504,7 @@ void Instruction::execute() {
       const double* n = operands[0].getAsVector<double>();
       uint64_t out[2] = {static_cast<uint64_t>(n[0] >= 0.0 ? -1 : 0),
                          static_cast<uint64_t>(n[1] >= 0.0 ? -1 : 0)};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCMGEv4i32rz: {  // fcmge vd.4s, vn.4s, 0.0
@@ -1517,7 +1513,7 @@ void Instruction::execute() {
                          static_cast<uint32_t>(n[1] >= 0.0 ? -1 : 0),
                          static_cast<uint32_t>(n[2] >= 0.0 ? -1 : 0),
                          static_cast<uint32_t>(n[3] >= 0.0 ? -1 : 0)};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCMGT_PPzZZ_D: {  // fcmgt pd.d, pg/z, zn.d, zm.d
@@ -1567,7 +1563,7 @@ void Instruction::execute() {
                          static_cast<uint32_t>(n[1] > m[1] ? -1 : 0),
                          static_cast<uint32_t>(n[2] > m[2] ? -1 : 0),
                          static_cast<uint32_t>(n[3] > m[3] ? -1 : 0)};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCMLT_PPzZ0_S: {  // fcmlt pd.s, pg/z, zn.s, #0.0
@@ -1596,7 +1592,7 @@ void Instruction::execute() {
                          static_cast<uint32_t>(n[1] < 0.0 ? -1 : 0),
                          static_cast<uint32_t>(n[2] < 0.0 ? -1 : 0),
                          static_cast<uint32_t>(n[3] < 0.0 ? -1 : 0)};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCMPDri:     // fcmp dn, #imm
@@ -1671,7 +1667,7 @@ void Instruction::execute() {
           out[i] = 0xffffffff;
         }
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCMEQv4i32rz: {  // fcmeq vd.4s vn.4s, #0.0
@@ -1682,24 +1678,21 @@ void Instruction::execute() {
           out[i] = 0xffffffff;
         }
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCSELDrrr: {  // fcsel dd, dn, dm, cond
       double n = operands[1].get<double>();
       double m = operands[2].get<double>();
-      double out[2] = {
-          conditionHolds(metadata.cc, operands[0].get<uint8_t>()) ? n : m, 0.0};
-      results[0] = out;
+      results[0] = RegisterValue(
+          conditionHolds(metadata.cc, operands[0].get<uint8_t>()) ? n : m, 256);
       break;
     }
     case Opcode::AArch64_FCSELSrrr: {  // fcsel sd, sn, sm, cond
       float n = operands[1].get<float>();
       float m = operands[2].get<float>();
-      float out[4] = {
-          conditionHolds(metadata.cc, operands[0].get<uint8_t>()) ? n : m, 0.f,
-          0.f, 0.f};
-      results[0] = out;
+      results[0] = RegisterValue(
+          conditionHolds(metadata.cc, operands[0].get<uint8_t>()) ? n : m, 256);
       break;
     }
     case Opcode::AArch64_FCVTASUWDr: {  // fcvtas wd, dn
@@ -1713,41 +1706,39 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_FCVTDSr: {  // fcvt dd, sn
       // TODO: Handle NaNs, denorms, and saturation?
-      double out[2] = {static_cast<double>(operands[0].get<float>()), 0.0};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<double>(operands[0].get<float>()), 256);
       break;
     }
     case Opcode::AArch64_FCVTLv2i32: {  // fcvtl vd.2d, vn.2s
       const float* n = operands[0].getAsVector<float>();
       double out[2] = {static_cast<double>(n[0]), static_cast<double>(n[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCVTLv4i32: {  // fcvtl2 vd.2d, vn.4s
       const float* n = operands[0].getAsVector<float>();
       double out[2] = {static_cast<double>(n[2]), static_cast<double>(n[3])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCVTNv2i32: {  // fcvtn vd.2s, vn.2d
       const double* n = operands[0].getAsVector<double>();
-      float out[4] = {static_cast<float>(n[0]), static_cast<float>(n[1]), 0.f,
-                      0.f};
-      results[0] = out;
+      float out[2] = {static_cast<float>(n[0]), static_cast<float>(n[1])};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCVTNv4i32: {  // fcvtn2 vd.4s, vn.2d
       const double* n = operands[0].getAsVector<double>();
       float out[4] = {0.f, 0.f, static_cast<float>(n[0]),
                       static_cast<float>(n[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FCVTSDr: {  // fcvt sd, dn
       // TODO: Handle NaNs, denorms, and saturation?
-      float out[4] = {static_cast<float>(operands[0].get<double>()), 0.f, 0.f,
-                      0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(operands[0].get<double>()), 256);
       break;
     }
     case Opcode::AArch64_FCVTZSUWDr: {  // fcvtzs wd, dn
@@ -1798,21 +1789,19 @@ void Instruction::execute() {
       // TODO: Handle NaNs, denorms, and saturation
       int64_t out[2] = {static_cast<int64_t>(std::trunc(n[0])),
                         static_cast<int64_t>(std::trunc(n[1]))};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FDIVDrr: {  // fdiv dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {n / m, 0.0};
-      results[0] = out;
+      results[0] = {n / m, 256};
       break;
     }
     case Opcode::AArch64_FDIVSrr: {  // fdiv sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {n / m, 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {n / m, 256};
       break;
     }
     case Opcode::AArch64_FDIV_ZPmZ_D: {  // fdiv zd.d, pg/m, zn.d, zm.d
@@ -1840,7 +1829,7 @@ void Instruction::execute() {
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
       double out[2] = {n[0] / m[0], n[1] / m[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FDUP_ZI_D: {  // fdup zd.d, #imm
@@ -1873,16 +1862,14 @@ void Instruction::execute() {
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
       double a = operands[2].get<double>();
-      double out[2] = {std::fma(n, m, a), 0.0};
-      results[0] = out;
+      results[0] = {std::fma(n, m, a), 256};
       break;
     }
     case Opcode::AArch64_FMADDSrrr: {  // fmadd sn, sm, sa
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
       float a = operands[2].get<float>();
-      float out[4] = {std::fma(n, m, a), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {std::fma(n, m, a), 256};
       break;
     }
     case Opcode::AArch64_FMAD_ZPmZZ_S: {  // fmad zd.s, pg/m, zn.s, zm.s
@@ -1910,55 +1897,49 @@ void Instruction::execute() {
     case Opcode::AArch64_FMAXNMDrr: {  // fmaxnm dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {std::fmax(n, m), 0.0};
-      results[0] = out;
+      results[0] = {std::fmax(n, m), 256};
       break;
     }
     case Opcode::AArch64_FMAXNMPv2i64p: {  // fmaxnmp dd vd.2d
       const double* n = operands[0].getAsVector<double>();
-      double out[2] = {std::fmax(n[0], n[1]), 0.0};
-      results[0] = out;
+      results[0] = {std::fmax(n[0], n[1]), 256};
       break;
     }
     case Opcode::AArch64_FMAXNMSrr: {  // fmaxnm sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {std::fmax(n, m), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {std::fmax(n, m), 256};
       break;
     }
     case Opcode::AArch64_FMAXNMv2f64: {  // fmaxnm vd.2d, vn.2d, vm.2d
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
       double out[2] = {std::fmax(n[0], m[0]), std::fmax(n[1], m[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMINNMDrr: {  // fminnm dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {std::fmin(n, m), 0.0};
-      results[0] = out;
+      results[0] = {std::fmin(n, m), 256};
       break;
     }
     case Opcode::AArch64_FMINNMSrr: {  // fminnm sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {std::fmin(n, m), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {std::fmin(n, m), 256};
       break;
     }
     case Opcode::AArch64_FMINNMv2f64: {  // fminnm vd.2d, vn.2d, vm.2d
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
       double out[2] = {std::fmin(n[0], m[0]), std::fmin(n[1], m[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMINNMPv2i64p: {  // fminnmp dd vd.2d
       const double* n = operands[0].getAsVector<double>();
-      double out[2] = {std::fmin(n[0], n[1]), 0.0};
-      results[0] = out;
+      results[0] = {std::fmin(n[0], n[1]), 256};
       break;
     }
     case Opcode::AArch64_FMLAv2f64: {  // fmla vd.2d, vn.2d, vm.2d
@@ -1966,7 +1947,7 @@ void Instruction::execute() {
       const double* b = operands[1].getAsVector<double>();
       const double* c = operands[2].getAsVector<double>();
       double out[2] = {a[0] + b[0] * c[0], a[1] + b[1] * c[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMLAv4f32: {  // fmla vd.4s, vn.4s, vm.4s
@@ -1975,7 +1956,7 @@ void Instruction::execute() {
       const float* c = operands[2].getAsVector<float>();
       float out[4] = {a[0] + b[0] * c[0], a[1] + b[1] * c[1],
                       a[2] + b[2] * c[2], a[3] + b[3] * c[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMLAv4i32_indexed: {  // fmla vd.4s, vn.4s, vm.s[index]
@@ -1985,7 +1966,7 @@ void Instruction::execute() {
       const float c = operands[2].getAsVector<float>()[index];
       float out[4] = {a[0] + b[0] * c, a[1] + b[1] * c, a[2] + b[2] * c,
                       a[3] + b[3] * c};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMLA_ZPmZZ_D: {  // fmla zd.d, pg/m, zn.d, zm.d
@@ -2035,7 +2016,7 @@ void Instruction::execute() {
       const double* b = operands[1].getAsVector<double>();
       const double* c = operands[2].getAsVector<double>();
       double out[2] = {a[0] - (b[0] * c[0]), a[1] - (b[1] * c[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMLSv4f32: {  // fmls vd.4s, vn.4s, vm.4s
@@ -2044,7 +2025,7 @@ void Instruction::execute() {
       const float* c = operands[2].getAsVector<float>();
       float out[4] = {a[0] - b[0] * c[0], a[1] - b[1] * c[1],
                       a[2] - b[2] * c[2], a[3] - b[3] * c[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMLSv4i32_indexed: {  // fmls vd.4s, vn.4s, vm.s[index]
@@ -2054,7 +2035,7 @@ void Instruction::execute() {
       const float c = operands[2].getAsVector<float>()[index];
       float out[4] = {a[0] - b[0] * c, a[1] - b[1] * c, a[2] - b[2] * c,
                       a[3] - b[3] * c};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMLS_ZPmZZ_S: {  // fmls zd.s, pg/m, zn.s, zm.s
@@ -2087,13 +2068,11 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_FMOVDi: {  // fmov dn, #imm
-      double out[2] = {metadata.operands[1].fp, 0.0};
-      results[0] = out;
+      results[0] = RegisterValue(metadata.operands[1].fp, 256);
       break;
     }
     case Opcode::AArch64_FMOVDr: {  // fmov dd, dn
-      double out[2] = {operands[0].get<double>(), 0.0};
-      results[0] = out;
+      results[0] = RegisterValue(operands[0].get<double>(), 256);
       break;
     }
     case Opcode::AArch64_FMOVSWr: {  // fmov wd, sn
@@ -2101,62 +2080,56 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_FMOVSi: {  // fmov sn, #imm
-      float out[4] = {static_cast<float>(metadata.operands[1].fp), 0.f, 0.f,
-                      0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(metadata.operands[1].fp), 256);
       break;
     }
     case Opcode::AArch64_FMOVSr: {  // fmov sd, sn
-      float out[4] = {operands[0].get<float>(), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = RegisterValue(operands[0].get<float>(), 256);
       break;
     }
     case Opcode::AArch64_FMOVWSr: {  // fmov sd, wn
-      float out[4] = {operands[0].get<float>(), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = RegisterValue(operands[0].get<float>(), 256);
       break;
     }
     case Opcode::AArch64_FMOVXDHighr: {  // fmov vd.d[1], xn
       double out[2] = {operands[0].get<double>(), operands[1].get<double>()};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMOVXDr: {  // fmov dd, xn
-      double out[2] = {operands[0].get<double>(), 0.0};
-      results[0] = out;
+      results[0] = RegisterValue(operands[0].get<double>(), 256);
       break;
     }
     case Opcode::AArch64_FMOVv2f64_ns: {  // fmov vd.2d, #imm
       double out[2] = {metadata.operands[1].fp, metadata.operands[1].fp};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMOVv2f32_ns: {  // fmov vd.2s, #imm
       float imm = static_cast<float>(metadata.operands[1].fp);
-      float out[4] = {imm, imm, 0.f, 0.f};
-      results[0] = out;
+      float out[2] = {imm, imm};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMOVv4f32_ns: {  // fmov vd.4s, #imm
       float imm = static_cast<float>(metadata.operands[1].fp);
       float out[4] = {imm, imm, imm, imm};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMSUBDrrr: {  // fmsub dn, dm, da
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
       double a = operands[2].get<double>();
-      double out[2] = {std::fma(-n, m, a), 0.0};
-      results[0] = out;
+      results[0] = {std::fma(-n, m, a), 256};
       break;
     }
     case Opcode::AArch64_FMSUBSrrr: {  // fmsub sn, sm, sa
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
       float a = operands[2].get<float>();
-      float out[4] = {std::fma(-n, m, a), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {std::fma(-n, m, a), 256};
       break;
     }
     case Opcode::AArch64_FMSB_ZPmZZ_S: {  // fmsb zd.s, pg/m, zn.s, zm.s
@@ -2184,45 +2157,41 @@ void Instruction::execute() {
     case Opcode::AArch64_FMULDrr: {  // fmul dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {n * m, 0.0};
-      results[0] = out;
+      results[0] = {n * m, 256};
       break;
     }
     case Opcode::AArch64_FMULSrr: {  // fmul sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {n * m, 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {n * m, 256};
       break;
     }
     case Opcode::AArch64_FMULv1i32_indexed: {  // fmul sd, sn, vm.s[index]
       int index = metadata.operands[2].vector_index;
       float n = operands[0].get<float>();
       float m = operands[1].getAsVector<float>()[index];
-      float out[4] = {n * m, 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {n * m, 256};
       break;
     }
     case Opcode::AArch64_FMULv1i64_indexed: {  // fmul dd, dn, vm.d[index]
       int index = metadata.operands[2].vector_index;
       double n = operands[0].get<double>();
       double m = operands[1].getAsVector<double>()[index];
-      double out[2] = {n * m, 0.0};
-      results[0] = out;
+      results[0] = {n * m, 256};
       break;
     }
     case Opcode::AArch64_FMULv2f64: {  // fmul vd.2d, vn.2d, vm.2d
       const double* a = operands[0].getAsVector<double>();
       const double* b = operands[1].getAsVector<double>();
       double out[2] = {a[0] * b[0], a[1] * b[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMULv4f32: {  // fmul vd.4s, vn.4s, vm.4s
       const float* a = operands[0].getAsVector<float>();
       const float* b = operands[1].getAsVector<float>();
       float out[4] = {a[0] * b[0], a[1] * b[1], a[2] * b[2], a[3] * b[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMULv4i32_indexed: {  // fmul vd.4s, vn.4s, vm.s[index]
@@ -2230,7 +2199,7 @@ void Instruction::execute() {
       const float* a = operands[0].getAsVector<float>();
       const float b = operands[1].getAsVector<float>()[index];
       float out[4] = {a[0] * b, a[1] * b, a[2] * b, a[3] * b};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FMUL_ZZZ_D: {  // fmul zd.d, zn.d, zm.d
@@ -2342,13 +2311,11 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_FNEGDr: {  // fneg dd, dn
-      double out[2] = {-operands[0].get<double>(), 0.0};
-      results[0] = out;
+      results[0] = RegisterValue(-operands[0].get<double>(), 256);
       break;
     }
     case Opcode::AArch64_FNEGSr: {  // fneg sd, sn
-      float out[4] = {-operands[0].get<float>(), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = RegisterValue(-operands[0].get<float>(), 256);
       break;
     }
     case Opcode::AArch64_FNEG_ZPmZ_D: {  // fneg zd.d, pg/m, zn.d
@@ -2394,60 +2361,53 @@ void Instruction::execute() {
     case Opcode::AArch64_FNEGv2f64: {  // fneg vd.2d, vn.2d
       const double* n = operands[0].getAsVector<double>();
       double out[2] = {-n[0], -n[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FNEGv4f32: {  // fneg vd.4s, vn.4s
       const float* n = operands[0].getAsVector<float>();
       float out[4] = {-n[0], -n[1], -n[2], -n[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FNMSUBDrrr: {  // fnmsub dd, dn, dm, da
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
       double a = operands[2].get<double>();
-      double out[2] = {std::fma(n, m, -a), 0.0};
-      results[0] = out;
+      results[0] = {std::fma(n, m, -a), 256};
       break;
     }
     case Opcode::AArch64_FNMSUBSrrr: {  // fnmsub sd, sn, sm, sa
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
       float a = operands[2].get<float>();
-      float out[4] = {std::fma(n, m, -a), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {std::fma(n, m, -a), 256};
       break;
     }
     case Opcode::AArch64_FNMULDrr: {  // fnmul dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {-(n * m), 0.0};
-      results[0] = out;
+      results[0] = {-(n * m), 256};
       break;
     }
     case Opcode::AArch64_FNMULSrr: {  // fnmul sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {-(n * m), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {-(n * m), 256};
       break;
     }
     case Opcode::AArch64_FRINTADr: {  // frinta dd, dn
-      double out[2] = {round(operands[0].get<double>()), 0.0};
-      results[0] = out;
+      results[0] = RegisterValue(round(operands[0].get<double>()), 256);
       break;
     }
     case Opcode::AArch64_FRSQRTEv1i32: {  // frsqrte sd, sn
       float n = operands[0].get<float>();
-      float out[4] = {1.f / sqrtf(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {1.f / sqrtf(n), 256};
       break;
     }
     case Opcode::AArch64_FRSQRTEv1i64: {  // frsqrte dd, dn
       double n = operands[0].get<double>();
-      double out[2] = {1.0 / ::sqrt(n), 0.0};
-      results[0] = out;
+      results[0] = {1.0 / ::sqrt(n), 256};
       break;
     }
     case Opcode::AArch64_FRSQRTEv2f32: {  // frsqrte vd.2s, vn.2s
@@ -2456,7 +2416,7 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = 1.f / sqrtf(n[i]);
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FRSQRTEv4f32: {  // frsqrte vd.4s, vn.4s
@@ -2465,7 +2425,7 @@ void Instruction::execute() {
       for (int i = 0; i < 4; i++) {
         out[i] = 1.f / ::sqrtf(n[i]);
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FRSQRTEv2f64: {  // frsqrte vd.2d, vn.2d
@@ -2474,23 +2434,21 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = 1.0 / sqrt(n[i]);
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FRSQRTS32: {  // frsqrts sd, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
       float result = (3.f - n * m) / 2.f;
-      float out[4] = {result, 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {result, 256};
       break;
     }
     case Opcode::AArch64_FRSQRTS64: {  // frsqrts dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
       double result = (3.0 - n * m) / 2.0;
-      double out[2] = {result, 0.0};
-      results[0] = out;
+      results[0] = {result, 256};
       break;
     }
     case Opcode::AArch64_FRSQRTSv2f32: {  // frsqrts vd.2s, vn.2s, vn.2s
@@ -2500,7 +2458,7 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = (3.f - n[i] * m[i]) / 2.f;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FRSQRTSv4f32: {  // frsqrts vd.4s, vn.4s, vm.4s
@@ -2510,7 +2468,7 @@ void Instruction::execute() {
       for (int i = 0; i < 4; i++) {
         out[i] = (3.f - n[i] * m[i]) / 2.f;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FRSQRTSv2f64: {  // frsqrts vd.2d, vn.2d, vm.2d
@@ -2520,17 +2478,15 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = (3.0 - n[i] * m[i]) / 2.0;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FSQRTDr: {  // fsqrt dd, dn
-      double out[2] = {::sqrt(operands[0].get<double>()), 0.0};
-      results[0] = out;
+      results[0] = RegisterValue(::sqrt(operands[0].get<double>()), 256);
       break;
     }
     case Opcode::AArch64_FSQRTSr: {  // fsqrt sd, sn
-      float out[4] = {::sqrtf(operands[0].get<float>()), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = RegisterValue(::sqrtf(operands[0].get<float>()), 256);
       break;
     }
     case Opcode::AArch64_FSQRT_ZPmZ_S: {  // fsqrt zd.s, pg/m, zn.s
@@ -2556,28 +2512,26 @@ void Instruction::execute() {
     case Opcode::AArch64_FSQRTv2f64: {  // fsqrt vd.2d, vn.2d
       const double* n = operands[0].getAsVector<double>();
       double out[2] = {::sqrtf(n[0]), ::sqrtf(n[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FSQRTv4f32: {  // fsqrt vd.4s, vn.4s
       const float* n = operands[0].getAsVector<float>();
       float out[4] = {::sqrtf(n[0]), ::sqrtf(n[1]), ::sqrtf(n[2]),
                       ::sqrtf(n[3])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FSUBDrr: {  // fsub dd, dn, dm
       double n = operands[0].get<double>();
       double m = operands[1].get<double>();
-      double out[2] = {n - m, 0.0};
-      results[0] = out;
+      results[0] = {n - m, 256};
       break;
     }
     case Opcode::AArch64_FSUBSrr: {  // fsub ss, sn, sm
       float n = operands[0].get<float>();
       float m = operands[1].get<float>();
-      float out[4] = {n - m, 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] = {n - m, 256};
       break;
     }
     case Opcode::AArch64_FSUB_ZZZ_D: {  // fsub zd.d, zn.d, zm.d
@@ -2612,14 +2566,14 @@ void Instruction::execute() {
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
       double out[2] = {n[0] - m[0], n[1] - m[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_FSUBv4f32: {  // fsub vd.4s, vn.4s, vm.4s
       const float* n = operands[0].getAsVector<float>();
       const float* m = operands[1].getAsVector<float>();
       float out[4] = {n[0] - m[0], n[1] - m[1], n[2] - m[2], n[3] - m[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_INCB_XPiI: {  // incb xdn{, pattern{, #imm}}
@@ -2657,7 +2611,7 @@ void Instruction::execute() {
       uint32_t out[4] = {d[0], d[1], d[2], d[3]};
       out[metadata.operands[0].vector_index] =
           n[metadata.operands[1].vector_index];
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_INSvi8gpr: {  // ins vd.b[index], wn
@@ -2668,7 +2622,7 @@ void Instruction::execute() {
         out[i] = d[i];
       }
       out[metadata.operands[0].vector_index] = n;
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_INSvi16gpr: {  // ins vd.h[index], wn
@@ -2679,7 +2633,7 @@ void Instruction::execute() {
         out[i] = d[i];
       }
       out[metadata.operands[0].vector_index] = n;
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_INSvi32gpr: {  // ins vd.s[index], wn
@@ -2687,7 +2641,7 @@ void Instruction::execute() {
       const uint32_t n = operands[1].get<uint32_t>();
       uint32_t out[4] = {d[0], d[1], d[2], d[3]};
       out[metadata.operands[0].vector_index] = n;
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_INSvi64gpr: {  // ins vd.d[index], xn
@@ -2695,7 +2649,7 @@ void Instruction::execute() {
       const uint64_t n = operands[1].get<uint64_t>();
       uint64_t out[2] = {d[0], d[1]};
       out[metadata.operands[0].vector_index] = n;
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_LD1i32: {  // ld1 {vt.s}[index], [xn]
@@ -2705,7 +2659,7 @@ void Instruction::execute() {
       for (int i = 0; i < 4; i++) {
         out[i] = (i == index) ? memoryData[0].get<uint32_t>() : vt[i];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_LD1i64: {  // ld1 {vt.d}[index], [xn]
@@ -2715,7 +2669,7 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = (i == index) ? memoryData[0].get<uint64_t>() : vt[i];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_LD1i64_POST: {  // ld1 {vt.d}[index], [xn], #8
@@ -2725,7 +2679,7 @@ void Instruction::execute() {
       for (int i = 0; i < 2; i++) {
         out[i] = (i == index) ? memoryData[0].get<uint64_t>() : vt[i];
       }
-      results[0] = out;
+      results[0] = {out, 256};
       results[1] = operands[1].get<uint64_t>() + metadata.operands[2].imm;
       break;
     }
@@ -2786,13 +2740,13 @@ void Instruction::execute() {
     case Opcode::AArch64_LD1Rv4s: {  // ld1r {vt.4s}, [xn]
       uint32_t val = memoryData[0].get<uint32_t>();
       uint32_t out[4] = {val, val, val, val};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_LD1Rv4s_POST: {  // ld1r {vt.4s}, [xn], #imm
       uint32_t val = memoryData[0].get<uint32_t>();
       uint32_t out[4] = {val, val, val, val};
-      results[0] = out;
+      results[0] = {out, 256};
       results[1] = operands[1].get<uint64_t>() + metadata.operands[2].imm;
       break;
     }
@@ -2899,14 +2853,14 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LD1Twov16b: {  // ld1 {vt1.16b, vt2.16b}, [xn]
-      results[0] = memoryData[0];
-      results[1] = memoryData[1];
+      results[0] = memoryData[0].zeroExtend(memoryData[0].size(), 256);
+      results[1] = memoryData[1].zeroExtend(memoryData[1].size(), 256);
       break;
     }
     case Opcode::AArch64_LD1Twov16b_POST: {  // ld1 {vt1.16b, vt2.16b}, [xn],
                                              //   #imm
-      results[0] = memoryData[0];
-      results[1] = memoryData[1];
+      results[0] = memoryData[0].zeroExtend(memoryData[0].size(), 256);
+      results[1] = memoryData[1].zeroExtend(memoryData[1].size(), 256);
       results[2] = operands[0].get<uint64_t>() + metadata.operands[3].imm;
       break;
     }
@@ -2923,8 +2877,8 @@ void Instruction::execute() {
       const float* region2 = memoryData[1].getAsVector<float>();
       float t1[4] = {region1[0], region1[2], region2[0], region2[2]};
       float t2[4] = {region1[1], region1[3], region2[1], region2[3]};
-      results[0] = t1;
-      results[1] = t2;
+      results[0] = {t1, 256};
+      results[1] = {t2, 256};
       uint64_t offset = 32;
       if (metadata.operandCount == 4) {
         offset = operands[3].get<uint64_t>();
@@ -2945,47 +2899,47 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDNPSi: {  // ldnp st1, st2, [xn, #imm]
-      results[0] = memoryData[0].zeroExtend(4, 16);
-      results[1] = memoryData[1].zeroExtend(4, 16);
+      results[0] = memoryData[0].zeroExtend(4, 256);
+      results[1] = memoryData[1].zeroExtend(4, 256);
       break;
     }
     case Opcode::AArch64_LDPDi: {  // ldp dt1, dt2, [xn, #imm]
-      results[0] = memoryData[0].zeroExtend(8, 16);
-      results[1] = memoryData[1].zeroExtend(8, 16);
+      results[0] = memoryData[0].zeroExtend(8, 256);
+      results[1] = memoryData[1].zeroExtend(8, 256);
       break;
     }
     case Opcode::AArch64_LDPDpost: {  // ldp dt1, dt2, [xn], #imm
-      results[0] = memoryData[0].zeroExtend(8, 16);
-      results[1] = memoryData[1].zeroExtend(8, 16);
+      results[0] = memoryData[0].zeroExtend(8, 256);
+      results[1] = memoryData[1].zeroExtend(8, 256);
       results[2] = operands[0].get<uint64_t>() + metadata.operands[3].imm;
       break;
     }
     case Opcode::AArch64_LDPDpre: {  // ldp dt1, dt2, [xn, #imm]
-      results[0] = memoryData[0].zeroExtend(8, 16);
-      results[1] = memoryData[1].zeroExtend(8, 16);
+      results[0] = memoryData[0].zeroExtend(8, 256);
+      results[1] = memoryData[1].zeroExtend(8, 256);
       results[2] = operands[0].get<uint64_t>() + metadata.operands[2].mem.disp;
       break;
     }
     case Opcode::AArch64_LDPQi: {  // ldp qt1, qt2, [xn, #imm]
-      results[0] = memoryData[0];
-      results[1] = memoryData[1];
+      results[0] = memoryData[0].zeroExtend(16, 256);
+      results[1] = memoryData[1].zeroExtend(16, 256);
       break;
     }
     case Opcode::AArch64_LDPQpost: {  // ldp qt1, qt2, [xn], #imm
-      results[0] = memoryData[0];
-      results[1] = memoryData[1];
+      results[0] = memoryData[0].zeroExtend(16, 256);
+      results[1] = memoryData[1].zeroExtend(16, 256);
       results[2] = operands[0].get<uint64_t>() + metadata.operands[3].imm;
       break;
     }
     case Opcode::AArch64_LDPQpre: {  // ldp qt1, qt2, [xn, #imm]
-      results[0] = memoryData[0];
-      results[1] = memoryData[1];
+      results[0] = memoryData[0].zeroExtend(16, 256);
+      results[1] = memoryData[1].zeroExtend(16, 256);
       results[2] = operands[0].get<uint64_t>() + metadata.operands[2].mem.disp;
       break;
     }
     case Opcode::AArch64_LDPSi: {  // ldp st1, st2, [xn, #imm]
-      results[0] = memoryData[0].zeroExtend(4, 16);
-      results[1] = memoryData[1].zeroExtend(4, 16);
+      results[0] = memoryData[0].zeroExtend(4, 256);
+      results[1] = memoryData[1].zeroExtend(4, 256);
       break;
     }
     case Opcode::AArch64_LDPWi: {  // ldp wt1, wt2, [xn, #imm]
@@ -3035,25 +2989,25 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDRDpost: {  // ldr dt, [xn], #imm
-      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 16);
+      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 256);
       results[1] = operands[0].get<uint64_t>() + metadata.operands[2].imm;
       break;
     }
     case Opcode::AArch64_LDRDpre: {  // ldr dt, [xn, #imm]!
-      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 16);
+      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 256);
       results[1] = operands[0].get<uint64_t>() + metadata.operands[1].mem.disp;
       break;
     }
     case Opcode::AArch64_LDRDroW: {  // ldr dt, [xn, wm, {extend {#amount}}]
-      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 16);
+      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 256);
       break;
     }
     case Opcode::AArch64_LDRDroX: {  // ldr dt, [xn, xm, {extend {#amount}}]
-      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 16);
+      results[0] = memoryData[0].zeroExtend(memoryAddresses[0].size, 256);
       break;
     }
     case Opcode::AArch64_LDRDui: {  // ldr dt, [xn, #imm]
-      results[0] = memoryData[0].zeroExtend(8, 16);
+      results[0] = memoryData[0].zeroExtend(8, 256);
       break;
     }
     case Opcode::AArch64_LDRHHpost: {  // ldrh wt, [xn], #imm
@@ -3079,16 +3033,16 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDRQpost: {  // ldr qt, [xn], #imm
-      results[0] = memoryData[0];
+      results[0] = memoryData[0].zeroExtend(16, 256);
       results[1] = operands[0].get<uint64_t>() + metadata.operands[2].imm;
       break;
     }
     case Opcode::AArch64_LDRQroX: {  // ldr qt, [xn, xm, {extend {#amount}}]
-      results[0] = memoryData[0];
+      results[0] = memoryData[0].zeroExtend(16, 256);
       break;
     }
     case Opcode::AArch64_LDRQui: {  // ldr qt, [xn, #imm]
-      results[0] = memoryData[0];
+      results[0] = memoryData[0].zeroExtend(16, 256);
       break;
     }
     case Opcode::AArch64_LDRSBWroX: {  // ldrsb wt, [xn, xm{, extend {#amount}}]
@@ -3151,25 +3105,25 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDRSpost: {  // ldr st, [xn], #imm
-      results[0] = memoryData[0].zeroExtend(4, 16);
+      results[0] = memoryData[0].zeroExtend(4, 256);
       results[1] = operands[0].get<uint64_t>() + metadata.operands[2].imm;
       break;
     }
     case Opcode::AArch64_LDRSpre: {  // ldr st, [xn, #imm]!
-      results[0] = memoryData[0].zeroExtend(4, 16);
+      results[0] = memoryData[0].zeroExtend(4, 256);
       results[1] = operands[0].get<uint64_t>() + metadata.operands[1].mem.disp;
       break;
     }
     case Opcode::AArch64_LDRSroW: {  // ldr st, [xn, wm, {extend {#amount}}]
-      results[0] = memoryData[0].zeroExtend(4, 16);
+      results[0] = memoryData[0].zeroExtend(4, 256);
       break;
     }
     case Opcode::AArch64_LDRSroX: {  // ldr st, [xn, xm, {extend {#amount}}]
-      results[0] = memoryData[0].zeroExtend(4, 16);
+      results[0] = memoryData[0].zeroExtend(4, 256);
       break;
     }
     case Opcode::AArch64_LDRSui: {  // ldr st, [xn, #imm]
-      results[0] = memoryData[0].zeroExtend(4, 16);
+      results[0] = memoryData[0].zeroExtend(4, 256);
       break;
     }
     case Opcode::AArch64_LDRSWl: {  // ldrsw xt, #imm
@@ -3261,7 +3215,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDURDi: {  // ldur dt, [xn, #imm]
-      results[0] = memoryData[0].zeroExtend(8, 16);
+      results[0] = memoryData[0].zeroExtend(8, 256);
       break;
     }
     case Opcode::AArch64_LDURHHi: {  // ldurh wt, [xn, #imm]
@@ -3269,7 +3223,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDURQi: {  // ldur qt, [xn, #imm]
-      results[0] = memoryData[0];
+      results[0] = memoryData[0].zeroExtend(16, 256);
       break;
     }
     case Opcode::AArch64_LDURSWi: {  // ldursw xt, [xn, #imm]
@@ -3347,8 +3301,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_MOVID: {  // movi dd, #imm
       uint64_t bits = static_cast<uint64_t>(metadata.operands[1].imm);
-      uint64_t vector[2] = {bits, 0};
-      results[0] = vector;
+      results[0] = {bits, 256};
       break;
     }
     case Opcode::AArch64_MOVIv16b_ns: {  // movi vd.16b, #imm
@@ -3357,21 +3310,21 @@ void Instruction::execute() {
       for (int i = 0; i < 16; i++) {
         vector[i] = bits;
       }
-      results[0] = vector;
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_MOVIv2d_ns: {  // movi vd.2d, #imm
       uint64_t bits = static_cast<uint64_t>(metadata.operands[1].imm);
       uint64_t vector[2] = {bits, bits};
-      results[0] = vector;
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_MOVIv2i32: {  // movi vd.2s, #imm{, lsl #shift}
       uint32_t bits = shiftValue(
           static_cast<uint32_t>(metadata.operands[1].imm),
           metadata.operands[1].shift.type, metadata.operands[1].shift.value);
-      uint32_t vector[4] = {bits, bits, 0, 0};
-      results[0] = vector;
+      uint32_t vector[2] = {bits, bits};
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_MOVIv4i32: {  // movi vd.4s, #imm{, LSL #shift}
@@ -3379,7 +3332,7 @@ void Instruction::execute() {
           static_cast<uint32_t>(metadata.operands[1].imm),
           metadata.operands[1].shift.type, metadata.operands[1].shift.value);
       uint32_t vector[4] = {bits, bits, bits, bits};
-      results[0] = vector;
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_MOVKWi: {  // movk wd, #imm
@@ -3457,16 +3410,16 @@ void Instruction::execute() {
       uint32_t bits = ~shiftValue(
           static_cast<uint32_t>(metadata.operands[1].imm),
           metadata.operands[1].shift.type, metadata.operands[1].shift.value);
-      uint32_t vector[4] = {bits, bits, 0, 0};
-      results[0] = vector;
+      uint32_t vector[2] = {bits, bits};
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_MVNIv4i16: {  // mvni vd.4h, #imm{, lsl #shift}
       uint16_t bits = ~shiftValue(
           static_cast<uint16_t>(metadata.operands[1].imm),
           metadata.operands[1].shift.type, metadata.operands[1].shift.value);
-      uint16_t vector[8] = {bits, bits, bits, bits, 0, 0, 0, 0};
-      results[0] = vector;
+      uint16_t vector[4] = {bits, bits, bits, bits};
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_MVNIv4i32: {  // mvni vd.4s, #imm{, lsl #shift}
@@ -3474,7 +3427,7 @@ void Instruction::execute() {
           static_cast<uint32_t>(metadata.operands[1].imm),
           metadata.operands[1].shift.type, metadata.operands[1].shift.value);
       uint32_t vector[4] = {bits, bits, bits, bits};
-      results[0] = vector;
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_MVNIv8i16: {  // mvni vd.8h, #imm{, lsl #shift}
@@ -3482,7 +3435,7 @@ void Instruction::execute() {
           static_cast<uint16_t>(metadata.operands[1].imm),
           metadata.operands[1].shift.type, metadata.operands[1].shift.value);
       uint16_t vector[8] = {bits, bits, bits, bits, bits, bits, bits, bits};
-      results[0] = vector;
+      results[0] = {vector, 256};
       break;
     }
     case Opcode::AArch64_HINT: {  // nop|yield|wfe|wfi|etc...
@@ -3576,7 +3529,7 @@ void Instruction::execute() {
                              operands[1].getAsVector<uint64_t>()[0],
                          operands[0].getAsVector<uint64_t>()[1] |
                              operands[1].getAsVector<uint64_t>()[1]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_PRFMui: {  // prfm op, [xn, xm{, extend{, #amount}}]
@@ -3747,49 +3700,46 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_SCVTFUWDri: {  // scvtf dd, wn
-      double out[2] = {static_cast<double>(operands[0].get<int32_t>()), 0.0};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<double>(operands[0].get<int32_t>()), 256);
       break;
     }
     case Opcode::AArch64_SCVTFUWSri: {  // scvtf sd, wn
-      int32_t n = operands[0].get<int32_t>();
-      float out[4] = {static_cast<float>(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(operands[0].get<int32_t>()), 256);
       break;
     }
     case Opcode::AArch64_SCVTFUXDri: {  // scvtf dd, xn
-      double out[2] = {static_cast<double>(operands[0].get<int64_t>()), 0.0};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<double>(operands[0].get<int64_t>()), 256);
       break;
     }
     case Opcode::AArch64_SCVTFUXSri: {  // scvtf sd, xn
-      int64_t n = operands[0].get<int64_t>();
-      float out[4] = {static_cast<float>(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(operands[0].get<int64_t>()), 256);
       break;
     }
     case Opcode::AArch64_SCVTFv1i32: {  // scvtf sd, sn
-      int32_t n = operands[0].get<int32_t>();
-      float out[4] = {static_cast<float>(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(operands[0].get<int32_t>()), 256);
       break;
     }
     case Opcode::AArch64_SCVTFv1i64: {  // scvtf dd, dn
-      double out[2] = {static_cast<double>(operands[0].get<int64_t>()), 0.0};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<double>(operands[0].get<int64_t>()), 256);
       break;
     }
     case Opcode::AArch64_SCVTFv2f64: {  // scvtf vd.2d, vn.2d
       const int64_t* n = operands[0].getAsVector<int64_t>();
       double out[2] = {static_cast<double>(n[0]), static_cast<double>(n[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SCVTFv4f32: {  // scvtf vd.4s, vn.4s
       const int32_t* n = operands[0].getAsVector<int32_t>();
       float out[4] = {static_cast<float>(n[0]), static_cast<float>(n[1]),
                       static_cast<float>(n[2]), static_cast<float>(n[3])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SDIVWr: {  // sdiv wd, wn, wm
@@ -3855,8 +3805,7 @@ void Instruction::execute() {
     case Opcode::AArch64_SHLd: {  // shl dd, dn #imm
       const uint64_t n = operands[0].get<uint64_t>();
       int64_t shift = metadata.operands[2].imm;
-      uint64_t out[2] = {static_cast<uint64_t>(n << shift), 0};
-      results[0] = out;
+      results[0] = RegisterValue(static_cast<uint64_t>(n << shift), 256);
       break;
     }
     case Opcode::AArch64_SHLv4i32_shift: {  // shl vd.4s, vn.4s, #imm
@@ -3866,7 +3815,7 @@ void Instruction::execute() {
                          static_cast<uint32_t>(n[1] << shift),
                          static_cast<uint32_t>(n[2] << shift),
                          static_cast<uint32_t>(n[3] << shift)};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SMADDLrrr: {  // smaddl xd, wn, wm, xa
@@ -3903,7 +3852,7 @@ void Instruction::execute() {
       const int32_t* m = operands[1].getAsVector<int32_t>();
       int32_t out[4] = {std::max(n[0], m[0]), std::max(n[1], m[1]),
                         std::max(n[2], m[2]), std::max(n[3], m[3])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SMIN_ZPmZ_S: {  // smin zd.s, pg/m, zn.s, zm.s
@@ -3943,13 +3892,13 @@ void Instruction::execute() {
         }
       }
 
-      results[0] = RegisterValue(out, 16);
+      results[0] = RegisterValue(out, 256);
       break;
     }
     case Opcode::AArch64_SMINVv4i32v: {  // sminv sd, vn.4s
       const int32_t* n = operands[0].getAsVector<int32_t>();
       int32_t out = std::min(std::min(n[0], n[1]), std::min(n[2], n[3]));
-      results[0] = RegisterValue(out, 16);
+      results[0] = RegisterValue(out, 256);
       break;
     }
     case Opcode::AArch64_SMINv4i32: {  // smin vd.4s, vn.4s, vm.4s
@@ -3957,7 +3906,7 @@ void Instruction::execute() {
       const int32_t* m = operands[1].getAsVector<int32_t>();
       int32_t out[4] = {std::min(n[0], m[0]), std::min(n[1], m[1]),
                         std::min(n[2], m[2]), std::min(n[3], m[3])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SMULHrr: {  // smulh xd, xn, xm
@@ -3973,7 +3922,7 @@ void Instruction::execute() {
       int64_t out[2] = {
           static_cast<int64_t>(static_cast<int32_t>(n[0] << shift)),
           static_cast<int64_t>(static_cast<int32_t>(n[1] << shift))};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SSHLLv4i32_shift: {  // sshll2 vd.2d, vn.4s, #imm
@@ -3982,7 +3931,7 @@ void Instruction::execute() {
       int64_t out[2] = {
           static_cast<int64_t>(static_cast<int32_t>(n[2] << shift)),
           static_cast<int64_t>(static_cast<int32_t>(n[3] << shift))};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SSHRv4i32_shift: {  // sshr vd.4s, vn.4s, #imm
@@ -3992,7 +3941,7 @@ void Instruction::execute() {
                         static_cast<int32_t>(std::trunc(n[1] >> shift)),
                         static_cast<int32_t>(std::trunc(n[2] >> shift)),
                         static_cast<int32_t>(std::trunc(n[3] >> shift))};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ST1B: {  // st1b {zt.b}, pg, [xn, xm]
@@ -4476,7 +4425,7 @@ void Instruction::execute() {
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint32_t* m = operands[1].getAsVector<uint32_t>();
       uint32_t out[4] = {n[0] - m[0], n[1] - m[1], n[2] - m[2], n[3] - m[3]};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_SUBSWri: {  // subs wd, wn, #imm
@@ -4735,36 +4684,33 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_UCVTFUWDri: {  // ucvtf dd, wn
-      double out[2] = {static_cast<double>(operands[0].get<uint32_t>()), 0.0};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<double>(operands[0].get<uint32_t>()), 256);
       break;
     }
     case Opcode::AArch64_UCVTFUWSri: {  // ucvtf sd, wn
-      uint32_t n = operands[0].get<uint32_t>();
-      float out[4] = {static_cast<float>(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(operands[0].get<uint32_t>()), 256);
       break;
     }
     case Opcode::AArch64_UCVTFUXDri: {  // ucvtf dd, xn
-      double out[2] = {static_cast<double>(operands[0].get<uint64_t>()), 0.0};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<double>(operands[0].get<uint64_t>()), 256);
       break;
     }
     case Opcode::AArch64_UCVTFUXSri: {  // ucvtf sd, xn
-      uint64_t n = operands[0].get<uint64_t>();
-      float out[4] = {static_cast<float>(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(operands[0].get<uint64_t>()), 256);
       break;
     }
     case Opcode::AArch64_UCVTFv1i32: {  // ucvtf sd, sn
-      uint32_t n = operands[0].get<uint32_t>();
-      float out[4] = {static_cast<float>(n), 0.f, 0.f, 0.f};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<float>(operands[0].get<uint32_t>()), 256);
       break;
     }
     case Opcode::AArch64_UCVTFv1i64: {  // ucvtf dd, dn
-      double out[2] = {static_cast<double>(operands[0].get<uint64_t>()), 0.0};
-      results[0] = out;
+      results[0] =
+          RegisterValue(static_cast<double>(operands[0].get<uint64_t>()), 256);
       break;
     }
     case Opcode::AArch64_UDIVWr: {  // udiv wd, wn, wm
@@ -4829,7 +4775,7 @@ void Instruction::execute() {
                          static_cast<uint16_t>(n[1] << shift), 0,
                          static_cast<uint16_t>(n[2] << shift), 0,
                          static_cast<uint16_t>(n[3] << shift), 0};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_UZP1_ZZZ_S: {  // uzp1 zd.s, zn.s, zm.s
@@ -4950,22 +4896,17 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_XTNv2i32: {  // xtn vd.2s, vn.2d
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      uint32_t out[4] = {static_cast<uint32_t>(n[0]),
-                         static_cast<uint32_t>(n[1]), 0, 0};
-      results[0] = out;
+      uint32_t out[2] = {static_cast<uint32_t>(n[0]),
+                         static_cast<uint32_t>(n[1])};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_XTNv4i16: {  // xtn vd.4h, vn.4s
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
-      uint16_t out[8] = {static_cast<uint16_t>(n[0]),
-                         static_cast<uint16_t>(n[1]),
-                         static_cast<uint16_t>(n[2]),
-                         static_cast<uint16_t>(n[3]),
-                         0,
-                         0,
-                         0,
-                         0};
-      results[0] = out;
+      uint16_t out[4] = {
+          static_cast<uint16_t>(n[0]), static_cast<uint16_t>(n[1]),
+          static_cast<uint16_t>(n[2]), static_cast<uint16_t>(n[3])};
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_XTNv4i32: {  // xtn2 vd.4s, vn.2d
@@ -4973,7 +4914,7 @@ void Instruction::execute() {
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       uint32_t out[4] = {d[0], d[1], static_cast<uint32_t>(n[0]),
                          static_cast<uint32_t>(n[1])};
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ZIP1_ZZZ_D: {  // zip1 zd.d, zn.d, zm.d
@@ -5027,14 +4968,19 @@ void Instruction::execute() {
     default:
       return executionNYI();
   }
-  // Zero-out upper bits of vector registers because Z configuration
+
+#ifndef NDEBUG
+  // Check if upper bits of vector registers are zeroed because Z configuration
   // extend to 256 bytes whilst V configurations only extend to 16 bytes.
   // Thus upper 240 bytes must be ignored by being set to 0.
   for (int i = 0; i < destinationRegisterCount; i++) {
     if ((destinationRegisters[i].type == RegisterType::VECTOR) && !isSVEData_) {
-      results[i] = results[i].zeroExtend(16, 256);
+      if (results[i].size() != 256)
+        std::cerr << metadata.mnemonic << " opcode: " << metadata.opcode
+                  << " has not been zero extended correctly\n";
     }
   }
+#endif
 }
 
 }  // namespace aarch64

--- a/src/lib/kernel/Linux.cc
+++ b/src/lib/kernel/Linux.cc
@@ -363,7 +363,7 @@ int64_t Linux::openat(int64_t dirfd, const std::string& pathname, int64_t flags,
   return vfd;
 }
 
-int64_t Linux::readlinkat(int64_t dirfd, const std::string pathname, char* buf,
+int64_t Linux::readlinkat(int64_t dirfd, const std::string& pathname, char* buf,
                           size_t bufsize) const {
   const auto& processState = processStates_[0];
   if (pathname == "/proc/self/exe") {

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -19,7 +19,7 @@ Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
            uint64_t processMemorySize, uint64_t entryPoint,
            const arch::Architecture& isa, BranchPredictor& branchPredictor,
            pipeline::PortAllocator& portAllocator,
-           std::vector<std::pair<uint8_t, uint64_t>> rsArrangement,
+           const std::vector<std::pair<uint8_t, uint64_t>>& rsArrangement,
            YAML::Node config)
     : isa_(isa),
       physicalRegisterStructures_(

--- a/src/lib/pipeline/A64FXPortAllocator.cc
+++ b/src/lib/pipeline/A64FXPortAllocator.cc
@@ -8,10 +8,9 @@ namespace simeng {
 namespace pipeline {
 
 A64FXPortAllocator::A64FXPortAllocator(
-    std::vector<std::vector<uint16_t>> portArrangement) {
-  // Initiliase reservation station to port mapping
-  rsToPort_ = {{0, 1, 2}, {3, 4}, {5}, {6}, {7}};
-}
+    const std::vector<std::vector<uint16_t>>& portArrangement)
+    :  // Initiliase reservation station to port mapping
+      rsToPort_({{0, 1, 2}, {3, 4}, {5}, {6}, {7}}) {}
 
 uint8_t A64FXPortAllocator::allocate(std::vector<uint8_t> ports) {
   assert(ports.size() &&
@@ -148,7 +147,8 @@ uint8_t A64FXPortAllocator::allocate(std::vector<uint8_t> ports) {
 void A64FXPortAllocator::issued(uint8_t port) {}
 void A64FXPortAllocator::deallocate(uint8_t port) { issued(port); };
 
-uint8_t A64FXPortAllocator::attributeMapping(std::vector<uint8_t> ports) {
+uint8_t A64FXPortAllocator::attributeMapping(
+    const std::vector<uint8_t>& ports) {
   uint8_t attribute = 0;
   bool foundAttribute = false;
   if (ports == std::vector<uint8_t>({2, 4, 5, 6})) {  // EXA,EXB,EAGA,EAGB

--- a/src/lib/pipeline/A64FXPortAllocator.cc
+++ b/src/lib/pipeline/A64FXPortAllocator.cc
@@ -12,7 +12,7 @@ A64FXPortAllocator::A64FXPortAllocator(
     :  // Initiliase reservation station to port mapping
       rsToPort_({{0, 1, 2}, {3, 4}, {5}, {6}, {7}}) {}
 
-uint8_t A64FXPortAllocator::allocate(std::vector<uint8_t> ports) {
+uint8_t A64FXPortAllocator::allocate(const std::vector<uint8_t>& ports) {
   assert(ports.size() &&
          "No supported ports supplied; cannot allocate from a empty set");
   const uint8_t attribute = attributeMapping(ports);

--- a/src/lib/pipeline/A64FXPortAllocator.cc
+++ b/src/lib/pipeline/A64FXPortAllocator.cc
@@ -151,26 +151,22 @@ uint8_t A64FXPortAllocator::attributeMapping(
     const std::vector<uint8_t>& ports) {
   uint8_t attribute = 0;
   bool foundAttribute = false;
-  if (ports == std::vector<uint8_t>({2, 4, 5, 6})) {  // EXA,EXB,EAGA,EAGB
+  if (ports == EXA_EXB_EAGA_EAGB) {  // EXA,EXB,EAGA,EAGB
     attribute = InstructionAttribute::RSX;
     foundAttribute = true;
-  } else if (ports == std::vector<uint8_t>({2, 4}) ||
-             ports == std::vector<uint8_t>({0, 3})) {  // EXA,EXB|FLA,FLB
+  } else if (ports == EXA_EXB || ports == FLA_FLB) {  // EXA,EXB|FLA,FLB
     attribute = InstructionAttribute::RSE;
     foundAttribute = true;
-  } else if (ports == std::vector<uint8_t>({5, 6})) {  // EAGA,EAGB
+  } else if (ports == EAGA_EAGB) {  // EAGA,EAGB
     attribute = InstructionAttribute::RSA;
     foundAttribute = true;
-  } else if (ports == std::vector<uint8_t>({0}) ||
-             ports == std::vector<uint8_t>({1}) ||
-             ports == std::vector<uint8_t>({2})) {  // EXA|FLA|PR
+  } else if (ports == EXA || ports == FLA || ports == PR) {  // EXA|FLA|PR
     attribute = InstructionAttribute::RSE0;
     foundAttribute = true;
-  } else if (ports == std::vector<uint8_t>({3}) ||
-             ports == std::vector<uint8_t>({4})) {  // EXB|FLB
+  } else if (ports == EXB || ports == FLB) {  // EXB|FLB
     attribute = InstructionAttribute::RSE1;
     foundAttribute = true;
-  } else if (ports == std::vector<uint8_t>({7})) {  // BR
+  } else if (ports == BR) {  // BR
     attribute = InstructionAttribute::BR;
     foundAttribute = true;
   }

--- a/src/lib/pipeline/BalancedPortAllocator.cc
+++ b/src/lib/pipeline/BalancedPortAllocator.cc
@@ -9,7 +9,7 @@ BalancedPortAllocator::BalancedPortAllocator(
     const std::vector<std::vector<uint16_t>>& portArrangement)
     : weights(portArrangement.size(), 0) {}
 
-uint8_t BalancedPortAllocator::allocate(std::vector<uint8_t> ports) {
+uint8_t BalancedPortAllocator::allocate(const std::vector<uint8_t>& ports) {
   assert(ports.size() &&
          "No supported ports supplied; cannot allocate from a empty set");
   bool foundPort = false;

--- a/src/lib/pipeline/BalancedPortAllocator.cc
+++ b/src/lib/pipeline/BalancedPortAllocator.cc
@@ -6,7 +6,7 @@ namespace simeng {
 namespace pipeline {
 
 BalancedPortAllocator::BalancedPortAllocator(
-    std::vector<std::vector<uint16_t>> portArrangement)
+    const std::vector<std::vector<uint16_t>>& portArrangement)
     : weights(portArrangement.size(), 0) {}
 
 uint8_t BalancedPortAllocator::allocate(std::vector<uint8_t> ports) {

--- a/src/lib/pipeline/DispatchIssueUnit.cc
+++ b/src/lib/pipeline/DispatchIssueUnit.cc
@@ -57,7 +57,7 @@ void DispatchIssueUnit::tick() {
       continue;
     }
 
-    std::vector<uint8_t> supportedPorts = uop->getSupportedPorts();
+    const std::vector<uint8_t>& supportedPorts = uop->getSupportedPorts();
     if (uop->exceptionEncountered()) {
       // Exception; mark as ready to commit, and remove from pipeline
       uop->setCommitReady();

--- a/src/lib/pipeline/DispatchIssueUnit.cc
+++ b/src/lib/pipeline/DispatchIssueUnit.cc
@@ -155,7 +155,7 @@ void DispatchIssueUnit::issue() {
   }
 
   if (issued == 0) {
-    for (auto rs : reservationStations_) {
+    for (const auto& rs : reservationStations_) {
       if (rs.currentSize != 0) {
         backendStalls_++;
         return;

--- a/src/lib/pipeline/DispatchIssueUnit.cc
+++ b/src/lib/pipeline/DispatchIssueUnit.cc
@@ -1,5 +1,6 @@
 #include "simeng/pipeline/DispatchIssueUnit.hh"
 
+#include <algorithm>
 #include <unordered_set>
 
 namespace simeng {
@@ -44,13 +45,15 @@ DispatchIssueUnit::DispatchIssueUnit(
     reservationStations_[RS.first].ports.resize(port_index + 1);
     reservationStations_[RS.first].ports[port_index].issuePort = port;
   }
-};
+  dispatches.resize(reservationStations_.size());
+}
 
 void DispatchIssueUnit::tick() {
-  // Maintain record of dispatch amounts made
-  std::vector<uint8_t> dispatches(reservationStations_.size(), 0);
-
   input_.stall(false);
+
+  // Reset the counters
+  std::fill(dispatches.begin(), dispatches.end(), 0);
+
   for (size_t slot = 0; slot < input_.getWidth(); slot++) {
     auto& uop = input_.getHeadSlots()[slot];
     if (uop == nullptr) {

--- a/src/lib/pipeline/ExecuteUnit.cc
+++ b/src/lib/pipeline/ExecuteUnit.cc
@@ -13,7 +13,7 @@ ExecuteUnit::ExecuteUnit(
     std::function<void(const std::shared_ptr<Instruction>&)> handleStore,
     std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
     BranchPredictor& predictor, bool pipelined,
-    std::vector<uint16_t> blockingGroups)
+    const std::vector<uint16_t>& blockingGroups)
     : input_(input),
       output_(output),
       forwardOperands_(forwardOperands),

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -1,5 +1,6 @@
 #include "simeng/pipeline/LoadStoreQueue.hh"
 
+#include <array>
 #include <cassert>
 #include <cstring>
 
@@ -217,7 +218,7 @@ void LoadStoreQueue::tick() {
   // Send memory requests adhering to set bandwidth and number of permitted
   // requests per cycle
   uint64_t dataTransfered = 0;
-  std::vector<uint8_t> reqCounts = {0, 0};
+  std::array<uint8_t, 2> reqCounts = {0, 0};
   while (requestQueue_.size() > 0) {
     uint8_t isWrite = 0;
     auto& entry = requestQueue_.front();
@@ -234,7 +235,7 @@ void LoadStoreQueue::tick() {
       if (dataTransfered >= L1Bandwidth_) {
         break;
       }
-      for (int i = 0; i < entry.reqAddresses.size(); i++) {
+      for (size_t i = 0; i < entry.reqAddresses.size(); i++) {
         const MemoryAccessTarget req = entry.reqAddresses[i];
         dataTransfered += req.size;
         if (!isWrite) {

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -25,10 +25,9 @@ LoadStoreQueue::LoadStoreQueue(
       combined_(true),
       memory_(memory),
       L1Bandwidth_(L1Bandwidth),
-      totalLimit_(permittedRequests) {
-  // Set per-cycle limits for each request type
-  reqLimits_ = {permittedLoads, permittedStores};
-};
+      totalLimit_(permittedRequests),
+      // Set per-cycle limits for each request type
+      reqLimits_{permittedLoads, permittedStores} {};
 
 LoadStoreQueue::LoadStoreQueue(
     unsigned int maxLoadQueueSpace, unsigned int maxStoreQueueSpace,
@@ -44,10 +43,9 @@ LoadStoreQueue::LoadStoreQueue(
       combined_(false),
       memory_(memory),
       L1Bandwidth_(L1Bandwidth),
-      totalLimit_(permittedRequests) {
-  // Set per-cycle limits for each request type
-  reqLimits_ = {permittedLoads, permittedStores};
-};
+      totalLimit_(permittedRequests),
+      // Set per-cycle limits for each request type
+      reqLimits_{permittedLoads, permittedStores} {};
 
 unsigned int LoadStoreQueue::getLoadQueueSpace() const {
   if (combined_) {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SOURCES
     BTBPredictorTest.cc
     ISATest.cc
     RegisterValueTest.cc
+    PoolTest.cc
     LatencyMemoryInterfaceTest.cc
     )
 

--- a/test/unit/MockBranchPredictor.hh
+++ b/test/unit/MockBranchPredictor.hh
@@ -8,8 +8,8 @@ namespace simeng {
 /** Mock implementation of the `BranchPredictor` interface. */
 class MockBranchPredictor : public BranchPredictor {
  public:
-  MOCK_METHOD1(predict, BranchPrediction(std::shared_ptr<Instruction> uop));
-  MOCK_METHOD3(update, void(std::shared_ptr<Instruction> uop, bool taken,
+  MOCK_METHOD1(predict, BranchPrediction(std::shared_ptr<Instruction>& uop));
+  MOCK_METHOD3(update, void(std::shared_ptr<Instruction>& uop, bool taken,
                             uint64_t targetAddress));
 };
 

--- a/test/unit/MockInstruction.hh
+++ b/test/unit/MockInstruction.hh
@@ -37,7 +37,7 @@ class MockInstruction : public Instruction {
   MOCK_CONST_METHOD0(getGroup, uint16_t());
 
   MOCK_METHOD1(setSupportedPorts, void(std::vector<uint8_t>));
-  MOCK_METHOD0(getSupportedPorts, std::vector<uint8_t>());
+  MOCK_METHOD0(getSupportedPorts, const std::vector<uint8_t>&());
 
   void setBranchResults(bool wasTaken, uint64_t targetAddress) {
     branchTaken_ = wasTaken;

--- a/test/unit/PoolTest.cc
+++ b/test/unit/PoolTest.cc
@@ -1,0 +1,62 @@
+#include <random>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "simeng/Pool.hh"
+
+namespace {
+
+// Tests that memory is reused correctly
+TEST(FixedPoolTest, MemoryReused) {
+  auto p = simeng::fixedPool_<10, 2>();
+  void* ptr = p.allocate();
+  void* ptr2 = p.allocate();
+  // The pool will grow by 4. Total size is 6.
+  void* ptr3 = p.allocate();
+
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_NE(ptr2, nullptr);
+  ASSERT_NE(ptr3, nullptr);
+
+  p.deallocate(ptr);
+  p.deallocate(ptr2);
+  p.deallocate(ptr3);
+
+  void* ptr4 = p.allocate();
+  void* ptr5 = p.allocate();
+  void* ptr6 = p.allocate();
+
+  EXPECT_EQ(ptr3, ptr4);
+  EXPECT_EQ(ptr5, ptr2);
+  EXPECT_EQ(ptr6, ptr);
+}
+
+// Tests that the pointer returned by allocate is sufficiently aligned
+TEST(FixedPoolTest, Alignment) {
+  auto p = simeng::fixedPool_<25>();
+  uintptr_t ptr = reinterpret_cast<uintptr_t>(p.allocate());
+
+  EXPECT_EQ(ptr & (alignof(std::max_align_t) - 1), 0);
+}
+
+// Tests general usage works correctly. To be tested with sanitizers
+TEST(FixedPoolTest, GeneralUsage) {
+  std::mt19937 gen;
+  std::uniform_int_distribution<> distribution(0, 1);
+
+  auto p = simeng::fixedPool_<10>();
+  for (size_t i = 0; i < 65535; i++) {
+    void* ptr = p.allocate();
+
+    // Allocation was successful.
+    ASSERT_NE(ptr, nullptr);
+
+    // Test that we can access all the bytes.
+    memset(ptr, 0, 10);
+
+    // Randomly deallocate to simulate real usage.
+    if (distribution(gen)) p.deallocate(ptr);
+  }
+}
+
+}  // namespace

--- a/test/unit/RegisterValueTest.cc
+++ b/test/unit/RegisterValueTest.cc
@@ -52,4 +52,14 @@ TEST(RegisterValueTest, ZeroExtend) {
   EXPECT_EQ(extended.get<uint64_t>(), 1);
 }
 
+TEST(RegisterValueTest, Array) {
+  uint64_t arr[] = {0, 0xffffffffffffffff};
+  simeng::RegisterValue z_reg = {arr, 256};
+  EXPECT_EQ(z_reg.size(), 256);
+  auto ptr = z_reg.getAsVector<uint64_t>();
+  EXPECT_EQ(ptr[0], 0);
+  EXPECT_EQ(ptr[1], 0xffffffffffffffff);
+  EXPECT_EQ(ptr[2], 0);
+  EXPECT_EQ(ptr[3], 0);
+}
 }  // namespace


### PR DESCRIPTION
The main theme of this pull request is optimizing memory allocations/deallocations. It was found while profiling that on average, 10-20 memory allocations/deallocations would occur per cycle. By reducing the no. of allocations, I hope to reduce cycle time.

New language features and smaller changes were preferred over big structural changes to improve performance.

* 6bf6aad3 ... 5410557e primarily change function parameters to accept const references. This allows them to accept both lvalue and rvalue references; avoiding a copy.

*  member initializer list were also added/improved wherever possible. This change avoids having to a call the constructor of a member twice.

>Several of these changes were suggested by the static analyzer `CppCheck`.

* b0c1773b uses a new C++17 method `try_emplace` to construct an element in place avoiding a copy. It also has better syntax to pass constructor arguments compared to pre C++17 methods that require `std::piecewise_construct`.

* 16f27587 changes `getSupportedPorts` to return a reference to a vector. The `aarch64::Instruction` class has a member vector that stores the ports, and it is alive for as long as the instruction instance is, hence we return a reference to it to avoid copying.

* a0aebb11 adds a new CMake flag `SIMENG_OPTIMIZE`. This flag turns on Link-Time Optimizations allowing the compiler to optimize across translation units. Additionally, on x86 systems, it sets the `-march` and `-mtune` compiler flags.

* 856dc967 overloads `setMemoryAddresses` to accept rvalue references. This overload can reuse the resources of its parameter. The vectors created in `Instruction::generateAddresses` are deleted at the end of function. This presents an opportunity to reuse resources.

* bea1f887 creates a new member `flushed_` to avoid allocating a map every flush. The sets are still allocated/deallocated every flush, perhaps using a stack allocator here could be beneficial.

* f4a1dbb4 and ac830725 adds a second parameter `capacity` to the `RegisterValue` ctor that takes an array as a reference. In aarch64, FP, SVE and NEON instructions use the same register bank of 256 byte registers. The updated ctor makes it easier to create `RegisterValue` of the correct size. 

    `Instruction::execute` was updated to use the new ctor. This avoids data copying and an extra ctor call at the end of the function when zero extending.

>The `RegisterValue` class along with `Instruction` class are a major source of memory allocations. The next few commits focus on reducing it.

* b40fde09 experiments with using C++17's new `std::unsynchronized_pool_resource`. It is a general-purpose, non thread-safe memory pool implementation. However, it was abandoned as it was not implemented in LLVM/Clang. 

* a0684490 experiments with using raw pointers instead of shared_ptr. This required implementing copy and move constructors. This change resulted in a performance regression and was reverted.

* ee4ec4dd and cbd0d39e implement a simple memory pool implementation that is based on a free list. Each node of the free list is stored in the free chunks of memory. The memory pool grows by a factor of 2 when exhausted.

* ce708b07 changes the `predict` and `update` functions in `BranchPredictor` to accept a reference to shared_ptr. This is to avoid the cost of atomic increment/decrement. The lifetime of the ptr is expected to out last `predict` and `update`, hence it is safe.