### PR TITLE
Fix frsqrte behaviour (and minor changes)

### DIFF
--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -711,11 +711,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_ST1Twov16b: {  // st1v {vt.16b, vt2.16b}, [xn]
       const uint64_t base = operands[2].get<uint64_t>();
-      std::vector<MemoryAccessTarget> addresses;
-      for (int i = 0; i < 32; i++) {
-        addresses.push_back({base + i, 1});
-      }
-      setMemoryAddresses(addresses);
+      setMemoryAddresses({{base, 16}, {base + 16, 16}});
       break;
     }
     case Opcode::AArch64_ST1i8_POST:

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -4092,14 +4092,8 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_ST1Twov16b: {  // st1v {vt.16b, vt2.16b}, [xn]
-      const uint8_t* t = operands[0].getAsVector<uint8_t>();
-      const uint8_t* t2 = operands[1].getAsVector<uint8_t>();
-      for (int i = 0; i < 16; i++) {
-        memoryData[i] = t[i];
-      }
-      for (int i = 0; i < 16; i++) {
-        memoryData[i + 16] = t2[i];
-      }
+      memoryData[0] = operands[0];
+      memoryData[1] = operands[1];
       break;
     }
     case Opcode::AArch64_ST1i8: {  // st1 {vt.b}[index], [xn]
@@ -4167,8 +4161,8 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_ST2Twov4s_POST: {  // st2 {vt1.4s, vt2.4s}, [xn], #imm
-      const float* t1 = operands[0].getAsVector<float>();
-      const float* t2 = operands[1].getAsVector<float>();
+      const uint32_t* t1 = operands[0].getAsVector<uint32_t>();
+      const uint32_t* t2 = operands[1].getAsVector<uint32_t>();
       for (int i = 0; i < 4; i++) {
         memoryData[2 * i] = t1[i];
         memoryData[2 * i + 1] = t2[i];

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -1,5 +1,4 @@
 #include <cmath>
-#include <iostream>
 #include <limits>
 #include <tuple>
 

--- a/test/regression/aarch64/instructions/float.cc
+++ b/test/regression/aarch64/instructions/float.cc
@@ -1050,109 +1050,195 @@ TEST_P(InstFloat, frsqrte) {
   // single precision
   RUN_AARCH64(R"(
     fmov s0, 2.0
-    fmov s1, -0.125
-    fmov s6, 0.25
-    fmov s8, 0.375
+    fmov s1, 0.375
+    fmov s2, 0.25
+    fmov s3, -0.125
 
-    frsqrte s3, s0
-    frsqrte s4, s1
-    frsqrte s5, s2
-    frsqrte s7, s6
-    frsqrte s9, s8
+    # subnormals
+    mov w0, #0x00000002
+    mov w1, #0x00000100
+    mov w2, #0x00000001
+    mov v10.s[0], w0
+    mov v11.s[0], w1
+    mov v12.s[0], w2
+
+    frsqrte s5, s0
+    frsqrte s6, s1
+    frsqrte s7, s2
+    frsqrte s8, s3
+    frsqrte s9, s4
+    frsqrte s13, s10
+    frsqrte s14, s11
+    frsqrte s15, s12
   )");
-  CHECK_NEON(3, float, {0.705078125f, 0.f, 0.f, 0.f});  // vale from xci
-  CHECK_NEON(7, float, {1.99609375f, 0.f, 0.f, 0.f});   // value from xci
-  CHECK_NEON(9, float, {1.6328125f, 0.f, 0.f, 0.f});    // value from xci
+  CHECK_NEON(5, float, {0.705078125f, 0.f, 0.f, 0.f});  // value from hardware
+  CHECK_NEON(6, float, {1.6328125f, 0.f, 0.f, 0.f});    // value from hardware
+  CHECK_NEON(7, float, {1.99609375f, 0.f, 0.f, 0.f});   // value from hardware
 
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 0>(4)));
-  EXPECT_EQ((getVectorRegisterElement<float, 1>(4)), 0.f);
-  EXPECT_EQ((getVectorRegisterElement<float, 2>(4)), 0.f);
-  EXPECT_EQ((getVectorRegisterElement<float, 3>(4)), 0.f);
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 0>(8)));
+  EXPECT_EQ((getVectorRegisterElement<float, 1>(3)), 0.f);
+  EXPECT_EQ((getVectorRegisterElement<float, 2>(3)), 0.f);
+  EXPECT_EQ((getVectorRegisterElement<float, 3>(3)), 0.f);
 
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 0>(5)));
-  EXPECT_EQ((getVectorRegisterElement<float, 1>(5)), 0.f);
-  EXPECT_EQ((getVectorRegisterElement<float, 2>(5)), 0.f);
-  EXPECT_EQ((getVectorRegisterElement<float, 3>(5)), 0.f);
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 0>(9)));
+  EXPECT_EQ((getVectorRegisterElement<float, 1>(9)), 0.f);
+  EXPECT_EQ((getVectorRegisterElement<float, 2>(9)), 0.f);
+  EXPECT_EQ((getVectorRegisterElement<float, 3>(9)), 0.f);
+  // value from hardware
+  CHECK_NEON(13, uint32_t, {0x647f8000, 0, 0, 0});
+  CHECK_NEON(14, uint32_t, {0x62b48000, 0, 0, 0});
+  CHECK_NEON(15, uint32_t, {0x64b48000, 0, 0, 0});
 
   // double precision
   RUN_AARCH64(R"(
-    fmov d1, 2.0
-    fmov d2, -0.125
-    fmov d4, 0.0
-    frsqrte d0, d1
-    frsqrte d3, d2
-    frsqrte d5, d4
+    fmov d0, #0.1953125
+    fmov d1, #3.875
+    fmov d2, #0.875
+    fmov d3, #1.9375
+    fmov d4, #-0.5
+
+    # subnormals
+    mov x0, #0x0000000000000001
+    mov x1, #0x0000000000001000
+    mov v12.d[0], x0
+    mov v13.d[0], x1
+
+    frsqrte d6, d0
+    frsqrte d7, d1
+    frsqrte d8, d2
+    frsqrte d9, d3
+    frsqrte d10, d4
+    frsqrte d11, d5 
+    frsqrte d14, d12
+    frsqrte d15, d13
   )");
-  CHECK_NEON(0, double, {1.0 / sqrt(2.0), 0.0});
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<double, 0>(3)));
-  EXPECT_EQ((getVectorRegisterElement<double, 1>(3)), 0.0);
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<double, 0>(5)));
-  EXPECT_EQ((getVectorRegisterElement<double, 1>(5)), 0.0);
+  CHECK_NEON(6, double, {2.2578125, 0.0});    // value from hardware
+  CHECK_NEON(7, double, {0.5078125, 0.0});    // value from hardware
+  CHECK_NEON(8, double, {1.06640625, 0.0});   // value from hardware
+  CHECK_NEON(9, double, {0.716796875, 0.0});  // value from hardware
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<double, 0>(10)));
+  EXPECT_EQ((getVectorRegisterElement<double, 1>(10)), 0.0);
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<double, 0>(11)));
+  EXPECT_EQ((getVectorRegisterElement<double, 1>(11)), 0.0);
+  // value from hardware
+  CHECK_NEON(14, uint64_t, {0x617ff00000000000, 0});
+  CHECK_NEON(15, uint64_t, {0x611ff00000000000, 0});
 
   // Vector single precision
   RUN_AARCH64(R"(
     fmov v0.4s, 2.0
-    fmov v1.4s, -0.125
+    fmov v1.4s, 0.375
+    fmov v2.4s, 0.25
+    fmov v3.4s, -0.125
 
-    frsqrte v4.4s, v0.4s
-    frsqrte v5.4s, v1.4s
-    frsqrte v6.4s, v2.4s
+    # subnormals
+    mov w0, #0x00000002
+    mov w1, #0x00000100
+    mov w2, #0x00000001
+    mov v10.s[0], w0
+    mov v10.s[1], w1
+    mov v10.s[2], w2
+
+    frsqrte v5.4s, v0.4s
+    frsqrte v6.4s, v1.4s
+    frsqrte v7.4s, v2.4s
+    frsqrte v8.4s, v3.4s
+    frsqrte v9.4s, v4.4s
+    frsqrte v11.4s, v10.4s 
   )");
-  CHECK_NEON(4, float,
-             {
-                 1.f / sqrtf(2.f),
-                 1.f / sqrtf(2.f),
-                 1.f / sqrtf(2.f),
-                 1.f / sqrtf(2.f),
-             });
+  CHECK_NEON(5, float,
+             {0.705078125f, 0.705078125f, 0.705078125f,
+              0.705078125f});  // value from hardware
+  CHECK_NEON(
+      6, float,
+      {1.6328125f, 1.6328125f, 1.6328125f, 1.6328125f});  // value from hardware
+  CHECK_NEON(7, float,
+             {1.99609375f, 1.99609375f, 1.99609375f,
+              1.99609375f});  // value from hardware
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 0>(8)));
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 1>(8)));
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 2>(8)));
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 3>(8)));
 
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 0>(5)));
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 1>(5)));
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 2>(5)));
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 3>(5)));
-
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 0>(6)));
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 1>(6)));
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 2>(6)));
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 3>(6)));
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 0>(9)));
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 1>(9)));
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 2>(9)));
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 3>(9)));
+  // value from hardware
+  EXPECT_EQ((getVectorRegisterElement<uint32_t, 0>(11)), 0x647f8000);
+  EXPECT_EQ((getVectorRegisterElement<uint32_t, 1>(11)), 0x62b48000);
+  EXPECT_EQ((getVectorRegisterElement<uint32_t, 2>(11)), 0x64b48000);
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 3>(11)));
 
   // Vector single precision (2S)
   RUN_AARCH64(R"(
     fmov v0.4s, 2.0
-    fmov v1.4s, -0.125
+    fmov v1.4s, 0.375
+    fmov v2.4s, 0.25
+    fmov v3.4s, -0.125
 
-    frsqrte v4.2s, v0.2s
-    frsqrte v5.2s, v1.2s
-    frsqrte v6.2s, v2.2s
+    # subnormals
+    mov w0, #0x00000002
+    mov w1, #0x00000100
+    mov v10.s[0], w0
+    mov v10.s[1], w1
+
+    frsqrte v5.2s, v0.2s
+    frsqrte v6.2s, v1.2s
+    frsqrte v7.2s, v2.2s
+    frsqrte v8.2s, v3.2s
+    frsqrte v9.2s, v4.2s
+    frsqrte v11.2s, v10.2s
   )");
-  CHECK_NEON(4, float, {1.f / sqrtf(2.f), 1.f / sqrtf(2.f), 0.f, 0.f});
-
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 0>(5)));
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 1>(5)));
-  EXPECT_EQ((getVectorRegisterElement<float, 2>(5)), 0.f);
-  EXPECT_EQ((getVectorRegisterElement<float, 3>(5)), 0.f);
-
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 0>(6)));
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 1>(6)));
-  EXPECT_EQ((getVectorRegisterElement<float, 2>(6)), 0.f);
-  EXPECT_EQ((getVectorRegisterElement<float, 3>(6)), 0.f);
+  CHECK_NEON(5, float,
+             {0.705078125f, 0.705078125f, 0.f, 0.f});  // value from hardware
+  CHECK_NEON(6, float,
+             {1.6328125f, 1.6328125f, 0.f, 0.f});  // value from hardware
+  CHECK_NEON(7, float,
+             {1.99609375f, 1.99609375f, 0.f, 0.f});  // value from hardware
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 0>(8)));
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 1>(8)));
+  EXPECT_EQ((getVectorRegisterElement<float, 2>(8)), 0.f);
+  EXPECT_EQ((getVectorRegisterElement<float, 3>(8)), 0.f);
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 0>(9)));
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<float, 1>(9)));
+  EXPECT_EQ((getVectorRegisterElement<float, 2>(9)), 0.f);
+  EXPECT_EQ((getVectorRegisterElement<float, 3>(9)), 0.f);
+  CHECK_NEON(11, uint32_t,
+             {0x647f8000, 0x62b48000, 0, 0});  // value from hardware
 
   // Vector double precison
   RUN_AARCH64(R"(
-    fmov v0.2d, 2.0
-    fmov v1.2d, -0.125
+    fmov v0.2d, #0.1953125
+    fmov v1.2d, #3.875
+    fmov v2.2d, #0.875
+    fmov v3.2d, #1.9375
+    fmov v4.2d, #-0.5
 
-    frsqrte v3.2d, v0.2d
-    frsqrte v4.2d, v1.2d
-    frsqrte v5.2d, v2.2d
+    # subnormals
+    mov x0, #0x0000000000000001
+    mov x1, #0x0000000000001000
+    mov v12.d[0], x0
+    mov v12.d[1], x1
+
+    frsqrte v6.2d, v0.2d
+    frsqrte v7.2d, v1.2d
+    frsqrte v8.2d, v2.2d
+    frsqrte v9.2d, v3.2d
+    frsqrte v10.2d, v4.2d
+    frsqrte v11.2d, v5.2d 
+    frsqrte v13.2d, v12.2d
   )");
-  CHECK_NEON(3, double, {1.0 / sqrt(2.0), 1.0 / sqrt(2.0)});
-
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<double, 0>(4)));
-  EXPECT_TRUE(std::isnan(getVectorRegisterElement<double, 1>(4)));
-
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<double, 0>(5)));
-  EXPECT_TRUE(std::isinf(getVectorRegisterElement<double, 1>(5)));
+  CHECK_NEON(6, double, {2.2578125, 2.2578125});      // value from hardware
+  CHECK_NEON(7, double, {0.5078125, 0.5078125});      // value from hardware
+  CHECK_NEON(8, double, {1.06640625, 1.06640625});    // value from hardware
+  CHECK_NEON(9, double, {0.716796875, 0.716796875});  // value from hardware
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<double, 0>(10)));
+  EXPECT_TRUE(std::isnan(getVectorRegisterElement<double, 1>(10)));
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<double, 0>(11)));
+  EXPECT_TRUE(std::isinf(getVectorRegisterElement<double, 1>(11)));
+  CHECK_NEON(13, uint64_t,
+             {0x617ff00000000000, 0x611ff00000000000});  // value from hardware
 }
 
 TEST_P(InstFloat, frsqrts) {

--- a/test/regression/aarch64/instructions/float.cc
+++ b/test/regression/aarch64/instructions/float.cc
@@ -1051,12 +1051,18 @@ TEST_P(InstFloat, frsqrte) {
   RUN_AARCH64(R"(
     fmov s0, 2.0
     fmov s1, -0.125
+    fmov s6, 0.25
+    fmov s8, 0.375
 
     frsqrte s3, s0
     frsqrte s4, s1
     frsqrte s5, s2
+    frsqrte s7, s6
+    frsqrte s9, s8
   )");
-  CHECK_NEON(3, float, {1.f / sqrtf(2.f), 0.f, 0.f, 0.f});
+  CHECK_NEON(3, float, {0.705078125f, 0.f, 0.f, 0.f});  // vale from xci
+  CHECK_NEON(7, float, {1.99609375f, 0.f, 0.f, 0.f});   // value from xci
+  CHECK_NEON(9, float, {1.6328125f, 0.f, 0.f, 0.f});    // value from xci
 
   EXPECT_TRUE(std::isnan(getVectorRegisterElement<float, 0>(4)));
   EXPECT_EQ((getVectorRegisterElement<float, 1>(4)), 0.f);

--- a/test/regression/aarch64/instructions/neon.cc
+++ b/test/regression/aarch64/instructions/neon.cc
@@ -708,11 +708,25 @@ TEST_P(InstNeon, faddp) {
 
   // V.4S
   RUN_AARCH64(R"(
-    fmov v0.4s, #0.25
-    fmov v1.4s, #3.75
+    mov w0, #0x3f800000
+    mov w1, #0x3fc00000
+    mov w2, #0x40000000
+    mov w3, #0x3fa00000
+    mov w4, #0x40100000
+    mov w5, #0x40500000
+
+    fmov s0, #0.5
+    mov v0.s[1], w0
+    mov v0.s[2], w1
+    mov v0.s[3], w2
+    fmov s1, #0.25
+    mov v1.s[1], w3
+    mov v1.s[2], w4
+    mov v1.s[3], w5
+
     faddp v2.4s, v1.4s, v0.4s
   )");
-  CHECK_NEON(2, float, {7.5f, 7.5f, 0.5f, 0.5f});
+  CHECK_NEON(2, float, {1.5f, 5.5f, 1.5f, 3.5f});
 
   // V.2S
   RUN_AARCH64(R"(
@@ -1551,10 +1565,10 @@ TEST_P(InstNeon, ins) {
 TEST_P(InstNeon, mov_from_general) {
   // from general to byte
   RUN_AARCH64(R"(
-    mov w0, #0x01
-    mov w1, #0x04
-    mov w2, #0x07
-    mov w3, #0x0A
+    mov w0, #0xAB01
+    mov w1, #0xAB04
+    mov w2, #0xAB07
+    mov w3, #0xAB0A
 
     # inserting elements
     mov v0.b[1], w0
@@ -1568,10 +1582,19 @@ TEST_P(InstNeon, mov_from_general) {
 
   // from general to half precision
   RUN_AARCH64(R"(
-    mov w0, #0x1010
-    mov w1, #0x3030
-    mov w2, #0x5050
-    mov w3, #0x7070
+    mov w5, #0xAD
+
+    lsl w0, w5, #16
+    add w0, w0, #0x1000
+
+    lsl w1, w5, #16
+    add w1, w1, #0x0303
+    
+    lsl w2, w5, #16
+    add w2, w2, #0x0505
+
+    lsl w3, w5, #16
+    add w3, w3, #0x0707
 
     # inserting elements
     mov v0.h[1], w0
@@ -1580,7 +1603,7 @@ TEST_P(InstNeon, mov_from_general) {
     mov v0.h[7], w3
   )");
   CHECK_NEON(0, uint16_t,
-             {0x0000, 0x1010, 0x0000, 0x3030, 0x0000, 0x5050, 0x0000, 0x7070});
+             {0x0000, 0x1000, 0x0000, 0x0303, 0x0000, 0x0505, 0x0000, 0x0707});
 
   // from general to single precision
   RUN_AARCH64(R"(
@@ -1599,14 +1622,14 @@ TEST_P(InstNeon, mov_from_general) {
 
   // from general to double precision
   RUN_AARCH64(R"(
-    mov x0, #100
-    mov x1, #200
+    mov x0, #0x3ff4000000000000
+    mov x1, #0x4009000000000000
 
     # inserting elemetns
     mov v0.d[0], x0
     mov v0.d[1], x1
   )");
-  CHECK_NEON(0, uint64_t, {100UL, 200UL})
+  CHECK_NEON(0, double, {1.25, 3.125});
 }
 
 TEST_P(InstNeon, movi) {
@@ -1637,6 +1660,7 @@ TEST_P(InstNeon, movi) {
   // vector 8-bit
   RUN_AARCH64(R"(
     movi v0.16b, #1
+    movi v1.16b, #0xff
   )");
   CHECK_NEON(0, uint8_t,
              {static_cast<uint8_t>(1), static_cast<uint8_t>(1),
@@ -1646,7 +1670,16 @@ TEST_P(InstNeon, movi) {
               static_cast<uint8_t>(1), static_cast<uint8_t>(1),
               static_cast<uint8_t>(1), static_cast<uint8_t>(1),
               static_cast<uint8_t>(1), static_cast<uint8_t>(1),
-              static_cast<uint8_t>(1), static_cast<uint8_t>(1)})
+              static_cast<uint8_t>(1), static_cast<uint8_t>(1)});
+  CHECK_NEON(1, uint8_t,
+             {static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff),
+              static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff),
+              static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff),
+              static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff),
+              static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff),
+              static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff),
+              static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff),
+              static_cast<uint8_t>(0xff), static_cast<uint8_t>(0xff)});
 }
 
 TEST_P(InstNeon, mvni) {

--- a/test/regression/aarch64/instructions/store.cc
+++ b/test/regression/aarch64/instructions/store.cc
@@ -345,32 +345,54 @@ TEST_P(InstStore, st1twov) {
 TEST_P(InstStore, st2_multi_struct) {
   // V.4S (float)
   RUN_AARCH64(R"(
-    fmov v0.4s, #-0.5
-    fmov v1.4s, #2.0
-    fmov v2.4s, #1.5
-    fmov v3.4s, -3.0
-    mov x1, #48
+    # Preparing vector elements
+    mov w0, #1
+    mov w1, #2
+    mov w2, #3
+    mov w3, #4
+    mov w4, #5
+    mov w5, #6
+    mov w6, #7
+    mov w7, #8
+
+    # Inserting elements to vectors
+    mov v0.s[0], w0
+    mov v0.s[1], w1
+    mov v0.s[2], w2
+    mov v0.s[3], w3
+
+    mov v1.s[0], w4
+    mov v1.s[1], w5
+    mov v1.s[2], w6
+    mov v1.s[3], w7
+
+    mov v2.16b, v0.16b
+    mov v3.16b, v1.16b
+
+    mov x10, #48
     sub sp, sp, #80
-    st2 {v2.4s, v3.4s}, [sp], x1
+    st2 {v2.4s, v3.4s}, [sp], x10
     st2 {v0.4s, v1.4s}, [sp], #32
   )");
+
   EXPECT_EQ(getGeneralRegister<uint64_t>(31), process_->getStackPointer());
-  for (int i = 0; i < 4; i++) {
-    EXPECT_EQ(
-        getMemoryValue<float>(getGeneralRegister<uint64_t>(31) - 32 + 8 * i),
-        -0.5);
-    EXPECT_EQ(
-        getMemoryValue<float>(getGeneralRegister<uint64_t>(31) - 28 + 8 * i),
-        2.0);
-  }
-  for (int i = 0; i < 4; i++) {
-    EXPECT_EQ(
-        getMemoryValue<float>(getGeneralRegister<uint64_t>(31) - 80 + 8 * i),
-        1.5);
-    EXPECT_EQ(
-        getMemoryValue<float>(getGeneralRegister<uint64_t>(31) - 76 + 8 * i),
-        -3.0);
-  }
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 80), 1);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 76), 5);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 72), 2);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 68), 6);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 64), 3);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 60), 7);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 56), 4);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 52), 8);
+
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 32), 1);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 28), 5);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 24), 2);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 20), 6);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 16), 3);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 12), 7);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 8), 4);
+  EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) - 4), 8);
 }
 
 TEST_P(InstStore, stpd) {


### PR DESCRIPTION
This branch was initially created to fix the error output difference between
SimEng and hardware. (SimEng has greater error than hardware)
There was result differences between hardware and SimEng when the
instruction `frsqrte` was used.
Therefore, it was suspected to be the cause and some changes are made
as below.
Even though the error output was reduced by very small amount after the fix,
the behaviour of `frsqrte` is now exactly same as hardware.

The use of `1/sqrt(x)` and `1/sqrtf(x)` in `frsqrte` are replaced with the methods
based on the pseudo code from _Arm Architecture Reference Manual
Armv8, for Armv8-A architecture profile_.

While checking wrongly implemented instructions, better tests are added to
instructions `st2 (multi struct)`, `faddp (single precision vector)`,
`mov (general to vector)`, and `frsqrte`.

`st1 (two 16b vectors variant)` and `st2 (two 4s vectors post index variant)`
are found that they can have minor improvements.
Address generation of `st1` is simplified, so it can simply store data vector
by vector.
Type of operands in `st2` are changed to `uint32_t` to ensure non-floating point
data can also be handled.
