### PR TITLE
Minifmm aarch64 coverage

### DIFF
--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -344,6 +344,12 @@ class Instruction : public simeng::Instruction {
    * registers. */
   void decode();
 
+  /** Helper function to check if the current source register is a
+   * Zero-register. If it is then it is immediatly decoded as such and added to
+   * the instruction's operands list. Otherwise, the count for operands pending
+   * is incremented by 1.*/
+  void checkZeroReg();
+
   /** Generate an EncodingNotYetImplemented exception. */
   void nyi();
 

--- a/src/include/simeng/kernel/Linux.hh
+++ b/src/include/simeng/kernel/Linux.hh
@@ -10,7 +10,7 @@
 namespace simeng {
 namespace kernel {
 
-/** Fixed-width definition of `timeval`.
+/** Fixed-width definition of `stat`.
  * Defined by Linux kernel in include/uapi/asm-generic/stat.h */
 struct stat {
   uint64_t dev;       // offset =   0
@@ -94,6 +94,26 @@ struct LinuxProcessState {
   std::set<int64_t> freeFileDescriptors;
 };
 
+/** Fixed-width definition of 'rusage' (from <sys/resource.h>). */
+struct rusage {
+  struct ::timeval ru_utime;  // user CPU time used
+  struct ::timeval ru_stime;  // system CPU time used
+  int64_t ru_maxrss;          // maximum resident set size
+  int64_t ru_ixrss;           // integral shared memory size
+  int64_t ru_idrss;           // integral unshared data size
+  int64_t ru_isrss;           // integral unshared stack size
+  int64_t ru_minflt;          // page reclaims (soft page faults)
+  int64_t ru_majflt;          // page faults (hard page faults)
+  int64_t ru_nswap;           // swaps
+  int64_t ru_inblock;         // block input operations
+  int64_t ru_oublock;         // block output operations
+  int64_t ru_msgsnd;          // IPC messages sent
+  int64_t ru_msgrcv;          // IPC messages received
+  int64_t ru_nsignals;        // signals received
+  int64_t ru_nvcsw;           // voluntary context switches
+  int64_t ru_nivcsw;          // involuntary context switches
+};
+
 /** A Linux kernel syscall emulation implementation, which mimics the responses
    to Linux system calls. */
 class Linux {
@@ -118,6 +138,11 @@ class Linux {
   /** ftruncate syscall: truncate a file to an exact size. */
   int64_t ftruncate(uint64_t fd, uint64_t length);
 
+  /** faccessat syscall: checks whether the calling process can access the file
+   * 'pathname'. */
+  int64_t faccessat(int64_t dfd, const std::string& filename, int64_t mode,
+                    int64_t flag);
+
   /** close syscall: close a file descriptor. */
   int64_t close(int64_t fd);
 
@@ -127,6 +152,9 @@ class Linux {
 
   /** fstat syscall: get file status. */
   int64_t fstat(int64_t fd, stat& out);
+
+  /** getrusage syscall: get recource usage measures for Who*/
+  int64_t getrusage(int64_t who, rusage& out);
 
   /** getpid syscall: get the process owner's process ID. */
   int64_t getpid() const;

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -233,6 +233,11 @@ std::vector<RegisterFileStructure> Architecture::getRegisterFileStructures()
 
 uint16_t Architecture::getSystemRegisterTag(uint16_t reg) const {
   assert(systemRegisterMap_.count(reg) && "unhandled system register");
+  // Check below is done for speculative instructions that may be passed into
+  // the function but will not be executed. Currently the above assertion is not
+  // performed on release mode, and so such invalid speculative instructions get
+  // through with the potential to cause an out-of-range error.
+  if (!systemRegisterMap_.count(reg)) return 0;
   return systemRegisterMap_.at(reg);
 }
 

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -51,6 +51,14 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       // access specifier for last operand was missing
       operands[2].access = CS_AC_READ;
       break;
+    case Opcode::AArch64_CASALW:
+      [[fallthrough]];
+    case Opcode::AArch64_CASALX:
+      operandCount = 3;
+      operands[0].access = CS_AC_READ;
+      operands[1].access = CS_AC_READ;
+      operands[2].access = CS_AC_READ;
+      break;
     case Opcode::AArch64_CBNZW:
       [[fallthrough]];
     case Opcode::AArch64_CBNZX:
@@ -75,6 +83,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       [[fallthrough]];
     case Opcode::AArch64_CNTH_XPiI:
       [[fallthrough]];
+    case Opcode::AArch64_CNTD_XPiI:
+      [[fallthrough]];
     case Opcode::AArch64_CNTW_XPiI: {
       // lacking access specifiers for destination
       operands[0].access = CS_AC_WRITE;
@@ -89,6 +99,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       }
       break;
     }
+    case Opcode::AArch64_DECD_XPiI:
+      [[fallthrough]];
     case Opcode::AArch64_DECB_XPiI:
       // lacking access specifiers for destination
       operands[0].access = CS_AC_READ | CS_AC_WRITE;
@@ -102,9 +114,15 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[1].access = CS_AC_READ;
       operands[1].type = ARM64_OP_IMM;
       break;
+    case Opcode::AArch64_FNMLS_ZPmZZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_FNMLS_ZPmZZ_S:
+      [[fallthrough]];
     case Opcode::AArch64_FADDA_VPZ_D:
       [[fallthrough]];
     case Opcode::AArch64_FDIV_ZPmZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_FMAD_ZPmZZ_D:
       [[fallthrough]];
     case Opcode::AArch64_FMAD_ZPmZZ_S:
       [[fallthrough]];
@@ -112,7 +130,11 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       [[fallthrough]];
     case Opcode::AArch64_FMLA_ZPmZZ_S:
       [[fallthrough]];
+    case Opcode::AArch64_FMLS_ZPmZZ_D:
+      [[fallthrough]];
     case Opcode::AArch64_FMLS_ZPmZZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_FMSB_ZPmZZ_D:
       [[fallthrough]];
     case Opcode::AArch64_FMSB_ZPmZZ_S:
       [[fallthrough]];
@@ -125,13 +147,63 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[2].access = CS_AC_READ;
       operands[3].access = CS_AC_READ;
       break;
+    case Opcode::AArch64_MOVPRFX_ZPzZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_MOVPRFX_ZPzZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_SUB_ZZZ_B:
+      [[fallthrough]];
+    case Opcode::AArch64_SUB_ZZZ_H:
+      [[fallthrough]];
+    case Opcode::AArch64_SUB_ZZZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_SUB_ZZZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_II_B:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_II_H:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_II_S:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_II_D:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_IR_B:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_IR_D:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_IR_H:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_IR_S:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RI_B:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RI_D:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RI_H:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RI_S:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RR_B:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RR_D:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RR_H:
+      [[fallthrough]];
+    case Opcode::AArch64_INDEX_RR_S:
+      [[fallthrough]];
     case Opcode::AArch64_FABS_ZPmZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_ADD_ZZZ_B:
+      [[fallthrough]];
+    case Opcode::AArch64_ADD_ZZZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_ADD_ZZZ_H:
+      [[fallthrough]];
+    case Opcode::AArch64_ADD_ZZZ_S:
       [[fallthrough]];
     case Opcode::AArch64_FADD_ZZZ_D:
       [[fallthrough]];
     case Opcode::AArch64_FADD_ZZZ_S:
-      [[fallthrough]];
-    case Opcode::AArch64_FSQRT_ZPmZ_S:
       [[fallthrough]];
     case Opcode::AArch64_FSUB_ZZZ_D:
       [[fallthrough]];
@@ -153,6 +225,10 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[1].access = CS_AC_READ;
       operands[2].access = CS_AC_READ;
       break;
+    case Opcode::AArch64_FSQRT_ZPmZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_FSQRT_ZPmZ_D:
+      [[fallthrough]];
     case Opcode::AArch64_FCVTZS_ZPmZ_DtoS:
       // No defined access types
       operands[0].access = CS_AC_READ | CS_AC_WRITE;
@@ -179,6 +255,28 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
 
       break;
     }
+    case Opcode::AArch64_FADD_ZPmI_D:
+      [[fallthrough]];
+    case Opcode::AArch64_FADD_ZPmI_S:
+      // No defined access types
+      operandCount = 4;
+      operands[0].access = CS_AC_WRITE;
+      operands[1].access = CS_AC_READ;
+      operands[2].access = CS_AC_READ;
+      operands[3].type = ARM64_OP_FP;
+      operands[3].access = CS_AC_READ;
+      // Doesn't recognise immediate operands
+      // Extract two possible values, 0.5 or 1.0
+      if (operandStr.substr(operandStr.length() - 1, 1) == "5") {
+        operands[3].fp = 0.5f;
+      } else {
+        operands[3].fp = 1.0f;
+      }
+      break;
+    case Opcode::AArch64_FDIVR_ZPmZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_FDIVR_ZPmZ_S:
+      [[fallthrough]];
     case Opcode::AArch64_AND_PPzPP:
       [[fallthrough]];
     case Opcode::AArch64_FADD_ZPmZ_D:
@@ -196,6 +294,14 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
     case Opcode::AArch64_FMUL_ZPmZ_D:
       [[fallthrough]];
     case Opcode::AArch64_FMUL_ZPmZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_MUL_ZPmZ_B:
+      [[fallthrough]];
+    case Opcode::AArch64_MUL_ZPmZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_MUL_ZPmZ_H:
+      [[fallthrough]];
+    case Opcode::AArch64_MUL_ZPmZ_S:
       [[fallthrough]];
     case Opcode::AArch64_SEL_ZPZZ_D:
       [[fallthrough]];
@@ -239,11 +345,87 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       }
       break;
     }
+    case Opcode::AArch64_INCD_ZPiI:
+      [[fallthrough]];
+    case Opcode::AArch64_INCH_ZPiI:
+      [[fallthrough]];
+    case Opcode::AArch64_INCW_ZPiI: {
+      // lacking access specifiers for destination
+      operands[0].access = CS_AC_READ | CS_AC_WRITE;
+      if (operandStr.length() < 6) {
+        operandCount = 2;
+        operands[1].type = ARM64_OP_IMM;
+        operands[1].imm = 1;
+        operands[1].access = CS_AC_READ;
+        operands[1].shift = {ARM64_SFT_INVALID, 0};
+        operands[1].ext = ARM64_EXT_INVALID;
+        operands[1].vector_index = -1;
+      }
+      break;
+    }
     case Opcode::AArch64_LD1i32:
       [[fallthrough]];
     case Opcode::AArch64_LD1i64:
       operands[1].access = CS_AC_READ;
       break;
+    case Opcode::AArch64_GLD1D_SCALED_REAL:
+      [[fallthrough]];
+    case Opcode::AArch64_GLD1D_REAL: {
+      // LD1D gather instruction doesn't correctly identify destination register
+      uint16_t reg_enum = ARM64_REG_Z0;
+      // Single or double digit Z register identifier
+      if (operandStr[3] == '.') {
+        reg_enum += std::stoi(operandStr.substr(2, 1));
+      } else {
+        reg_enum += std::stoi(operandStr.substr(2, 2));
+      }
+      operands[0].reg = static_cast<arm64_reg>(reg_enum);
+
+      // No defined access types
+      operands[0].access = CS_AC_WRITE;
+      operands[1].access = CS_AC_READ;
+      // LD1D gather instruction doesn't correctly identify memory operands
+      operands[2].type = ARM64_OP_MEM;
+      operands[2].access = CS_AC_READ;
+      break;
+    }
+    case Opcode::AArch64_GLD1SW_D_IMM_REAL:
+      [[fallthrough]];
+    case Opcode::AArch64_GLD1D_IMM_REAL: {
+      // LD1D gather instruction doesn't correctly identify destination register
+      uint16_t reg_enum = ARM64_REG_Z0;
+      // Single or double digit Z register identifier
+      if (operandStr[3] == '.') {
+        reg_enum += std::stoi(operandStr.substr(2, 1));
+      } else {
+        reg_enum += std::stoi(operandStr.substr(2, 2));
+      }
+
+      operands[0].reg = static_cast<arm64_reg>(reg_enum);
+      // No defined access types
+      operands[0].access = CS_AC_WRITE;
+      operands[1].access = CS_AC_READ;
+      // LD1D gather instruction doesn't correctly identify second Z reg as
+      // memory operand
+      operands[2].type = ARM64_OP_MEM;
+      operands[2].access = CS_AC_READ;
+      // LD1D gather instruction doesn't recognise memory-offset immediate
+      // correctly
+      if (operandStr[operandStr.length() - 3] != '.') {
+        int64_t startPos = operandStr.find('#') + 1;
+        int64_t immSize = (operandStr.length() - 1) - startPos;
+        if (immSize == 1) {
+          operands[2].mem.disp =
+              std::stoi(operandStr.substr(startPos, immSize));
+        } else {
+          // double or tripple digit immediates are converted to hex, and so
+          // require a different conversion to uint
+          operands[2].mem.disp =
+              std::stoul(operandStr.substr(startPos, immSize), nullptr, 16);
+        }
+      }
+      break;
+    }
     case Opcode::AArch64_LD1B:
       [[fallthrough]];
     case Opcode::AArch64_LD1D:
@@ -253,6 +435,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
     case Opcode::AArch64_LD1RD_IMM:
       [[fallthrough]];
     case Opcode::AArch64_LD1RW_IMM:
+      [[fallthrough]];
+    case Opcode::AArch64_LD1H:
       [[fallthrough]];
     case Opcode::AArch64_LD1W:
       [[fallthrough]];
@@ -273,6 +457,38 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[2].access = CS_AC_READ;
       break;
     }
+    case Opcode::AArch64_LD1Rv4h_POST:
+      [[fallthrough]];
+    case Opcode::AArch64_LD1Rv8h_POST:
+      // Fix for exclusion of post_index immediate in disassembly
+      operandCount = 3;
+      operands[2].type = ARM64_OP_IMM;
+      operands[2].access = CS_AC_READ;
+      // For vector arrangment of 16-bit, post_index immediate is 2
+      operands[2].imm = 2;
+      break;
+    case Opcode::AArch64_LD1Rv1d_POST:
+      [[fallthrough]];
+    case Opcode::AArch64_LD1Rv2d_POST:
+      // Fix for exclusion of post_index immediate in disassembly
+      operandCount = 3;
+      operands[2].type = ARM64_OP_IMM;
+      operands[2].access = CS_AC_READ;
+      // For vector arrangment of 64-bit, post_index immediate is 8
+      operands[2].imm = 8;
+      break;
+    case Opcode::AArch64_LD1Rv16b_POST:
+      [[fallthrough]];
+    case Opcode::AArch64_LD1Rv8b_POST:
+      // Fix for exclusion of post_index immediate in disassembly
+      operandCount = 3;
+      operands[2].type = ARM64_OP_IMM;
+      operands[2].access = CS_AC_READ;
+      // For vector arrangment of 8-bit, post_index immediate is 1
+      operands[2].imm = 1;
+      break;
+    case Opcode::AArch64_LD1Rv2s_POST:
+      [[fallthrough]];
     case Opcode::AArch64_LD1Rv4s_POST:
       // Fix for exclusion of post_index immediate in disassembly
       operandCount = 3;
@@ -354,6 +570,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
     }
     case Opcode::AArch64_PTRUE_B:
       [[fallthrough]];
+    case Opcode::AArch64_PTRUE_H:
+      [[fallthrough]];
     case Opcode::AArch64_PTRUE_D:
       [[fallthrough]];
     case Opcode::AArch64_PTRUE_S:
@@ -361,7 +579,7 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[0].access = CS_AC_WRITE;
       break;
     case Opcode::AArch64_RET:
-      // RET doesn't list use of x30 (LR) if no register is supplied
+      // If no register supplied to RET, default to x30 (LR)
       if (operandCount == 0) {
         operandCount = 1;
         operands[0].type = ARM64_OP_REG;
@@ -371,13 +589,33 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       groupCount = 1;
       groups[0] = CS_GRP_JUMP;
       break;
+    case Opcode::AArch64_SST1D:
+      [[fallthrough]];
+    case Opcode::AArch64_SST1D_SCALED: {
+      // ST1W doesn't correctly identify first source register
+      uint16_t reg_enum = ARM64_REG_Z0;
+      // Single or double digit Z register identifier
+      if (operandStr[3] == '.') {
+        reg_enum += std::stoi(operandStr.substr(2, 1));
+      } else {
+        reg_enum += std::stoi(operandStr.substr(2, 2));
+      }
+
+      operands[0].reg = static_cast<arm64_reg>(reg_enum);
+      // No defined access types
+      operands[0].access = CS_AC_READ;
+      operands[1].access = CS_AC_READ;
+      // SST1D{_SCALED} gather instruction doesn't correctly identify memory
+      // operands
+      operands[2].type = ARM64_OP_MEM;
+      operands[2].access = CS_AC_READ;
+      break;
+    }
     case Opcode::AArch64_ST1B:
       [[fallthrough]];
     case Opcode::AArch64_ST1D:
       [[fallthrough]];
     case Opcode::AArch64_ST1D_IMM:
-      [[fallthrough]];
-    case Opcode::AArch64_ST1W:
       [[fallthrough]];
     case Opcode::AArch64_ST1W_IMM: {
       // ST1W doesn't correctly identify first source register
@@ -394,6 +632,66 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[0].access = CS_AC_READ;
       operands[1].access = CS_AC_READ;
       operands[2].access = CS_AC_READ;
+      break;
+    }
+    case Opcode::AArch64_ST1W:
+      [[fallthrough]];
+    case Opcode::AArch64_ST1W_D: {
+      // ST1W doesn't correctly identify first source register
+      uint16_t reg_enum = ARM64_REG_Z0;
+      // Single or double digit Z register identifier
+      if (operandStr[3] == '.') {
+        reg_enum += std::stoi(operandStr.substr(2, 1));
+      } else {
+        reg_enum += std::stoi(operandStr.substr(2, 2));
+      }
+
+      operands[0].reg = static_cast<arm64_reg>(reg_enum);
+      // No defined access types
+      operands[0].access = CS_AC_READ;
+      operands[1].access = CS_AC_READ;
+      operands[2].access = CS_AC_READ;
+      operands[3].access = CS_AC_READ;
+      break;
+    }
+    case Opcode::AArch64_SST1D_IMM:
+      [[fallthrough]];
+    case Opcode::AArch64_SST1W_D_IMM:
+      [[fallthrough]];
+    case Opcode::AArch64_SST1W_IMM: {
+      // ST1W scatter instruction doesn't correctly identify first source
+      // register
+      uint16_t reg_enum = ARM64_REG_Z0;
+      // Single or double digit Z register identifier
+      if (operandStr[3] == '.') {
+        reg_enum += std::stoi(operandStr.substr(2, 1));
+      } else {
+        reg_enum += std::stoi(operandStr.substr(2, 2));
+      }
+
+      operands[0].reg = static_cast<arm64_reg>(reg_enum);
+      // No defined access types
+      operands[0].access = CS_AC_READ;
+      operands[1].access = CS_AC_READ;
+      // ST1W scatter instruction doesn't correctly identify second Z reg as
+      // memory operand
+      operands[2].type = ARM64_OP_MEM;
+      operands[2].access = CS_AC_READ;
+      // ST1W scatter instruction doesn't recognise memory-offset immediate
+      // correctly
+      if (operandStr[operandStr.length() - 3] != '.') {
+        int64_t startPos = operandStr.find('#') + 1;
+        int64_t immSize = (operandStr.length() - 1) - startPos;
+        if (immSize == 1) {
+          operands[2].mem.disp =
+              std::stoi(operandStr.substr(startPos, immSize));
+        } else {
+          // double or tripple digit immediates are converted to hex, and so
+          // require a different conversion to uint
+          operands[2].mem.disp =
+              std::stoul(operandStr.substr(startPos, immSize), nullptr, 16);
+        }
+      }
       break;
     }
     case Opcode::AArch64_ST1i8_POST:
@@ -471,9 +769,25 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       }
       operands[1].access = CS_AC_READ;
       break;
+    case Opcode::AArch64_UUNPKHI_ZZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_UUNPKHI_ZZ_H:
+      [[fallthrough]];
+    case Opcode::AArch64_UUNPKHI_ZZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_UUNPKLO_ZZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_UUNPKLO_ZZ_H:
+      [[fallthrough]];
+    case Opcode::AArch64_UUNPKLO_ZZ_S:
+      operands[0].access = CS_AC_WRITE;
+      operands[1].access = CS_AC_READ;
+      break;
     case Opcode::AArch64_WHILELO_PXX_B:
       [[fallthrough]];
     case Opcode::AArch64_WHILELO_PXX_D:
+      [[fallthrough]];
+    case Opcode::AArch64_WHILELO_PXX_H:
       [[fallthrough]];
     case Opcode::AArch64_WHILELO_PXX_S:
       // WHILELO doesn't label access or vector specifiers
@@ -490,11 +804,49 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       // XTN2 incorrectly flags destination as only WRITE
       operands[0].access = CS_AC_READ | CS_AC_WRITE;
       break;
+    case Opcode::AArch64_ZIP1_PPP_B:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP1_PPP_D:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP1_PPP_H:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP1_PPP_S:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP1_ZZZ_S:
+      [[fallthrough]];
     case Opcode::AArch64_ZIP1_ZZZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP2_PPP_B:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP2_PPP_D:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP2_PPP_H:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP2_PPP_S:
+      [[fallthrough]];
+    case Opcode::AArch64_ZIP2_ZZZ_S:
       [[fallthrough]];
     case Opcode::AArch64_ZIP2_ZZZ_D:
       // ZIP lacks access types
       operands[0].access = CS_AC_WRITE;
+      operands[1].access = CS_AC_READ;
+      operands[2].access = CS_AC_READ;
+      break;
+    case Opcode::AArch64_SXTW_ZPmZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_FCVT_ZPmZ_DtoS:
+      [[fallthrough]];
+    case Opcode::AArch64_FCVT_ZPmZ_StoD:
+      [[fallthrough]];
+    case Opcode::AArch64_SCVTF_ZPmZ_DtoS:
+      [[fallthrough]];
+    case Opcode::AArch64_SCVTF_ZPmZ_StoD:
+      [[fallthrough]];
+    case Opcode::AArch64_SCVTF_ZPmZ_StoS:
+      [[fallthrough]];
+    case Opcode::AArch64_SCVTF_ZPmZ_DtoD:
+      // Need to see if Destination vector elements are active
+      operands[0].access = CS_AC_READ | CS_AC_WRITE;
       operands[1].access = CS_AC_READ;
       operands[2].access = CS_AC_READ;
       break;
@@ -784,6 +1136,7 @@ void InstructionMetadata::revertAliasing() {
       if (opcode == Opcode::AArch64_DUPM_ZI ||
           opcode == Opcode::AArch64_DUP_ZI_B ||
           opcode == Opcode::AArch64_DUP_ZI_D ||
+          opcode == Opcode::AArch64_DUP_ZI_H ||
           opcode == Opcode::AArch64_DUP_ZI_S) {
         // mov Zd.T, #imm; alias for dupm Zd.T, #imm
         // or
@@ -839,7 +1192,8 @@ void InstructionMetadata::revertAliasing() {
 
         return;
       }
-      if (opcode == Opcode::AArch64_DUP_ZR_S) {
+      if (opcode == Opcode::AArch64_DUP_ZR_S ||
+          opcode == Opcode::AArch64_DUP_ZR_D) {
         // mov Zd.T, <rn|sp>; alias for dup Zd.T, <rn|sp>
         operands[0].access = CS_AC_WRITE;
         operands[0].vas = ARM64_VAS_1S;
@@ -863,7 +1217,8 @@ void InstructionMetadata::revertAliasing() {
         operands[1].vector_index = 0;
         return;
       }
-      if (opcode == Opcode::AArch64_INSvi32lane) {
+      if (opcode == Opcode::AArch64_INSvi32lane ||
+          opcode == Opcode::AArch64_INSvi64lane) {
         // mov vd.T[index1], vn.T[index2]; alias for ins vd.T[index1],
         // vn.T[index2]
         return;
@@ -967,6 +1322,12 @@ void InstructionMetadata::revertAliasing() {
         }
         return;
       }
+      if (opcode == Opcode::AArch64_MUL_ZPmZ_B ||
+          opcode == Opcode::AArch64_MUL_ZPmZ_D ||
+          opcode == Opcode::AArch64_MUL_ZPmZ_H ||
+          opcode == Opcode::AArch64_MUL_ZPmZ_S) {
+        return;
+      }
       return aliasNYI();
     case ARM64_INS_MVN:
       if (opcode == Opcode::AArch64_ORNWrs ||
@@ -983,6 +1344,13 @@ void InstructionMetadata::revertAliasing() {
         } else {
           operands[1].reg = ARM64_REG_XZR;
         }
+        return;
+      }
+      if (opcode == Opcode::AArch64_NOTv16i8 ||
+          opcode == Opcode::AArch64_NOTv8i8) {
+        // mvn vd.t, vn.t; alias for : not vd.t, vn.t
+        // Blank entry was for a legitimate alias, however operands were
+        // identical so nothing to alter between the instructions.
         return;
       }
       return aliasNYI();
@@ -1110,6 +1478,9 @@ void InstructionMetadata::revertAliasing() {
         operands[3].type = ARM64_OP_IMM;
         operands[3].access = CS_AC_READ;
         operands[3].imm = 31;
+        return;
+      }
+      if (opcode == Opcode::AArch64_SXTW_ZPmZ_D) {
         return;
       }
       return aliasNYI();

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -277,7 +277,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses({{operands[1].get<uint64_t>(), 4}});
       break;
     }
-    case Opcode::AArch64_LDARB: {  // ldar wt, [<xn|sp>]
+    case Opcode::AArch64_LDARB: {  // ldarb wt, [xn]
       setMemoryAddresses({{operands[0].get<uint64_t>(), 1}});
       break;
     }

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -285,6 +285,10 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses({{operands[0].get<uint64_t>(), 4}});
       break;
     }
+    case Opcode::AArch64_LDARX: {  // ldar xt, [xn]
+      setMemoryAddresses({{operands[0].get<uint64_t>(), 8}});
+      break;
+    }
     case Opcode::AArch64_LDAXRW: {  // ldaxr wd, [xn]
       setMemoryAddresses({{operands[0].get<uint64_t>(), 4}});
       break;
@@ -1071,6 +1075,10 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_STLRW: {  // stlr wt, [xn]
       setMemoryAddresses({{operands[1].get<uint64_t>(), 4}});
+      break;
+    }
+    case Opcode::AArch64_STLRX: {  // stlr xt, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
       break;
     }
     case Opcode::AArch64_STLXRW: {  // stlxr ws, wt, [xn]

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -12,6 +12,14 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
          "generateAddresses called on non-load-or-store instruction");
 
   switch (metadata.opcode) {
+    case Opcode::AArch64_CASALW: {  // casal ws, wt, [xn|sp]
+      setMemoryAddresses({{operands[2].get<uint64_t>(), 4}});
+      break;
+    }
+    case Opcode::AArch64_CASALX: {  // casal xs, xt, [xn|sp]
+      setMemoryAddresses({{operands[2].get<uint64_t>(), 8}});
+      break;
+    }
     case Opcode::AArch64_LD1i32: {  // ld1 {vt.s}[index], [xn]
       setMemoryAddresses({{operands[1].get<uint64_t>(), 4}});
       break;
@@ -46,6 +54,62 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
           break;
         }
       }
+      break;
+    }
+    case Opcode::AArch64_LD1Rv16b: {  // ld1r {vt.16b}, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 16}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv16b_POST: {  // ld1r {vt.16b}, [xn], #imm
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 16}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv1d: {  // ld1r {vt.1d}, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv1d_POST: {  // ld1r {vt.1d}, [xn], #imm
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv2d: {  // ld1r {vt.2d}, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 16}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv2d_POST: {  // ld1r {vt.2d}, [xn], #imm
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 16}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv2s: {  // ld1r {vt.2s}, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 16}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv2s_POST: {  // ld1r {vt.2s}, [xn], #imm
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv4h: {  // ld1r {vt.4h}, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv4h_POST: {  // ld1r {vt.4h}, [xn], #imm
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv8b: {  // ld1r {vt.8b}, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv8b_POST: {  // ld1r {vt.8b}, [xn], #imm
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv8h: {  // ld1r {vt.8h}, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 16}});
+      break;
+    }
+    case Opcode::AArch64_LD1Rv8h_POST: {  // ld1r {vt.8h}, [xn], #imm
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 16}});
       break;
     }
     case Opcode::AArch64_LD1Rv4s: {  // ld1r {vt.4s}, [xn]
@@ -135,6 +199,26 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses(std::move(addresses));
       break;
     }
+    case Opcode::AArch64_LD1H: {  // ld1h {zt.h}, pg/z, [xn, xm, lsl #1]
+      const uint64_t* p = operands[0].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint8_t partition_num = VL_bits / 16;
+
+      const uint64_t base = operands[1].get<uint64_t>();
+      const uint64_t offset = operands[2].get<uint64_t>();
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 2));
+        if (p[i / 32] & shifted_active) {
+          addresses.push_back({base + ((offset + i) * 2), 2});
+        }
+      }
+
+      setMemoryAddresses(addresses);
+      break;
+    }
     case Opcode::AArch64_LD1W: {  // ld1w {zt.s}, pg/z, [xn, xm, lsl #2]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const uint64_t VL_bits = 512;
@@ -191,6 +275,10 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       [[fallthrough]];
     case Opcode::AArch64_LDADDW: {  // ldadd ws, wt, [xn]
       setMemoryAddresses({{operands[1].get<uint64_t>(), 4}});
+      break;
+    }
+    case Opcode::AArch64_LDARB: {  // ldar wt, [<xn|sp>]
+      setMemoryAddresses({{operands[0].get<uint64_t>(), 1}});
       break;
     }
     case Opcode::AArch64_LDARW: {  // ldar wt, [xn]
@@ -465,6 +553,12 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses({{base, 16}, {base + 16, 16}});
       break;
     }
+    case Opcode::AArch64_LDPSWi: {  // ldpsw xt1, xt2, [xn {, #imm}]
+      uint64_t base =
+          operands[0].get<uint64_t>() + metadata.operands[2].mem.disp;
+      setMemoryAddresses({{base, 4}, {base + 4, 4}});
+      break;
+    }
     case Opcode::AArch64_LDPSi: {  // ldp st1, st2, [xn, #imm]
       uint64_t base =
           operands[0].get<uint64_t>() + metadata.operands[2].mem.disp;
@@ -628,6 +722,46 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses(std::move(addresses));
       break;
     }
+    case Opcode::AArch64_SST1D: {  // st1d {zt.d}, pg, [xn, zm.d]
+      const uint64_t* p = operands[1].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint16_t partition_num = VL_bits / 64;
+
+      const uint64_t base = operands[2].get<uint64_t>();
+      const uint64_t* offset = operands[3].getAsVector<uint64_t>();
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = base + offset[i];
+          addresses.push_back({addr, 8});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
+    case Opcode::AArch64_SST1D_SCALED: {  // st1d {zt.d}, pg, [xn, zm.d, lsl #3]
+      const uint64_t* p = operands[1].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint16_t partition_num = VL_bits / 64;
+
+      const uint64_t base = operands[2].get<uint64_t>();
+      const uint64_t* offset = operands[3].getAsVector<uint64_t>();
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = base + (offset[i] << 3);
+          addresses.push_back({addr, 8});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
     case Opcode::AArch64_ST1D: {  // st1d {zt.d}, pg, [xn, xm, lsl #3]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const uint64_t VL_bits = 512;
@@ -695,6 +829,26 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses(std::move(addresses));
       break;
     }
+    case Opcode::AArch64_ST1W_D: {  // st1w {zt.d}, pg, [xn, xm, lsl #2]
+      const uint64_t* p = operands[1].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint8_t partition_num = VL_bits / 64;
+
+      const uint64_t base = operands[2].get<uint64_t>();
+      const uint64_t offset = operands[3].get<uint64_t>();
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          addresses.push_back({base + ((offset + i) * 4), 4});
+        }
+      }
+
+      setMemoryAddresses(addresses);
+      break;
+    }
     case Opcode::AArch64_ST1W_IMM: {  // st1w {zt.s}, pg, [xn{, #imm, mul vl}]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const uint64_t VL_bits = 512;
@@ -717,6 +871,153 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         addr += 4;
       }
       setMemoryAddresses(std::move(addresses));
+      break;
+    }
+    case Opcode::AArch64_SST1W_D_IMM: {  // st1w {zt.d}, pg, [zn.d{, #imm}]
+      const uint64_t* p = operands[1].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint8_t partition_num = VL_bits / 64;
+
+      const uint64_t* n = operands[2].getAsVector<uint64_t>();
+      const uint64_t offset =
+          static_cast<uint64_t>(metadata.operands[2].mem.disp);
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = n[i] + (offset * 4);
+          addresses.push_back({addr, 4});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
+    case Opcode::AArch64_SST1W_IMM: {  // st1w {zt.s}, pg, [zn.s{, #imm}]
+      const uint64_t* p = operands[1].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint8_t partition_num = VL_bits / 32;
+
+      const uint32_t* n = operands[2].getAsVector<uint32_t>();
+      const uint64_t offset = static_cast<uint64_t>(
+          static_cast<uint32_t>(metadata.operands[2].mem.disp));
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 4));
+        if (p[i / 16] & shifted_active) {
+          uint64_t addr = static_cast<uint64_t>(n[i]) + (offset * 4);
+          addresses.push_back({addr, 4});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
+    case Opcode::AArch64_GLD1D_REAL: {  // ld1d {zt.d}, pg/z, [xn, zm.d]
+      const uint64_t* p = operands[0].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint16_t partition_num = VL_bits / 64;
+
+      const uint64_t base = operands[1].get<uint64_t>();
+      const uint64_t* offset = operands[2].getAsVector<uint64_t>();
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = base + offset[i];
+          addresses.push_back({addr, 8});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
+    case Opcode::AArch64_GLD1D_SCALED_REAL: {  // ld1d {zt.d}, pg/z, [xn, zm.d,
+                                               // LSL #3]
+      const uint64_t* p = operands[0].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint16_t partition_num = VL_bits / 64;
+
+      const uint64_t base = operands[1].get<uint64_t>();
+      const uint64_t* offset = operands[2].getAsVector<uint64_t>();
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = base + (offset[i] << 3);
+          addresses.push_back({addr, 8});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
+    case Opcode::AArch64_GLD1D_IMM_REAL: {  // ld1d {zd.d}, pg/z, [zn.d{, #imm}]
+      const uint64_t* p = operands[0].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint8_t partition_num = VL_bits / 64;
+
+      const uint64_t* n = operands[1].getAsVector<uint64_t>();
+      const uint64_t offset =
+          static_cast<uint64_t>(metadata.operands[2].mem.disp);
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = n[i] + (offset * 8);
+          addresses.push_back({addr, 8});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
+    case Opcode::AArch64_GLD1SW_D_IMM_REAL: {  // ld1sw {zd.d}, pg/z, [zn.d{,
+                                               // #imm}]
+      const uint64_t* p = operands[0].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint8_t partition_num = VL_bits / 64;
+
+      const uint64_t* n = operands[1].getAsVector<uint64_t>();
+      const uint64_t offset =
+          static_cast<uint64_t>(metadata.operands[2].mem.disp);
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = n[i] + (offset * 4);
+          addresses.push_back({addr, 4});
+        }
+      }
+      setMemoryAddresses(addresses);
+      break;
+    }
+    case Opcode::AArch64_SST1D_IMM: {  // st1d {zt.d}, pg, [zn.d{, #imm}]
+      const uint64_t* p = operands[1].getAsVector<uint64_t>();
+      const uint64_t VL_bits = 512;
+      const uint8_t partition_num = VL_bits / 64;
+
+      const uint64_t* n = operands[2].getAsVector<uint64_t>();
+      const uint64_t offset =
+          static_cast<uint64_t>(metadata.operands[2].mem.disp);
+
+      std::vector<MemoryAccessTarget> addresses;
+
+      for (int i = 0; i < partition_num; i++) {
+        uint64_t shifted_active = std::pow(2, (i * 8));
+        if (p[i / 8] & shifted_active) {
+          uint64_t addr = n[i] + (offset * 8);
+          addresses.push_back({addr, 8});
+        }
+      }
+      setMemoryAddresses(addresses);
       break;
     }
     case Opcode::AArch64_ST1Twov16b: {  // st1v {vt.16b, vt2.16b}, [xn]

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -211,7 +211,7 @@ void Instruction::execute() {
       for (int i = 0; i < 16; i++) {
         out[i] = static_cast<uint8_t>(n[i] + m[i]);
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDv1i64: {  // add dd, dn, dm
@@ -243,7 +243,7 @@ void Instruction::execute() {
       for (int i = 0; i < 4; i++) {
         out[i] = static_cast<uint16_t>(n[i] + m[i]);
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDv4i32: {  // add vd.4s, vn.4s, vm.4s
@@ -315,7 +315,7 @@ void Instruction::execute() {
       for (int i = 0; i < 8; i++) {
         out[i] = static_cast<uint16_t>(n[i] + m[i]);
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADDv8i8: {  // add vd.8b, vn.8b, vm.8b
@@ -325,7 +325,7 @@ void Instruction::execute() {
       for (int i = 0; i < 8; i++) {
         out[i] = static_cast<uint8_t>(n[i] + m[i]);
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADCXr: {  // adc xd, xn, xm
@@ -6212,7 +6212,7 @@ void Instruction::execute() {
       for (int i = 0; i < 8; i++) {
         out[i] = n[i + 8] << shift;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_USHLLv4i16_shift: {  // ushll vd.4s, vn.4h, #imm
@@ -6232,7 +6232,7 @@ void Instruction::execute() {
       for (int i = 0; i < 4; i++) {
         out[i] = n[i + 4] << shift;
       }
-      results[0] = out;
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_USHLLv8i8_shift: {  // ushll vd.8h, vn.8b, #imm
@@ -6241,6 +6241,18 @@ void Instruction::execute() {
       uint16_t out[8] = {0};
       for (int i = 0; i < 8; i++) {
         out[i] = n[i] << shift;
+      }
+      results[0] = {out, 256};
+      break;
+    }
+    case Opcode::AArch64_UUNPKHI_ZZ_D: {  // uunpkhi zd.d, zn.s
+      const uint32_t* n = operands[0].getAsVector<uint32_t>();
+      const uint64_t VL_bits = 512;
+      const uint16_t partition_num = VL_bits / 64;
+      uint64_t out[32] = {0};
+
+      for (int i = 0; i < partition_num; i++) {
+        out[i] = static_cast<uint64_t>(n[partition_num + i]);
       }
       results[0] = out;
       break;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -3808,6 +3808,10 @@ void Instruction::execute() {
       results[0] = memoryData[0].zeroExtend(4, 8);
       break;
     }
+    case Opcode::AArch64_LDARX: {  // ldar xt, [xn]
+      results[0] = memoryData[0];
+      break;
+    }
     case Opcode::AArch64_LDAXRW: {  // ldaxr wd, [xn]
       results[0] = memoryData[0].zeroExtend(4, 8);
       break;
@@ -5373,6 +5377,8 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_STLRB:  // stlrb wt, [xn]
+      [[fallthrough]];
+    case Opcode::AArch64_STLRX:  // stlr xt, [xn]
       [[fallthrough]];
     case Opcode::AArch64_STLRW: {  // stlr wt, [xn]
       memoryData[0] = operands[0];

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -204,6 +204,16 @@ void Instruction::execute() {
 
   executed_ = true;
   switch (metadata.opcode) {
+    case Opcode::AArch64_ADDv16i8: {  // add vd.16b, vn.16b, vm.16b
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      const uint8_t* m = operands[1].getAsVector<uint8_t>();
+      uint8_t out[16] = {0};
+      for (int i = 0; i < 16; i++) {
+        out[i] = static_cast<uint8_t>(n[i] + m[i]);
+      }
+      results[0] = out;
+      break;
+    }
     case Opcode::AArch64_ADDv1i64: {  // add dd, dn, dm
       const uint64_t n = operands[0].get<uint64_t>();
       const uint64_t m = operands[1].get<uint64_t>();
@@ -224,6 +234,16 @@ void Instruction::execute() {
       uint64_t out[2] = {static_cast<uint64_t>(n[0] + m[0]),
                          static_cast<uint64_t>(n[1] + m[1])};
       results[0] = {out, 256};
+      break;
+    }
+    case Opcode::AArch64_ADDv4i16: {  // add vd.4h, vn.4h, vm.4h
+      const uint16_t* n = operands[0].getAsVector<uint16_t>();
+      const uint16_t* m = operands[1].getAsVector<uint16_t>();
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 4; i++) {
+        out[i] = static_cast<uint16_t>(n[i] + m[i]);
+      }
+      results[0] = out;
       break;
     }
     case Opcode::AArch64_ADDv4i32: {  // add vd.4s, vn.4s, vm.4s
@@ -284,6 +304,26 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
         out[i] = n[i] + m[i];
+      }
+      results[0] = out;
+      break;
+    }
+    case Opcode::AArch64_ADDv8i16: {  // add vd.8h, vn.8h, vm.8h
+      const uint16_t* n = operands[0].getAsVector<uint16_t>();
+      const uint16_t* m = operands[1].getAsVector<uint16_t>();
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = static_cast<uint16_t>(n[i] + m[i]);
+      }
+      results[0] = out;
+      break;
+    }
+    case Opcode::AArch64_ADDv8i8: {  // add vd.8b, vn.8b, vm.8b
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      const uint8_t* m = operands[1].getAsVector<uint8_t>();
+      uint8_t out[16] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = static_cast<uint8_t>(n[i] + m[i]);
       }
       results[0] = out;
       break;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -6207,10 +6207,10 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_USHLLv16i8_shift: {  // ushll2 vd.8h, vn.16b, #imm
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
-      int64_t shift = metadata.operands[2].imm;
+      const uint64_t shift = metadata.operands[2].imm;
       uint16_t out[8] = {0};
       for (int i = 0; i < 8; i++) {
-        out[i] = (n[i + 8] << shift) & 0xff;
+        out[i] = n[i + 8] << shift;
       }
       results[0] = out;
       break;
@@ -6227,20 +6227,20 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_USHLLv8i16_shift: {  // ushll2 vd.4s, vn.8h, #imm
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
-      int64_t shift = metadata.operands[2].imm;
+      const uint64_t shift = metadata.operands[2].imm;
       uint32_t out[4] = {0};
       for (int i = 0; i < 4; i++) {
-        out[i] = (n[i + 4] << shift) & 0xffff;
+        out[i] = n[i + 4] << shift;
       }
       results[0] = out;
       break;
     }
     case Opcode::AArch64_USHLLv8i8_shift: {  // ushll vd.8h, vn.8b, #imm
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
-      int64_t shift = metadata.operands[2].imm;
+      const uint64_t shift = metadata.operands[2].imm;
       uint16_t out[8] = {0};
       for (int i = 0; i < 8; i++) {
-        out[i] = (n[i] << shift) & 0xff;
+        out[i] = n[i] << shift;
       }
       results[0] = out;
       break;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -6165,6 +6165,16 @@ void Instruction::execute() {
       results[0] = mulhi(x, y);
       break;
     }
+    case Opcode::AArch64_USHLLv16i8_shift: {  // ushll2 vd.8h, vn.16b, #imm
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      int64_t shift = metadata.operands[2].imm;
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = (n[i + 8] << shift) & 0xff;
+      }
+      results[0] = out;
+      break;
+    }
     case Opcode::AArch64_USHLLv4i16_shift: {  // ushll vd.4s, vn.4h, #imm
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
       const uint64_t shift = metadata.operands[2].imm;
@@ -6175,14 +6185,22 @@ void Instruction::execute() {
       results[0] = {out, 256};
       break;
     }
-    case Opcode::AArch64_UUNPKHI_ZZ_D: {  // uunpkhi zd.d, zn.s
-      const uint32_t* n = operands[0].getAsVector<uint32_t>();
-      const uint64_t VL_bits = 512;
-      const uint16_t partition_num = VL_bits / 64;
-      uint64_t out[32] = {0};
-
-      for (int i = 0; i < partition_num; i++) {
-        out[i] = static_cast<uint64_t>(n[partition_num + i]);
+    case Opcode::AArch64_USHLLv8i16_shift: {  // ushll2 vd.4s, vn.8h, #imm
+      const uint16_t* n = operands[0].getAsVector<uint16_t>();
+      int64_t shift = metadata.operands[2].imm;
+      uint32_t out[4] = {0};
+      for (int i = 0; i < 4; i++) {
+        out[i] = (n[i + 4] << shift) & 0xffff;
+      }
+      results[0] = out;
+      break;
+    }
+    case Opcode::AArch64_USHLLv8i8_shift: {  // ushll vd.8h, vn.8b, #imm
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      int64_t shift = metadata.operands[2].imm;
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = (n[i] << shift) & 0xff;
       }
       results[0] = out;
       break;

--- a/src/lib/pipeline/RegisterAliasTable.cc
+++ b/src/lib/pipeline/RegisterAliasTable.cc
@@ -42,6 +42,13 @@ RegisterAliasTable::RegisterAliasTable(
 };
 
 Register RegisterAliasTable::getMapping(Register architectural) const {
+  // Asserts to ensure mapping isn't attempted for an out-of-bound index (i.e.
+  // mapping of WZR / XZR)
+  assert(architectural.type < mappingTable_.size() &&
+         "Invalid register type. Cannot find RAT mapping.");
+  assert(architectural.type >= 0 &&
+         "Invalid register type. Cannot find RAT mapping.");
+
   auto tag = mappingTable_[architectural.type][architectural.tag];
   return {architectural.type, tag};
 }

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -31,6 +31,83 @@ TEST_P(Syscall, ioctl) {
   EXPECT_NE(getMemoryValue<uint16_t>(process_->getHeapStart() + 6), -1);
 }
 
+TEST_P(Syscall, faccessat) {
+  const char filepath[] = SIMENG_AARCH64_TEST_ROOT "/data/input.txt";
+  initialHeapData_.resize(strlen(filepath) + 1);
+  // Copy filepath to heap
+  memcpy(initialHeapData_.data(), filepath, strlen(filepath) + 1);
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, #0
+    mov x8, 214
+    svc #0
+    mov x20, x0
+
+    # faccessat(AT_FDCWD, filepath, F_OK, 0) = 0
+    mov x0, #-100
+    mov x1, x20
+    mov x2, #0
+    mov x3, #0
+    mov x8, #48
+    svc #0
+    mov x21, x0
+
+    # faccessat(AT_FDCWD, filepath, R_OK, 0) = 0
+    mov x0, #-100
+    mov x1, x20
+    mov x2, #0x04
+    mov x3, #0
+    mov x8, #48
+    svc #0
+    mov x22, x0
+
+    # faccessat(AT_FDCWD, filepath, W_OK, 0) = 0
+    mov x0, #-100
+    mov x1, x20
+    mov x2, #0x02
+    mov x3, #0
+    mov x8, #48
+    svc #0
+    mov x23, x0
+
+    # faccessat(AT_FDCWD, filepath, X_OK, 0) = -1
+    # File targeted isn't executable
+    mov x0, #-100
+    mov x1, x20
+    mov x2, #0x01
+    mov x3, #0
+    mov x8, #48
+    svc #0
+    mov x24, x0
+
+    # faccessat(AT_FDCWD, wrongFilepath, F_OK, 0) = -1
+    mov x0, #-100
+    add x1, x20, #1
+    mov x2, #0
+    mov x3, #0
+    mov x8, #48
+    svc #0
+    mov x25, x0
+
+    # faccessat(2, fullFilePath, F_OK, 0) = 0
+    # If an absolute filepath is referenced, dirfd is ignored
+    mov x0, #2
+    mov x1, x20
+    mov x2, #0
+    mov x3, #0
+    mov x8, #48
+    svc #0
+    mov x26, x0
+  )");
+  EXPECT_EQ(getGeneralRegister<int64_t>(21), 0);
+  EXPECT_EQ(getGeneralRegister<int64_t>(22), 0);
+  EXPECT_EQ(getGeneralRegister<int64_t>(23), 0);
+  EXPECT_EQ(getGeneralRegister<int64_t>(24), -1);
+  EXPECT_EQ(getGeneralRegister<int64_t>(25), -1);
+  EXPECT_EQ(getGeneralRegister<int64_t>(26), 0);
+}
+
 // Test reading from and seeking through a file
 TEST_P(Syscall, file_read) {
   const char filepath[] = SIMENG_AARCH64_TEST_ROOT "/data/input.txt";
@@ -467,7 +544,7 @@ TEST_P(Syscall, newfstatat) {
     svc #0
     mov x20, x0
 
-    # newfstatat(dirfd=AT_FDCWD, pathname=/data/input.txt, statbuf, flags=0)
+    # newfstatat(dirfd=AT_FDCWD, pathname=data/input.txt, statbuf, flags=0)
     mov x0, #-100
     add x1, x20, #129
     mov x2, x20
@@ -478,6 +555,34 @@ TEST_P(Syscall, newfstatat) {
   )");
   // Check fstatat returned -1 (file not found)
   EXPECT_EQ(getGeneralRegister<uint64_t>(21), -1);
+}
+
+TEST_P(Syscall, getrusage) {
+  // Reserve 128 bytes for usage
+  initialHeapData_.resize(128);
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+    mov x20, x0
+
+    # getrusage(who = RUSAGE_SELF, usage)
+    mov x0, #0
+    mov x1, x20
+    mov x8, #165
+    svc #0
+    mov x21, x0
+
+    # getrusage(who = RUSAGE_CHILDREN, usage)
+    mov x0, #-1
+    mov x1, x20
+    mov x8, #165
+    svc #0
+    mov x22, x0
+  )");
+  EXPECT_EQ(getGeneralRegister<int64_t>(21), 0);
+  EXPECT_EQ(getGeneralRegister<int64_t>(22), 0);
 }
 
 TEST_P(Syscall, ftruncate) {

--- a/test/regression/aarch64/instructions/float.cc
+++ b/test/regression/aarch64/instructions/float.cc
@@ -547,6 +547,96 @@ TEST_P(InstFloat, fcvt) {
   EXPECT_EQ((getGeneralRegister<int32_t>(3)), 321);
 }
 
+TEST_P(InstFloat, fcvtzu) {
+  initialHeapData_.resize(32);
+  double* dheap = reinterpret_cast<double*>(initialHeapData_.data());
+  dheap[0] = 1.0;
+  dheap[1] = -42.76;
+  dheap[2] = -0.125;
+  dheap[3] = 321.5;
+
+  // Double to uint32
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldp d0, d1, [x0]
+    ldp d2, d3, [x0, #16]
+    fcvtzu w0, d0
+    fcvtzu w1, d1
+    fcvtzu w2, d2
+    fcvtzu w3, d3
+  )");
+  EXPECT_EQ((getGeneralRegister<uint32_t>(0)), 1);
+  EXPECT_EQ((getGeneralRegister<uint32_t>(1)), -42);
+  EXPECT_EQ((getGeneralRegister<uint32_t>(2)), 0);
+  EXPECT_EQ((getGeneralRegister<uint32_t>(3)), 321);
+
+  // Double to uint64
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldp d0, d1, [x0]
+    ldp d2, d3, [x0, #16]
+    fcvtzu x0, d0
+    fcvtzu x1, d1
+    fcvtzu x2, d2
+    fcvtzu x3, d3
+  )");
+  EXPECT_EQ((getGeneralRegister<uint64_t>(0)), 1);
+  EXPECT_EQ((getGeneralRegister<uint64_t>(1)), -42);
+  EXPECT_EQ((getGeneralRegister<uint64_t>(2)), 0);
+  EXPECT_EQ((getGeneralRegister<uint64_t>(3)), 321);
+
+  float* fheap = reinterpret_cast<float*>(initialHeapData_.data());
+  fheap[0] = 1.0;
+  fheap[1] = -42.76;
+  fheap[2] = -0.125;
+  fheap[3] = 321.5;
+  // Float to uint32
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldp s0, s1, [x0]
+    ldp s2, s3, [x0, #8]
+    fcvtzu w0, s0
+    fcvtzu w1, s1
+    fcvtzu w2, s2
+    fcvtzu w3, s3
+  )");
+  EXPECT_EQ((getGeneralRegister<uint32_t>(0)), 1);
+  EXPECT_EQ((getGeneralRegister<uint32_t>(1)), -42);
+  EXPECT_EQ((getGeneralRegister<uint32_t>(2)), 0);
+  EXPECT_EQ((getGeneralRegister<uint32_t>(3)), 321);
+
+  // Float to uint64
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldp s0, s1, [x0]
+    ldp s2, s3, [x0, #8]
+    fcvtzu x0, s0
+    fcvtzu x1, s1
+    fcvtzu x2, s2
+    fcvtzu x3, s3
+  )");
+  EXPECT_EQ((getGeneralRegister<uint64_t>(0)), 1);
+  EXPECT_EQ((getGeneralRegister<uint64_t>(1)), -42);
+  EXPECT_EQ((getGeneralRegister<uint64_t>(2)), 0);
+  EXPECT_EQ((getGeneralRegister<uint64_t>(3)), 321);
+}
+
 TEST_P(InstFloat, fcvtl) {
   // 2 floats to 2 doubles
   RUN_AARCH64(R"(

--- a/test/regression/aarch64/instructions/load.cc
+++ b/test/regression/aarch64/instructions/load.cc
@@ -331,6 +331,23 @@ TEST_P(InstLoad, ldarb) {
   EXPECT_EQ(getGeneralRegister<uint32_t>(7), 64);
 }
 
+TEST_P(InstLoad, ldar) {
+  initialHeapData_.resize(8);
+  uint64_t* heap = reinterpret_cast<uint64_t*>(initialHeapData_.data());
+  heap[0] = 0xDEADBEEF12345678;
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0  
+    ldar x1, [x0]
+    ldar w2, [x0]
+  )");
+  EXPECT_EQ(getGeneralRegister<uint64_t>(1), 0xDEADBEEF12345678);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 0x12345678);
+}
+
 TEST_P(InstLoad, ldrb) {
   initialHeapData_.resize(8);
   uint32_t* heap = reinterpret_cast<uint32_t*>(initialHeapData_.data());

--- a/test/regression/aarch64/instructions/neon.cc
+++ b/test/regression/aarch64/instructions/neon.cc
@@ -8,6 +8,113 @@ using InstNeon = AArch64RegressionTest;
 
 TEST_P(InstNeon, add) {
   // Quad 32-bit : add vd.4s, vn.4s, vm.4s
+  // 8-bit vector
+  initialHeapData_.resize(32);
+  uint8_t* heap8 = reinterpret_cast<uint8_t*>(initialHeapData_.data());
+  heap8[0] = 0;
+  heap8[1] = 0xFF;
+  heap8[2] = 0xF0;
+  heap8[3] = 0x55;
+  heap8[4] = 0xAB;
+  heap8[5] = 0xEF;
+  heap8[6] = 0xFF;
+  heap8[7] = 0x52;
+  heap8[8] = heap8[0];
+  heap8[9] = heap8[1];
+  heap8[10] = heap8[2];
+  heap8[11] = heap8[3];
+  heap8[12] = heap8[4];
+  heap8[13] = heap8[5];
+  heap8[14] = heap8[6];
+  heap8[15] = heap8[7];
+
+  heap8[16] = 0;
+  heap8[17] = 0x01;
+  heap8[18] = 0x0F;
+  heap8[19] = 0xAA;
+  heap8[20] = 0xCD;
+  heap8[21] = 0x12;
+  heap8[22] = 0xFF;
+  heap8[23] = 0x87;
+  heap8[24] = heap8[16];
+  heap8[25] = heap8[17];
+  heap8[26] = heap8[18];
+  heap8[27] = heap8[19];
+  heap8[28] = heap8[20];
+  heap8[29] = heap8[21];
+  heap8[30] = heap8[22];
+  heap8[31] = heap8[23];
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldr q0, [x0]
+    ldr q1, [x0, #16]
+    add v2.16b, v1.16b, v0.16b
+    add v3.8b, v1.8b, v0.8b
+  )");
+  CHECK_NEON(2, uint8_t,
+             {0, 0, 0xFF, 0xFF, 0x78, 0x01, 0xFE, 0xD9, 0, 0, 0xFF, 0xFF, 0x78,
+              0x01, 0xFE, 0xD9});
+  CHECK_NEON(
+      3, uint8_t,
+      {0, 0, 0xFF, 0xFF, 0x78, 0x01, 0xFE, 0xD9, 0, 0, 0, 0, 0, 0, 0, 0});
+
+  // 16-bit vector (8h)
+  initialHeapData_.resize(32);
+  uint16_t* heap16 = reinterpret_cast<uint16_t*>(initialHeapData_.data());
+  heap16[0] = 0xDEAD;
+  heap16[1] = 0xBEEF;
+  heap16[2] = 0xF0F0;
+  heap16[3] = 0xFFFF;
+  heap16[4] = 0;
+  heap16[5] = 0x1234;
+  heap16[6] = 0x5678;
+  heap16[7] = 0x5555;
+
+  heap16[8] = 0xBEEF;
+  heap16[9] = 0xDEAD;
+  heap16[10] = 0x0F0F;
+  heap16[11] = 0x0001;
+  heap16[12] = 0;
+  heap16[13] = 0x1234;
+  heap16[14] = 0x5678;
+  heap16[15] = 0xAAAA;
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldr q0, [x0]
+    ldr q1, [x0, #16]
+    add v2.8h, v1.8h, v0.8h
+  )");
+  CHECK_NEON(2, uint16_t,
+             {0x9D9C, 0x9D9C, 0xFFFF, 0, 0, 0x2468, 0xACF0, 0xFFFF});
+
+  // 16-bit vector (4h)
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldr q0, [x0]
+    ldr q1, [x0, #8]
+    ldr q2, [x0, #16]
+    ldr q3, [x0, #24]
+    add v4.4h, v0.4h, v2.4h
+    add v5.4h, v1.4h, v3.4h
+  )");
+  CHECK_NEON(4, uint16_t, {0x9D9C, 0x9D9C, 0xFFFF, 0, 0, 0, 0, 0});
+  CHECK_NEON(5, uint16_t, {0, 0x2468, 0xACF0, 0xFFFF, 0, 0, 0, 0});
+
+  // 32-bit vector (4s)
   initialHeapData_.resize(32);
   uint32_t* heap32 = reinterpret_cast<uint32_t*>(initialHeapData_.data());
   heap32[0] = 0xDEADBEEF;

--- a/test/regression/aarch64/instructions/neon.cc
+++ b/test/regression/aarch64/instructions/neon.cc
@@ -2445,15 +2445,15 @@ TEST_P(InstNeon, sub) {
 TEST_P(InstNeon, ushll) {
   // ushll half precision to single precision
   initialHeapData_.resize(32);
-  uint16_t* heap = reinterpret_cast<uint16_t*>(initialHeapData_.data());
-  heap[0] = 31;
-  heap[1] = 333;
-  heap[2] = (UINT16_MAX);
-  heap[3] = 7;
-  heap[4] = 42;
-  heap[5] = 1u << 13;
-  heap[6] = 702;
-  heap[7] = 0;
+  uint16_t* heap16 = reinterpret_cast<uint16_t*>(initialHeapData_.data());
+  heap16[0] = 31;
+  heap16[1] = 333;
+  heap16[2] = (UINT16_MAX);
+  heap16[3] = 7;
+  heap16[4] = 42;
+  heap16[5] = 1u << 13;
+  heap16[6] = 702;
+  heap16[7] = 0;
 
   RUN_AARCH64(R"(
     # Get heap address
@@ -2465,11 +2465,18 @@ TEST_P(InstNeon, ushll) {
     ldr q1, [x0, #8]
     ushll v2.4s, v0.4h, #0
     ushll v3.4s, v1.4h, #2
+    ushll v4.4s, v0.4h, #15
   )");
   CHECK_NEON(2, uint32_t, {31, 333, (UINT16_MAX), 7});
   CHECK_NEON(3, uint32_t, {168, 1u << 15, 2808, 0});
+  CHECK_NEON(4, uint32_t, {31 << 15, 333 << 15, (UINT16_MAX) << 15, 7 << 15});
 
   // ushll2 half precision to single precision
+  heap16[4] = 0;
+  heap16[5] = (UINT16_MAX);
+  heap16[6] = 1u << 13;
+  heap16[7] = 27;
+
   RUN_AARCH64(R"(
     # Get heap address
     mov x0, 0
@@ -2482,29 +2489,29 @@ TEST_P(InstNeon, ushll) {
     ushll2 v2.4s, v0.8h, #8
     ushll2 v3.4s, v0.8h, #15
   )");
-  CHECK_NEON(1, uint32_t, {42, 1u << 13, 702, 0});
-  CHECK_NEON(2, uint32_t, {10752, 0, 48640, 0});
-  CHECK_NEON(3, uint32_t, {0, 0, 0, 0});
+  CHECK_NEON(1, uint32_t, {0, (UINT16_MAX), 1u << 13, 27});
+  CHECK_NEON(2, uint32_t, {0, (UINT16_MAX) << 8, 1u << 21, 27 << 8});
+  CHECK_NEON(3, uint32_t, {0, (UINT16_MAX) << 15, 1u << 28, 27 << 15});
 
   // ushll byte to half precision
   initialHeapData_.resize(16);
-  uint8_t* heap2 = reinterpret_cast<uint8_t*>(initialHeapData_.data());
-  heap2[0] = 0x7F;
-  heap2[1] = (UINT8_MAX);
-  heap2[2] = 0xAA;
-  heap2[3] = 0x80;
-  heap2[4] = 0;
-  heap2[5] = 0xbc;
-  heap2[6] = 0xde;
-  heap2[7] = 0xf0;
-  heap2[8] = 0x11;
-  heap2[9] = 0x22;
-  heap2[10] = 0x33;
-  heap2[11] = 0x44;
-  heap2[12] = 0x55;
-  heap2[13] = 0x66;
-  heap2[14] = 0x77;
-  heap2[15] = 0;
+  uint8_t* heap8 = reinterpret_cast<uint8_t*>(initialHeapData_.data());
+  heap8[0] = 0x7F;
+  heap8[1] = (UINT8_MAX);
+  heap8[2] = 0xAA;
+  heap8[3] = 0x80;
+  heap8[4] = 0;
+  heap8[5] = 0xbc;
+  heap8[6] = 0xde;
+  heap8[7] = 0xf0;
+  heap8[8] = 0x11;
+  heap8[9] = 0x22;
+  heap8[10] = 0x33;
+  heap8[11] = 0x44;
+  heap8[12] = 0x55;
+  heap8[13] = 0x66;
+  heap8[14] = 0x77;
+  heap8[15] = 0;
 
   RUN_AARCH64(R"(
     # Get heap address
@@ -2519,10 +2526,22 @@ TEST_P(InstNeon, ushll) {
     ushll v4.8h, v0.8b, #7
   )");
   CHECK_NEON(2, uint16_t, {0x7F, (UINT8_MAX), 0xAA, 0x80, 0, 0xbc, 0xde, 0xf0});
-  CHECK_NEON(3, uint16_t, {0xF0, 0xF0, 0xA0, 0, 0, 0xC0, 0xE0, 0});
-  CHECK_NEON(4, uint16_t, {0x80, 0x80, 0, 0, 0, 0, 0, 0});
+  CHECK_NEON(3, uint16_t,
+             {0x7F << 4, (UINT8_MAX) << 4, 0xAA << 4, 0x80 << 4, 0, 0xbc << 4,
+              0xde << 4, 0xf0 << 4});
+  CHECK_NEON(4, uint16_t,
+             {0x7F << 7, (UINT8_MAX) << 7, 0xAA << 7, 0x80 << 7, 0, 0xbc << 7,
+              0xde << 7, 0xf0 << 7});
 
   // ushll2 byte to half precision
+  heap8[8] = heap8[0];
+  heap8[9] = heap8[1];
+  heap8[10] = heap8[2];
+  heap8[11] = heap8[3];
+  heap8[12] = heap8[4];
+  heap8[13] = heap8[5];
+  heap8[14] = heap8[6];
+  heap8[15] = heap8[7];
   RUN_AARCH64(R"(
     # Get heap address
     mov x0, #0
@@ -2535,9 +2554,13 @@ TEST_P(InstNeon, ushll) {
     ushll2 v3.8h, v0.16b, #4
     ushll2 v4.8h, v0.16b, #7
   )");
-  CHECK_NEON(2, uint16_t, {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0});
-  CHECK_NEON(3, uint16_t, {0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0});
-  CHECK_NEON(4, uint16_t, {0x80, 0, 0x80, 0, 0x80, 0, 0x80, 0});
+  CHECK_NEON(2, uint16_t, {0x7F, (UINT8_MAX), 0xAA, 0x80, 0, 0xbc, 0xde, 0xf0});
+  CHECK_NEON(3, uint16_t,
+             {0x7F << 4, (UINT8_MAX) << 4, 0xAA << 4, 0x80 << 4, 0, 0xbc << 4,
+              0xde << 4, 0xf0 << 4});
+  CHECK_NEON(4, uint16_t,
+             {0x7F << 7, (UINT8_MAX) << 7, 0xAA << 7, 0x80 << 7, 0, 0xbc << 7,
+              0xde << 7, 0xf0 << 7});
 }
 
 TEST_P(InstNeon, xtn) {

--- a/test/regression/aarch64/instructions/store.cc
+++ b/test/regression/aarch64/instructions/store.cc
@@ -5,6 +5,7 @@ namespace {
 using InstStore = AArch64RegressionTest;
 
 TEST_P(InstStore, stlr) {
+  // stlrb
   RUN_AARCH64(R"(
     mov w0, 0xAB
     mov w1, 0x12
@@ -24,6 +25,33 @@ TEST_P(InstStore, stlr) {
   EXPECT_EQ(getMemoryValue<uint8_t>(process_->getStackPointer() - 3), 0x12);
   EXPECT_EQ(getMemoryValue<uint8_t>(process_->getStackPointer() - 2), 0xCD);
   EXPECT_EQ(getMemoryValue<uint8_t>(process_->getStackPointer() - 1), 0x34);
+
+  // stlr
+  RUN_AARCH64(R"(
+    mov x0, xzr
+    sub x0, x0, #1
+    mov x1, #0xBEEF
+    mov w2, wzr
+    sub w2, w2, #1
+    mov w3, #0xBABA
+
+    sub sp, sp, #24
+    stlr x0, [sp]
+    add sp, sp, #8
+    stlr x1, [sp]
+    add sp, sp, #8
+    stlr w2, [sp]
+    add sp, sp, #4
+    stlr w3, [sp]
+    add sp, sp, #4
+  )");
+
+  EXPECT_EQ(getMemoryValue<uint64_t>(process_->getStackPointer() - 24),
+            0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(getMemoryValue<uint64_t>(process_->getStackPointer() - 16), 0xBEEF);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 8),
+            0xFFFFFFFF);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 4), 0xBABA);
 }
 
 TEST_P(InstStore, strb) {


### PR DESCRIPTION
This branch adds more instructions to support OpenMP enabled minifmm.
Currently, GCC and Armclang compiled `fmm.omp-for` can be fully executed.

When SimEng runs Armclang compiled version of `fmm.omp-for`, a bug was found.
It made SimEng to stuck in infinite loop.
This bug is fixed at commit [`19b4a5f`](https://github.com/UoB-HPC/SimEng/pull/192/commits/19b4a5fa9b866981c5a210a96b32cbd96b640942)
To run Armclang version without issues, it will be ideal to merge PR [`Bug fixes #192`](https://github.com/UoB-HPC/SimEng/pull/192) before merging this PR.