### PR TITLE
Bug fixes

### DIFF
--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -151,7 +151,10 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
          "Fewer than 4 bytes supplied to AArch64 decoder");
 
   // Dereference the instruction pointer to obtain the instruction word
-  const uint32_t insn = *static_cast<const uint32_t*>(ptr);
+  // `ptr` is not guaranteed to be aligned.
+  uint32_t insn;
+  memcpy(&insn, ptr, 4);
+  const uint8_t* encoding = reinterpret_cast<const uint8_t*>(ptr);
 
   // Try to find the decoding in the decode cache
   auto iter = decodeCache.find(insn);

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -362,10 +362,12 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       break;
     case Opcode::AArch64_RET:
       // RET doesn't list use of x30 (LR) if no register is supplied
-      operandCount = 1;
-      operands[0].type = ARM64_OP_REG;
-      operands[0].reg = ARM64_REG_LR;
-      operands[0].access = CS_AC_READ;
+      if (operandCount == 0) {
+        operandCount = 1;
+        operands[0].type = ARM64_OP_REG;
+        operands[0].reg = ARM64_REG_LR;
+        operands[0].access = CS_AC_READ;
+      }
       groupCount = 1;
       groups[0] = CS_GRP_JUMP;
       break;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -31,8 +31,11 @@ std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>, T> shiftValue(
     case ARM64_SFT_ASR:
       return static_cast<std::make_signed_t<T>>(value) >> amount;
     case ARM64_SFT_ROR: {
-      auto highestBit = sizeof(T) * 8;
-      return (value >> amount) & (value << (highestBit - amount));
+      // Assuming sizeof(T) is a power of 2.
+      const auto mask = sizeof(T) * 8 - 1;
+      assert((amount <= mask) && "Rotate amount exceeds type width");
+      amount &= mask;
+      return (value >> amount) | (value << ((-amount) & mask));
     }
     case ARM64_SFT_INVALID:
       return value;

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -70,17 +70,14 @@ void FetchUnit::tick() {
     assert(fetched[fetchIndex].data && "Memory read failed");
     const uint8_t* fetchData = fetched[fetchIndex].data.getAsVector<uint8_t>();
 
-    if (bufferedBytes_ > 0) {
-      // Copy fetched data to fetch buffer after existing data
-      std::memcpy(fetchBuffer_ + bufferedBytes_, fetchData + bufferOffset,
-                  blockSize_ - bufferOffset);
-      bufferedBytes_ += blockSize_ - bufferOffset;
-      buffer = fetchBuffer_;
-    } else {
-      // Use the incoming fetch data directly to avoid a copy
-      buffer = fetchData;
-      bufferedBytes_ = blockSize_ - bufferOffset;
-    }
+    // Copy fetched data to fetch buffer after existing data
+    std::memcpy(fetchBuffer_ + bufferedBytes_, fetchData + bufferOffset,
+                blockSize_ - bufferOffset);
+
+    bufferedBytes_ += blockSize_ - bufferOffset;
+    buffer = fetchBuffer_;
+    // Decoding should start from the beginning of the fetchBuffer_.
+    bufferOffset = 0;
   } else {
     // There is already enough data in the fetch buffer, so use that
     buffer = fetchBuffer_;

--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -79,7 +79,11 @@ void ReorderBuffer::flush(uint64_t afterSeqId) {
       break;
     }
 
-    for (const auto& reg : uop->getDestinationRegisters()) {
+    // To rewind destination registers in correct history order, rewinding of
+    // register renaming is done backwards
+    auto destinations = uop->getDestinationRegisters();
+    for (int i = destinations.size() - 1; i >= 0; i--) {
+      const auto& reg = destinations[i];
       rat_.rewind(reg);
     }
     uop->setFlushed();

--- a/test/regression/aarch64/instructions/misc.cc
+++ b/test/regression/aarch64/instructions/misc.cc
@@ -15,6 +15,36 @@ TEST_P(InstMisc, adr) {
   EXPECT_EQ(getGeneralRegister<uint32_t>(2), 4u);
 }
 
+TEST_P(InstMisc, ret) {
+  RUN_AARCH64(R"(
+    bl #20
+    b.al #28
+    nop
+    add w2, w2, #1
+    nop
+    add w1, w1, #1
+    ret
+    nop
+  )");
+  EXPECT_EQ(getGeneralRegister<uint32_t>(1), 1);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 0);
+
+  RUN_AARCH64(R"(
+    mov x15, #36
+    bl #20
+    add w2, w2, #1
+    nop
+    nop
+    nop
+    add w1, w1, #1
+    ret x15
+    add w2, w2, #1
+    nop
+  )");
+  EXPECT_EQ(getGeneralRegister<uint32_t>(1), 1);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 0);
+}
+
 INSTANTIATE_TEST_SUITE_P(AArch64, InstMisc, ::testing::Values(EMULATION),
                          coreTypeToString);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_SOURCES
     ISATest.cc
     RegisterValueTest.cc
     PoolTest.cc
+    ShiftValueTest.cc
     LatencyMemoryInterfaceTest.cc
     )
 

--- a/test/unit/ShiftValueTest.cc
+++ b/test/unit/ShiftValueTest.cc
@@ -1,0 +1,41 @@
+#include "gtest/gtest.h"
+
+namespace simeng::arch::aarch64 {
+
+// Forward declaration of ShiftValue function.
+template <typename T>
+std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>, T> shiftValue(
+    T value, uint8_t shiftType, uint8_t amount);
+
+}  // namespace simeng::arch::aarch64
+
+namespace {
+
+TEST(ShiftValueTest, ROR) {
+  const auto ARM64_SFT_ROR = 5;
+
+  // 32-bit
+  const uint32_t a = 0x0000FFFF;
+  EXPECT_EQ(simeng::arch::aarch64::shiftValue(a, ARM64_SFT_ROR, 16),
+            0xFFFF0000);
+
+  const uint32_t b = 0xFFFF0000;
+  EXPECT_EQ(simeng::arch::aarch64::shiftValue(b, ARM64_SFT_ROR, 31),
+            0xFFFE0001);
+
+  EXPECT_EQ(simeng::arch::aarch64::shiftValue(b, ARM64_SFT_ROR, 0), 0xFFFF0000);
+
+  // 64-bit
+  const uint64_t c = 0x00000000FFFFFFFF;
+  EXPECT_EQ(simeng::arch::aarch64::shiftValue(c, ARM64_SFT_ROR, 32),
+            0xFFFFFFFF00000000);
+
+  const uint64_t d = 0xFFFFFFFF00000000;
+  EXPECT_EQ(simeng::arch::aarch64::shiftValue(d, ARM64_SFT_ROR, 63),
+            0xFFFFFFFE00000001);
+
+  EXPECT_EQ(simeng::arch::aarch64::shiftValue(d, ARM64_SFT_ROR, 0),
+            0xFFFFFFFF00000000);
+}
+
+}  // namespace


### PR DESCRIPTION
When SimEng flushes an instruction that sets multiple destinations as same register, the rewinding of register renaming fails. This is because the order of applying rewinding by `historyTable_` is in the wrong way.

Ultimately, it keeps the wrong physical register (which was freed) in `mappingTable_`. Therefore, the order of calling `rewind()` was reversed to have the correct order of updating `mappingTable_`  with `historyTable_`.

In `FetchUnit::tick`, If the `pc_` was not aligned to the blockSize boundary and the `fetchBuffer_` was empty, the `fetchData` would not be copied but used directly as an optimization. However, if the `fetchData` was not enough to start decoding right away, the function would exit and the `fetchData` would be lost.  To fix the bug, the optimization was removed and `fetchData` is always copied onto the `fetchBuffer_`. There was no observed performance difference.

Additionally, the pointer to the buffer passed to `predecode` is not guaranteed to be aligned. This caused misalignment bugs as `aarch64::predecode` was expecting it to be 4 byte aligned. A workaround proposed by @FinnWilkinson fixed the bug by copying the buffer into a local variable.

The `ROR` implementation was found to be buggy, hence a modified version using modular arithmetic was implemented.