### PR TITLE
Minifmm support

### DIFF
--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -277,7 +277,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses({{operands[1].get<uint64_t>(), 4}});
       break;
     }
-    case Opcode::AArch64_LDARB: {  // ldar wt, [<xn|sp>]
+    case Opcode::AArch64_LDARB: {  // ldarb wt, [xn]
       setMemoryAddresses({{operands[0].get<uint64_t>(), 1}});
       break;
     }

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -285,6 +285,10 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       setMemoryAddresses({{operands[0].get<uint64_t>(), 4}});
       break;
     }
+    case Opcode::AArch64_LDARX: {  // ldar xt, [xn]
+      setMemoryAddresses({{operands[0].get<uint64_t>(), 8}});
+      break;
+    }
     case Opcode::AArch64_LDAXRW: {  // ldaxr wd, [xn]
       setMemoryAddresses({{operands[0].get<uint64_t>(), 4}});
       break;
@@ -1071,6 +1075,10 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_STLRW: {  // stlr wt, [xn]
       setMemoryAddresses({{operands[1].get<uint64_t>(), 4}});
+      break;
+    }
+    case Opcode::AArch64_STLRX: {  // stlr xt, [xn]
+      setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
       break;
     }
     case Opcode::AArch64_STLXRW: {  // stlxr ws, wt, [xn]

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -3808,6 +3808,10 @@ void Instruction::execute() {
       results[0] = memoryData[0].zeroExtend(4, 8);
       break;
     }
+    case Opcode::AArch64_LDARX: {  // ldar xt, [xn]
+      results[0] = memoryData[0];
+      break;
+    }
     case Opcode::AArch64_LDAXRW: {  // ldaxr wd, [xn]
       results[0] = memoryData[0].zeroExtend(4, 8);
       break;
@@ -5373,6 +5377,8 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_STLRB:  // stlrb wt, [xn]
+      [[fallthrough]];
+    case Opcode::AArch64_STLRX:  // stlr xt, [xn]
       [[fallthrough]];
     case Opcode::AArch64_STLRW: {  // stlr wt, [xn]
       memoryData[0] = operands[0];

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -3800,7 +3800,7 @@ void Instruction::execute() {
       results[2] = operands[2].get<uint64_t>() + offset;
       break;
     }
-    case Opcode::AArch64_LDARB: {  // LDARB wt, [<xn|sp>]
+    case Opcode::AArch64_LDARB: {  // ldarb wt, [xn]
       results[0] = memoryData[0].zeroExtend(1, 8);
       break;
     }

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -6165,12 +6165,42 @@ void Instruction::execute() {
       results[0] = mulhi(x, y);
       break;
     }
+    case Opcode::AArch64_USHLLv16i8_shift: {  // ushll2 vd.8h, vn.16b, #imm
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      int64_t shift = metadata.operands[2].imm;
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = (n[i + 8] << shift) & 0xff;
+      }
+      results[0] = {out, 256};
+      break;
+    }
     case Opcode::AArch64_USHLLv4i16_shift: {  // ushll vd.4s, vn.4h, #imm
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
       const uint64_t shift = metadata.operands[2].imm;
       uint32_t out[4] = {0};
       for (int i = 0; i < 4; i++) {
         out[i] = n[i] << shift;
+      }
+      results[0] = {out, 256};
+      break;
+    }
+    case Opcode::AArch64_USHLLv8i16_shift: {  // ushll2 vd.4s, vn.8h, #imm
+      const uint16_t* n = operands[0].getAsVector<uint16_t>();
+      int64_t shift = metadata.operands[2].imm;
+      uint32_t out[4] = {0};
+      for (int i = 0; i < 4; i++) {
+        out[i] = (n[i + 4] << shift) & 0xffff;
+      }
+      results[0] = {out, 256};
+      break;
+    }
+    case Opcode::AArch64_USHLLv8i8_shift: {  // ushll vd.8h, vn.8b, #imm
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      int64_t shift = metadata.operands[2].imm;
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = (n[i] << shift) & 0xff;
       }
       results[0] = {out, 256};
       break;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -204,6 +204,16 @@ void Instruction::execute() {
 
   executed_ = true;
   switch (metadata.opcode) {
+    case Opcode::AArch64_ADDv16i8: {  // add vd.16b, vn.16b, vm.16b
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      const uint8_t* m = operands[1].getAsVector<uint8_t>();
+      uint8_t out[16] = {0};
+      for (int i = 0; i < 16; i++) {
+        out[i] = static_cast<uint8_t>(n[i] + m[i]);
+      }
+      results[0] = {out, 256};
+      break;
+    }
     case Opcode::AArch64_ADDv1i64: {  // add dd, dn, dm
       const uint64_t n = operands[0].get<uint64_t>();
       const uint64_t m = operands[1].get<uint64_t>();
@@ -223,6 +233,16 @@ void Instruction::execute() {
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
       uint64_t out[2] = {static_cast<uint64_t>(n[0] + m[0]),
                          static_cast<uint64_t>(n[1] + m[1])};
+      results[0] = {out, 256};
+      break;
+    }
+    case Opcode::AArch64_ADDv4i16: {  // add vd.4h, vn.4h, vm.4h
+      const uint16_t* n = operands[0].getAsVector<uint16_t>();
+      const uint16_t* m = operands[1].getAsVector<uint16_t>();
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 4; i++) {
+        out[i] = static_cast<uint16_t>(n[i] + m[i]);
+      }
       results[0] = {out, 256};
       break;
     }
@@ -286,6 +306,26 @@ void Instruction::execute() {
         out[i] = n[i] + m[i];
       }
       results[0] = out;
+      break;
+    }
+    case Opcode::AArch64_ADDv8i16: {  // add vd.8h, vn.8h, vm.8h
+      const uint16_t* n = operands[0].getAsVector<uint16_t>();
+      const uint16_t* m = operands[1].getAsVector<uint16_t>();
+      uint16_t out[8] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = static_cast<uint16_t>(n[i] + m[i]);
+      }
+      results[0] = {out, 256};
+      break;
+    }
+    case Opcode::AArch64_ADDv8i8: {  // add vd.8b, vn.8b, vm.8b
+      const uint8_t* n = operands[0].getAsVector<uint8_t>();
+      const uint8_t* m = operands[1].getAsVector<uint8_t>();
+      uint8_t out[16] = {0};
+      for (int i = 0; i < 8; i++) {
+        out[i] = static_cast<uint8_t>(n[i] + m[i]);
+      }
+      results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_ADCXr: {  // adc xd, xn, xm

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -6207,10 +6207,10 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_USHLLv16i8_shift: {  // ushll2 vd.8h, vn.16b, #imm
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
-      int64_t shift = metadata.operands[2].imm;
+      const uint64_t shift = metadata.operands[2].imm;
       uint16_t out[8] = {0};
       for (int i = 0; i < 8; i++) {
-        out[i] = (n[i + 8] << shift) & 0xff;
+        out[i] = n[i + 8] << shift;
       }
       results[0] = {out, 256};
       break;
@@ -6227,20 +6227,20 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_USHLLv8i16_shift: {  // ushll2 vd.4s, vn.8h, #imm
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
-      int64_t shift = metadata.operands[2].imm;
+      const uint64_t shift = metadata.operands[2].imm;
       uint32_t out[4] = {0};
       for (int i = 0; i < 4; i++) {
-        out[i] = (n[i + 4] << shift) & 0xffff;
+        out[i] = n[i + 4] << shift;
       }
       results[0] = {out, 256};
       break;
     }
     case Opcode::AArch64_USHLLv8i8_shift: {  // ushll vd.8h, vn.8b, #imm
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
-      int64_t shift = metadata.operands[2].imm;
+      const uint64_t shift = metadata.operands[2].imm;
       uint16_t out[8] = {0};
       for (int i = 0; i < 8; i++) {
-        out[i] = (n[i] << shift) & 0xff;
+        out[i] = n[i] << shift;
       }
       results[0] = {out, 256};
       break;

--- a/test/regression/aarch64/instructions/load.cc
+++ b/test/regression/aarch64/instructions/load.cc
@@ -345,6 +345,34 @@ TEST_P(InstLoad, ldarb) {
   EXPECT_EQ(getGeneralRegister<uint32_t>(7), 64);
 }
 
+TEST_P(InstLoad, ldrb) {
+  initialHeapData_.resize(8);
+  uint32_t* heap = reinterpret_cast<uint32_t*>(initialHeapData_.data());
+  heap[0] = 0xDEADBEEF;
+  heap[1] = 0x12345678;
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+    ldrb w1, [x0], 1
+    ldrb w2, [x0]
+    ldrb w3, [x0, 1]!
+    ldrb w4, [x0, 2]
+    mov w5, 1
+    ldrb w6, [x0, w5, uxtw]
+    mov w5, 3
+    ldrb w7, [x0, x5]
+  )");
+  EXPECT_EQ(getGeneralRegister<uint32_t>(1), 0xEF);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 0xBE);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(3), 0xAD);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(4), 0x78);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(6), 0xDE);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(7), 0x56);
+}
+
 TEST_P(InstLoad, ldrd) {
   initialHeapData_.resize(32);
   double* heap = reinterpret_cast<double*>(initialHeapData_.data());

--- a/test/regression/aarch64/instructions/load.cc
+++ b/test/regression/aarch64/instructions/load.cc
@@ -265,6 +265,24 @@ TEST_P(InstLoad, ldadd) {
   EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 928), 128);
 }
 
+TEST_P(InstLoad, ldar) {
+  initialHeapData_.resize(8);
+  uint64_t* heap = reinterpret_cast<uint64_t*>(initialHeapData_.data());
+  heap[0] = 0xDEADBEEF12345678;
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldar x1, [x0]
+    ldar w2, [x0]
+  )");
+  EXPECT_EQ(getGeneralRegister<uint64_t>(1), 0xDEADBEEF12345678);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 0x12345678);
+}
+
 TEST_P(InstLoad, ldarb) {
   initialHeapData_.resize(8);
   uint32_t* heap = reinterpret_cast<uint32_t*>(initialHeapData_.data());
@@ -276,7 +294,6 @@ TEST_P(InstLoad, ldarb) {
     mov x0, 0
     mov x8, 214
     svc #0
-
     ldarb w1, [x0]
     add x0, x0, #1
     ldarb w2, [x0]
@@ -308,14 +325,11 @@ TEST_P(InstLoad, ldarb) {
     mov w1, #32
     mov w2, #48
     mov w3, #64
-
     str w0, [sp], #32
     str w1, [sp], #32
     str w2, [sp], #32
     str w3, [sp], #32
-
     sub sp, sp, #128
-
     ldarb w4, [sp]
     add sp, sp, #32
     ldarb w5, [sp]
@@ -329,36 +343,6 @@ TEST_P(InstLoad, ldarb) {
   EXPECT_EQ(getGeneralRegister<uint32_t>(5), 32);
   EXPECT_EQ(getGeneralRegister<uint32_t>(6), 48);
   EXPECT_EQ(getGeneralRegister<uint32_t>(7), 64);
-}
-
-TEST_P(InstLoad, ldrb) {
-  initialHeapData_.resize(8);
-  uint32_t* heap = reinterpret_cast<uint32_t*>(initialHeapData_.data());
-  heap[0] = 0xDEADBEEF;
-  heap[1] = 0x12345678;
-
-  RUN_AARCH64(R"(
-    # Get heap address
-    mov x0, 0
-    mov x8, 214
-    svc #0
-
-    ldrb w1, [x0], 1
-    ldrb w2, [x0]
-    ldrb w3, [x0, 1]!
-    ldrb w4, [x0, 2]
-
-    mov w5, 1
-    ldrb w6, [x0, w5, uxtw]
-    mov w5, 3
-    ldrb w7, [x0, x5]
-  )");
-  EXPECT_EQ(getGeneralRegister<uint32_t>(1), 0xEF);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 0xBE);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(3), 0xAD);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(4), 0x78);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(6), 0xDE);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(7), 0x56);
 }
 
 TEST_P(InstLoad, ldrd) {

--- a/test/regression/aarch64/instructions/neon.cc
+++ b/test/regression/aarch64/instructions/neon.cc
@@ -7,7 +7,113 @@ namespace {
 using InstNeon = AArch64RegressionTest;
 
 TEST_P(InstNeon, add) {
-  // Quad 32-bit : add vd.4s, vn.4s, vm.4s
+  // 8-bit vector
+  initialHeapData_.resize(32);
+  uint8_t* heap8 = reinterpret_cast<uint8_t*>(initialHeapData_.data());
+  heap8[0] = 0;
+  heap8[1] = 0xFF;
+  heap8[2] = 0xF0;
+  heap8[3] = 0x55;
+  heap8[4] = 0xAB;
+  heap8[5] = 0xEF;
+  heap8[6] = 0xFF;
+  heap8[7] = 0x52;
+  heap8[8] = heap8[0];
+  heap8[9] = heap8[1];
+  heap8[10] = heap8[2];
+  heap8[11] = heap8[3];
+  heap8[12] = heap8[4];
+  heap8[13] = heap8[5];
+  heap8[14] = heap8[6];
+  heap8[15] = heap8[7];
+
+  heap8[16] = 0;
+  heap8[17] = 0x01;
+  heap8[18] = 0x0F;
+  heap8[19] = 0xAA;
+  heap8[20] = 0xCD;
+  heap8[21] = 0x12;
+  heap8[22] = 0xFF;
+  heap8[23] = 0x87;
+  heap8[24] = heap8[16];
+  heap8[25] = heap8[17];
+  heap8[26] = heap8[18];
+  heap8[27] = heap8[19];
+  heap8[28] = heap8[20];
+  heap8[29] = heap8[21];
+  heap8[30] = heap8[22];
+  heap8[31] = heap8[23];
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldr q0, [x0]
+    ldr q1, [x0, #16]
+    add v2.16b, v1.16b, v0.16b
+    add v3.8b, v1.8b, v0.8b
+  )");
+  CHECK_NEON(2, uint8_t,
+             {0, 0, 0xFF, 0xFF, 0x78, 0x01, 0xFE, 0xD9, 0, 0, 0xFF, 0xFF, 0x78,
+              0x01, 0xFE, 0xD9});
+  CHECK_NEON(
+      3, uint8_t,
+      {0, 0, 0xFF, 0xFF, 0x78, 0x01, 0xFE, 0xD9, 0, 0, 0, 0, 0, 0, 0, 0});
+
+  // 16-bit vector (8h)
+  initialHeapData_.resize(32);
+  uint16_t* heap16 = reinterpret_cast<uint16_t*>(initialHeapData_.data());
+  heap16[0] = 0xDEAD;
+  heap16[1] = 0xBEEF;
+  heap16[2] = 0xF0F0;
+  heap16[3] = 0xFFFF;
+  heap16[4] = 0;
+  heap16[5] = 0x1234;
+  heap16[6] = 0x5678;
+  heap16[7] = 0x5555;
+
+  heap16[8] = 0xBEEF;
+  heap16[9] = 0xDEAD;
+  heap16[10] = 0x0F0F;
+  heap16[11] = 0x0001;
+  heap16[12] = 0;
+  heap16[13] = 0x1234;
+  heap16[14] = 0x5678;
+  heap16[15] = 0xAAAA;
+
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldr q0, [x0]
+    ldr q1, [x0, #16]
+    add v2.8h, v1.8h, v0.8h
+  )");
+  CHECK_NEON(2, uint16_t,
+             {0x9D9C, 0x9D9C, 0xFFFF, 0, 0, 0x2468, 0xACF0, 0xFFFF});
+
+  // 16-bit vector (4h)
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldr q0, [x0]
+    ldr q1, [x0, #8]
+    ldr q2, [x0, #16]
+    ldr q3, [x0, #24]
+    add v4.4h, v0.4h, v2.4h
+    add v5.4h, v1.4h, v3.4h
+  )");
+  CHECK_NEON(4, uint16_t, {0x9D9C, 0x9D9C, 0xFFFF, 0, 0, 0, 0, 0});
+  CHECK_NEON(5, uint16_t, {0, 0x2468, 0xACF0, 0xFFFF, 0, 0, 0, 0});
+
+  // 32-bit vector (4s)
   initialHeapData_.resize(32);
   uint32_t* heap32 = reinterpret_cast<uint32_t*>(initialHeapData_.data());
   heap32[0] = 0xDEADBEEF;
@@ -33,7 +139,7 @@ TEST_P(InstNeon, add) {
              {0xDEADBEEFu + 0xF0F0F0F0u, 0x01234567u + 0x0F0F0F0F0u,
               0x89ABCDEFu + 0xDEADBEEFu, 0x0F0F0F0Fu + 0xDEADBEEFu});
 
-  // Double 32-bit : add vd.2s, vn.2s, vm.2s
+  // 32-bit vector (2s)
   RUN_AARCH64(R"(
     # Get heap address
     mov x0, 0
@@ -41,13 +147,13 @@ TEST_P(InstNeon, add) {
     svc #0
 
     ldr q0, [x0]
-    ldr q1, [x0, #8]
+    ldr q1, [x0, #16]
     add v2.2s, v0.2s, v1.2s
   )");
   CHECK_NEON(2, uint32_t,
-             {0xDEADBEEFu + 0x89ABCDEFu, 0x01234567u + 0x0F0F0F0Fu, 0u, 0u});
+             {0xDEADBEEFu + 0xF0F0F0F0u, 0x01234567u + 0x0F0F0F0F0u, 0, 0});
 
-  // Single 64-bit : add dd, dn, dm
+  // 64-bit scalar
   initialHeapData_.resize(32);
   uint64_t* heap64 = reinterpret_cast<uint64_t*>(initialHeapData_.data());
   heap64[0] = 0xDEADBEEF;
@@ -70,7 +176,7 @@ TEST_P(InstNeon, add) {
   CHECK_NEON(4, uint64_t, {0x168598CDE});
   CHECK_NEON(5, uint64_t, {0x10325476});
 
-  // Double 64-bit : add vd.2d, vn.2d, vm.2d
+  // 64-bit vector
   RUN_AARCH64(R"(
     # Get heap address
     mov x0, 0
@@ -79,10 +185,10 @@ TEST_P(InstNeon, add) {
 
     ldr q0, [x0]
     ldr q1, [x0, #16]
-    add v2.2d, v0.2d, v1.2d
+    
+    add v2.2d, v1.2d, v0.2d
   )");
-  CHECK_NEON(2, uint64_t,
-             {0xDEADBEEFul + 0x89ABCDEFul, 0x01234567ul + 0x0F0F0F0Ful});
+  CHECK_NEON(2, uint64_t, {0x168598CDE, 0x10325476});
 }
 
 TEST_P(InstNeon, addp) {

--- a/test/regression/aarch64/instructions/store.cc
+++ b/test/regression/aarch64/instructions/store.cc
@@ -5,6 +5,7 @@ namespace {
 using InstStore = AArch64RegressionTest;
 
 TEST_P(InstStore, stlr) {
+  // stlrb
   RUN_AARCH64(R"(
     mov w0, 0xAB
     mov w1, 0x12
@@ -24,6 +25,33 @@ TEST_P(InstStore, stlr) {
   EXPECT_EQ(getMemoryValue<uint8_t>(process_->getStackPointer() - 3), 0x12);
   EXPECT_EQ(getMemoryValue<uint8_t>(process_->getStackPointer() - 2), 0xCD);
   EXPECT_EQ(getMemoryValue<uint8_t>(process_->getStackPointer() - 1), 0x34);
+
+  // stlr
+  RUN_AARCH64(R"(
+    mov x0, xzr
+    sub x0, x0, #1
+    mov x1, #0xBEEF
+    mov w2, wzr
+    sub w2, w2, #1
+    mov w3, #0xBABA
+
+    sub sp, sp, #24
+    stlr x0, [sp]
+    add sp, sp, #8
+    stlr x1, [sp]
+    add sp, sp, #8
+    stlr w2, [sp]
+    add sp, sp, #4
+    stlr w3, [sp]
+    add sp, sp, #4
+  )");
+
+  EXPECT_EQ(getMemoryValue<uint64_t>(process_->getStackPointer() - 24),
+            0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(getMemoryValue<uint64_t>(process_->getStackPointer() - 16), 0xBEEF);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 8),
+            0xFFFFFFFF);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 4), 0xBABA);
 }
 
 TEST_P(InstStore, strb) {


### PR DESCRIPTION
This branch adds more instructions to support OpenMP enabled minifmm.
Currently, GCC and Armclang compiled fmm.omp-for can be fully executed.

When SimEng runs Armclang compiled version of fmm.omp-for, a bug was found.
It made SimEng to stuck in infinite loop.
To run Armclang version without issues, it will be ideal to merge PR Bug fixes #192 before merging this PR.