### PR TITLE
Variable SVE vector length

### DIFF
--- a/src/include/simeng/arch/aarch64/Architecture.hh
+++ b/src/include/simeng/arch/aarch64/Architecture.hh
@@ -50,6 +50,9 @@ class Architecture : public arch::Architecture {
   /** Returns the maximum size of a valid instruction in bytes. */
   uint8_t getMaxInstructionSize() const override;
 
+  /** Returns the current vector length set by the provided configuration. */
+  uint64_t getVectorLength() const;
+
  private:
   /** Retrieve an executionInfo object for the requested instruction. If a
    * opcode-based override has been defined for the latency and/or
@@ -82,6 +85,9 @@ class Architecture : public arch::Architecture {
 
   /** A reference to a Linux kernel object to forward syscalls to. */
   kernel::Linux& linux_;
+
+  /** The vector length used by the SVE extension in bits. */
+  uint64_t VL_;
 };
 
 }  // namespace aarch64

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -44,7 +44,8 @@ void ModelConfig::validate() {
   std::string root = "";
   // Core
   root = "Core";
-  subFields = {"Simulation-Mode", "Clock-Frequency", "Fetch-Block-Size"};
+  subFields = {"Simulation-Mode", "Clock-Frequency", "Fetch-Block-Size",
+               "Vector-Length"};
   nodeChecker<std::string>(configFile_[root][subFields[0]], subFields[0],
                            {"emulation", "inorderpipelined", "outoforder"},
                            ExpectedValue::String);
@@ -54,7 +55,7 @@ void ModelConfig::validate() {
                             std::make_pair(4, UINT16_MAX),
                             ExpectedValue::UInteger)) {
     uint16_t block_size = configFile_[root][subFields[2]].as<uint16_t>();
-    // Ensure ftech block size is a power of 2
+    // Ensure fetch block size is a power of 2
     if ((block_size & (block_size - 1)) == 0) {
       uint8_t alignment_bits = log2(block_size);
       configFile_[root]["Fetch-Block-Alignment-Bits"] =
@@ -63,6 +64,10 @@ void ModelConfig::validate() {
       invalid_ << "\t- Fetch-Block-Size must be a power of 2\n";
     }
   }
+  nodeChecker<uint16_t>(configFile_[root][subFields[3]], subFields[3],
+                        {128, 256, 384, 512, 640, 768, 896, 1024, 1152, 1280,
+                         1408, 1536, 1664, 1792, 1920, 2048},
+                        ExpectedValue::UInteger, 512);
   subFields.clear();
 
   // Branch-Predictor

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -13,7 +13,7 @@ std::unordered_map<uint32_t, Instruction> Architecture::decodeCache;
 std::forward_list<InstructionMetadata> Architecture::metadataCache;
 
 Architecture::Architecture(kernel::Linux& kernel, YAML::Node config)
-    : linux_(kernel) {
+    : linux_(kernel), VL_(config["Core"]["Vector-Length"].as<uint64_t>()) {
   if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &capstoneHandle) != CS_ERR_OK) {
     std::cerr << "Could not create capstone handle" << std::endl;
     exit(1);
@@ -275,6 +275,8 @@ ProcessStateChange Architecture::getUpdateState() const {
 }
 
 uint8_t Architecture::getMaxInstructionSize() const { return 4; }
+
+uint64_t Architecture::getVectorLength() const { return VL_; }
 
 }  // namespace aarch64
 }  // namespace arch

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -159,10 +159,21 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       break;
     case Opcode::AArch64_DECD_XPiI:
       [[fallthrough]];
-    case Opcode::AArch64_DECB_XPiI:
+    case Opcode::AArch64_DECB_XPiI: {
       // lacking access specifiers for destination
       operands[0].access = CS_AC_READ | CS_AC_WRITE;
+      std::string str(operandStr);
+      if (str.length() < 4) {
+        operandCount = 2;
+        operands[1].type = ARM64_OP_IMM;
+        operands[1].imm = 1;
+        operands[1].access = CS_AC_READ;
+        operands[1].shift = {ARM64_SFT_INVALID, 0};
+        operands[1].ext = ARM64_EXT_INVALID;
+        operands[1].vector_index = -1;
+      }
       break;
+    }
     case Opcode::AArch64_EOR_PPzPP: {
       operands[0].access = CS_AC_WRITE;
       operands[1].access = CS_AC_READ;
@@ -224,6 +235,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[2].access = CS_AC_READ;
       operands[3].access = CS_AC_READ;
       break;
+    case Opcode::AArch64_ADDPL_XXI:
+      [[fallthrough]];
     case Opcode::AArch64_ADDVL_XXI:
       [[fallthrough]];
     case Opcode::AArch64_MOVPRFX_ZPzZ_D:
@@ -420,6 +433,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
     case Opcode::AArch64_MUL_ZPmZ_H:
       [[fallthrough]];
     case Opcode::AArch64_MUL_ZPmZ_S:
+      [[fallthrough]];
+    case Opcode::AArch64_ORR_PPzPP:
       [[fallthrough]];
     case Opcode::AArch64_SEL_ZPZZ_D:
       [[fallthrough]];

--- a/src/lib/arch/aarch64/InstructionMetadata.hh
+++ b/src/lib/arch/aarch64/InstructionMetadata.hh
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "simeng/arch/aarch64/Architecture.hh"
 #include "simeng/arch/aarch64/Instruction.hh"
 
 namespace simeng {

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -10,6 +10,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
   assert((isLoad() || isStore()) &&
          "generateAddresses called on non-load-or-store instruction");
 
+  uint16_t VL_bits = architecture.getVectorLength();
   switch (metadata.opcode) {
     case Opcode::AArch64_CASALW: {  // casal ws, wt, [xn|sp]
       setMemoryAddresses({{operands[2].get<uint64_t>(), 4}});
@@ -132,8 +133,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_LD1B: {  // ld1b {zt.b}, pg/z, [xn, xm]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 8;
+      const uint16_t partition_num = VL_bits / 8;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset = operands[2].get<uint64_t>();

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -142,7 +142,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           addresses.push_back({base + (offset + i), 1});
         }
@@ -163,7 +163,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           addresses.push_back({base + ((offset + i) * 8), 8});
         }
@@ -188,7 +188,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       uint64_t addr = base + (offset * partition_num * 8);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           addresses.push_back({addr, 8});
         }
@@ -209,7 +209,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 2));
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           addresses.push_back({base + ((offset + i) * 2), 2});
         }
@@ -230,7 +230,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           addresses.push_back({base + ((offset + i) * 4), 4});
         }
@@ -255,7 +255,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       uint64_t addr = base + (offset * partition_num * 4);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           addresses.push_back({addr, 4});
         }
@@ -716,7 +716,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           addresses.push_back({base + (offset + i), 1});
         }
@@ -736,7 +736,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = base + offset[i];
           addresses.push_back({addr, 1});
@@ -756,7 +756,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = base + offset[i];
           addresses.push_back({addr, 8});
@@ -776,7 +776,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = base + (offset[i] << 3);
           addresses.push_back({addr, 8});
@@ -797,7 +797,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           addresses.push_back({base + ((offset + i) * 8), 8});
         }
@@ -821,7 +821,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       uint64_t addr = base + (offset * partition_num * 8);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           addresses.push_back({addr, 8});
         }
@@ -843,7 +843,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       addresses.reserve(partition_num);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           addresses.push_back({base + ((offset + i) * 4), 4});
         }
@@ -863,7 +863,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           addresses.push_back({base + ((offset + i) * 4), 4});
         }
@@ -887,7 +887,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       uint64_t addr = base + (offset * partition_num * 4);
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           addresses.push_back({addr, 4});
         }
@@ -908,7 +908,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = n[i] + (offset * 4);
           addresses.push_back({addr, 4});
@@ -929,7 +929,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           uint64_t addr = static_cast<uint64_t>(n[i]) + (offset * 4);
           addresses.push_back({addr, 4});
@@ -949,7 +949,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = base + offset[i];
           addresses.push_back({addr, 8});
@@ -970,7 +970,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = base + (offset[i] << 3);
           addresses.push_back({addr, 8});
@@ -991,7 +991,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = n[i] + (offset * 8);
           addresses.push_back({addr, 8});
@@ -1013,7 +1013,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = n[i] + (offset * 4);
           addresses.push_back({addr, 4});
@@ -1034,7 +1034,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       std::vector<MemoryAccessTarget> addresses;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           uint64_t addr = n[i] + (offset * 8);
           addresses.push_back({addr, 8});

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -10,7 +10,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
   assert((isLoad() || isStore()) &&
          "generateAddresses called on non-load-or-store instruction");
 
-  uint16_t VL_bits = architecture.getVectorLength();
+  const uint16_t VL_bits = architecture_.getVectorLength();
   switch (metadata.opcode) {
     case Opcode::AArch64_CASALW: {  // casal ws, wt, [xn|sp]
       setMemoryAddresses({{operands[2].get<uint64_t>(), 4}});
@@ -153,8 +153,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_LD1D: {  // ld1d {zt.d}, pg/z, [xn, xm, lsl #3]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset = operands[2].get<uint64_t>();
@@ -175,8 +174,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     case Opcode::AArch64_LD1D_IMM_REAL: {  // ld1d {zt.d}, pg/z, [xn{, #imm, mul
                                            // vl}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset =
@@ -200,8 +198,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_LD1H: {  // ld1h {zt.h}, pg/z, [xn, xm, lsl #1]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 16;
+      const uint16_t partition_num = VL_bits / 16;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset = operands[2].get<uint64_t>();
@@ -220,8 +217,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_LD1W: {  // ld1w {zt.s}, pg/z, [xn, xm, lsl #2]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 32;
+      const uint16_t partition_num = VL_bits / 32;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset = operands[2].get<uint64_t>();
@@ -242,8 +238,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     case Opcode::AArch64_LD1W_IMM_REAL: {  // ld1w {zt.s}, pg/z, [xn{, #imm, mul
                                            // vl}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 32;
+      const uint16_t partition_num = VL_bits / 32;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset =
@@ -479,7 +474,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_LDR_PXI: {  // ldr pt, [xn{, #imm, mul vl}]
       const uint64_t PL_bits = 64;
-      const uint8_t partition_num = PL_bits / 8;
+      const uint16_t partition_num = PL_bits / 8;
 
       const uint64_t base = operands[0].get<uint64_t>();
       const uint64_t offset =
@@ -498,8 +493,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       break;
     }
     case Opcode::AArch64_LDR_ZXI: {  // ldr zt, [xn{, #imm, mul vl}]
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 8;
+      const uint16_t partition_num = VL_bits / 8;
 
       const uint64_t base = operands[0].get<uint64_t>();
       const uint64_t offset =
@@ -706,8 +700,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_ST1B: {  // st1b {zt.b}, pg, [xn, xm]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 8;
+      const uint16_t partition_num = VL_bits / 8;
 
       const uint64_t base = operands[2].get<uint64_t>();
       const uint64_t offset = operands[3].get<uint64_t>();
@@ -727,7 +720,6 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_SST1B_D: {  // st1b {zd.d}, pg, [xn, zm.d]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[2].get<uint64_t>();
@@ -747,7 +739,6 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_SST1D: {  // st1d {zt.d}, pg, [xn, zm.d]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[2].get<uint64_t>();
@@ -767,7 +758,6 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_SST1D_SCALED: {  // st1d {zt.d}, pg, [xn, zm.d, lsl #3]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[2].get<uint64_t>();
@@ -787,8 +777,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_ST1D: {  // st1d {zt.d}, pg, [xn, xm, lsl #3]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[2].get<uint64_t>();
       const uint64_t offset = operands[3].get<uint64_t>();
@@ -808,8 +797,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_ST1D_IMM: {  // st1d {zt.d}, pg, [xn{, #imm, mul vl}]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[2].get<uint64_t>();
       const uint64_t offset =
@@ -833,8 +821,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_ST1W: {  // st1w {zt.s}, pg, [xn, xm, lsl #2]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 32;
+      const uint16_t partition_num = VL_bits / 32;
 
       const uint64_t base = operands[2].get<uint64_t>();
       const uint64_t offset = operands[3].get<uint64_t>();
@@ -854,8 +841,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_ST1W_D: {  // st1w {zt.d}, pg, [xn, xm, lsl #2]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[2].get<uint64_t>();
       const uint64_t offset = operands[3].get<uint64_t>();
@@ -874,8 +860,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_ST1W_IMM: {  // st1w {zt.s}, pg, [xn{, #imm, mul vl}]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 32;
+      const uint16_t partition_num = VL_bits / 32;
 
       const uint64_t base = operands[2].get<uint64_t>();
       const uint64_t offset =
@@ -898,8 +883,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_SST1W_D_IMM: {  // st1w {zt.d}, pg, [zn.d{, #imm}]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t* n = operands[2].getAsVector<uint64_t>();
       const uint64_t offset =
@@ -919,8 +903,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_SST1W_IMM: {  // st1w {zt.s}, pg, [zn.s{, #imm}]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 32;
+      const uint16_t partition_num = VL_bits / 32;
 
       const uint32_t* n = operands[2].getAsVector<uint32_t>();
       const uint64_t offset = static_cast<uint64_t>(
@@ -940,7 +923,6 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_GLD1D_REAL: {  // ld1d {zt.d}, pg/z, [xn, zm.d]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[1].get<uint64_t>();
@@ -961,7 +943,6 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     case Opcode::AArch64_GLD1D_SCALED_REAL: {  // ld1d {zt.d}, pg/z, [xn, zm.d,
                                                // LSL #3]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t base = operands[1].get<uint64_t>();
@@ -981,8 +962,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_GLD1D_IMM_REAL: {  // ld1d {zd.d}, pg/z, [zn.d{, #imm}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       const uint64_t offset =
@@ -1003,8 +983,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     case Opcode::AArch64_GLD1SW_D_IMM_REAL: {  // ld1sw {zd.d}, pg/z, [zn.d{,
                                                // #imm}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       const uint64_t offset =
@@ -1024,8 +1003,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_SST1D_IMM: {  // st1d {zt.d}, pg, [zn.d{, #imm}]
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 64;
+      const uint16_t partition_num = VL_bits / 64;
 
       const uint64_t* n = operands[2].getAsVector<uint64_t>();
       const uint64_t offset =
@@ -1364,7 +1342,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
     }
     case Opcode::AArch64_STR_PXI: {  // str pt, [xn{, #imm, mul vl}]
       const uint64_t PL_bits = 64;
-      const uint8_t partition_num = PL_bits / 8;
+      const uint16_t partition_num = PL_bits / 8;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset =
@@ -1383,8 +1361,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       break;
     }
     case Opcode::AArch64_STR_ZXI: {  // str zt, [xn{, #imm, mul vl}]
-      const uint64_t VL_bits = 512;
-      const uint8_t partition_num = VL_bits / 8;
+      const uint16_t partition_num = VL_bits / 8;
 
       const uint64_t base = operands[1].get<uint64_t>();
       const uint64_t offset =

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -473,7 +473,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       break;
     }
     case Opcode::AArch64_LDR_PXI: {  // ldr pt, [xn{, #imm, mul vl}]
-      const uint64_t PL_bits = 64;
+      const uint64_t PL_bits = VL_bits / 8;
       const uint16_t partition_num = PL_bits / 8;
 
       const uint64_t base = operands[0].get<uint64_t>();
@@ -1341,7 +1341,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       break;
     }
     case Opcode::AArch64_STR_PXI: {  // str pt, [xn{, #imm, mul vl}]
-      const uint64_t PL_bits = 64;
+      const uint64_t PL_bits = VL_bits / 8;
       const uint16_t partition_num = PL_bits / 8;
 
       const uint64_t base = operands[1].get<uint64_t>();

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -28,7 +28,7 @@ uint8_t getNZCVfromPred(uint64_t* predResult, uint64_t VL_bits, int byteCount) {
   // derives a 1 in the last position of the current predicate. Both
   // dictated by vector length.
   uint8_t C = !(predResult[(int)((VL_bits - 1) / 512)] &
-                1ull << ((VL_bits / 8) - byteCount));
+                1ull << (((VL_bits / 8) - byteCount) % 64));
   for (int i = 0; i < (int)((VL_bits - 1) / 512) + 1; i++) {
     if (predResult[i]) {
       Z = 0;
@@ -223,6 +223,7 @@ void Instruction::execute() {
       canExecute() &&
       "Attempted to execute an instruction before all operands were provided");
 
+  const uint16_t VL_bits = architecture_.getVectorLength();
   executed_ = true;
   switch (metadata.opcode) {
     case Opcode::AArch64_ADDv16i8: {  // add vd.16b, vn.16b, vm.16b
@@ -281,7 +282,6 @@ void Instruction::execute() {
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
       const uint8_t* m = operands[1].getAsVector<uint8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint8_t out[256] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -294,7 +294,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -307,7 +306,6 @@ void Instruction::execute() {
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
       const uint16_t* m = operands[1].getAsVector<uint16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -320,7 +318,6 @@ void Instruction::execute() {
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint32_t* m = operands[1].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -482,10 +479,18 @@ void Instruction::execute() {
       results[1] = result;
       break;
     }
+    case Opcode::AArch64_ADDPL_XXI: {  // addvl xd, xn, #imm
+      auto x = operands[0].get<uint64_t>();
+      auto y = static_cast<int64_t>(metadata.operands[2].imm);
+      // convert PL from VL_bits
+      const uint64_t PL = VL_bits / 64;
+      results[0] = x + (PL * y);
+      break;
+    }
     case Opcode::AArch64_ADDVL_XXI: {  // addvl xd, xn, #imm
       auto x = operands[0].get<uint64_t>();
       auto y = static_cast<int64_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       // convert VL from LEN (number of 128-bits) to bytes
       const uint64_t VL = VL_bits / 8;
       results[0] = x + (VL * y);
@@ -639,14 +644,14 @@ void Instruction::execute() {
       const uint64_t* g = operands[0].getAsVector<uint64_t>();
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       // Divide by 512 as we're operating in blocks of 64-bits
       // and each predicate bit represents 8 bits in Z registers or
       // more generally the VL notion.
-      const uint16_t partition_num = VL_bits / 512;
+      const uint16_t partition_num = (int)((VL_bits - 1) / 512);
       uint64_t out[4] = {0, 0, 0, 0};
 
-      for (int i = 0; i < partition_num; i++) {
+      for (int i = 0; i < partition_num + 1; i++) {
         // AND the two source registers in blocks of 64-bits with
         // the governing predicate as a mask.
         out[i] = g[i] & (n[i] & m[i]);
@@ -675,7 +680,6 @@ void Instruction::execute() {
       const uint8_t* dn = operands[1].getAsVector<uint8_t>();
       const uint8_t* m = operands[2].getAsVector<uint8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint8_t out[256] = {0};
 
@@ -695,7 +699,6 @@ void Instruction::execute() {
       const uint64_t* dn = operands[1].getAsVector<uint64_t>();
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -715,7 +718,6 @@ void Instruction::execute() {
       const uint16_t* dn = operands[1].getAsVector<uint16_t>();
       const uint16_t* m = operands[2].getAsVector<uint16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
 
@@ -735,7 +737,6 @@ void Instruction::execute() {
       const uint32_t* dn = operands[1].getAsVector<uint32_t>();
       const uint32_t* m = operands[2].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -1088,7 +1089,6 @@ void Instruction::execute() {
       const int8_t* n = operands[1].getAsVector<int8_t>();
       const int8_t m = static_cast<int8_t>(metadata.operands[3].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1110,7 +1110,6 @@ void Instruction::execute() {
       const int64_t* n = operands[1].getAsVector<int64_t>();
       const int8_t m = static_cast<int8_t>(metadata.operands[3].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1131,7 +1130,6 @@ void Instruction::execute() {
       const int16_t* n = operands[1].getAsVector<int16_t>();
       const int8_t m = static_cast<int8_t>(metadata.operands[3].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1153,7 +1151,6 @@ void Instruction::execute() {
       const int32_t* n = operands[1].getAsVector<int32_t>();
       const int8_t m = static_cast<int8_t>(metadata.operands[3].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1175,7 +1172,6 @@ void Instruction::execute() {
       const int8_t* n = operands[1].getAsVector<int8_t>();
       const int8_t* m = operands[2].getAsVector<int8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1197,7 +1193,6 @@ void Instruction::execute() {
       const int64_t* n = operands[1].getAsVector<int64_t>();
       const int64_t* m = operands[2].getAsVector<int64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1219,7 +1214,6 @@ void Instruction::execute() {
       const int16_t* n = operands[1].getAsVector<int16_t>();
       const int16_t* m = operands[2].getAsVector<int16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1241,7 +1235,6 @@ void Instruction::execute() {
       const int32_t* n = operands[1].getAsVector<int32_t>();
       const int32_t* m = operands[2].getAsVector<int32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1263,7 +1256,6 @@ void Instruction::execute() {
       const int8_t* n = operands[1].getAsVector<int8_t>();
       const int8_t* m = operands[2].getAsVector<int8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1284,7 +1276,6 @@ void Instruction::execute() {
       const int64_t* n = operands[1].getAsVector<int64_t>();
       const int64_t* m = operands[2].getAsVector<int64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1305,7 +1296,6 @@ void Instruction::execute() {
       const int16_t* n = operands[1].getAsVector<int16_t>();
       const int16_t* m = operands[2].getAsVector<int16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1326,7 +1316,6 @@ void Instruction::execute() {
       const int32_t* n = operands[1].getAsVector<int32_t>();
       const int32_t* m = operands[2].getAsVector<int32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1347,7 +1336,6 @@ void Instruction::execute() {
       const uint8_t* n = operands[1].getAsVector<uint8_t>();
       const uint8_t* m = operands[2].getAsVector<uint8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1368,7 +1356,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1389,7 +1376,6 @@ void Instruction::execute() {
       const uint16_t* n = operands[1].getAsVector<uint16_t>();
       const uint16_t* m = operands[2].getAsVector<uint16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1410,7 +1396,6 @@ void Instruction::execute() {
       const uint32_t* n = operands[1].getAsVector<uint32_t>();
       const uint32_t* m = operands[2].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1431,7 +1416,6 @@ void Instruction::execute() {
       const int32_t* n = operands[1].getAsVector<int32_t>();
       const int8_t m = static_cast<int8_t>(metadata.operands[3].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -1449,34 +1433,33 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_CNTB_XPiI: {  // cntb xd{, pattern{, #imm}}
-      const uint64_t VL_bits = 512;
+
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      results[0] = (VL_bits / 8) * imm;
+      results[0] = (uint64_t)((VL_bits / 8) * imm);
       break;
     }
     case Opcode::AArch64_CNTH_XPiI: {  // cnth xd{, pattern{, #imm}}
-      const uint64_t VL_bits = 512;
+
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      results[0] = (VL_bits / 16) * imm;
+      results[0] = (uint64_t)((VL_bits / 16) * imm);
       break;
     }
     case Opcode::AArch64_CNTD_XPiI: {  // cntd xd{, pattern{, #imm}}
-      const uint64_t VL_bits = 512;
+
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      results[0] = (VL_bits / 64) * imm;
+      results[0] = (uint64_t)((VL_bits / 64) * imm);
       break;
     }
     case Opcode::AArch64_CNTW_XPiI: {  // cntw xd{, pattern{, #imm}}
-      const uint64_t VL_bits = 512;
+
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      results[0] = (VL_bits / 32) * imm;
+      results[0] = (uint64_t)((VL_bits / 32) * imm);
       break;
     }
     case Opcode::AArch64_CNTP_XPP_B: {  // cntp xd, pg, pn.b
       const uint64_t* pg = operands[0].getAsVector<uint64_t>();
       const uint64_t* pn = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t count = 0;
 
@@ -1493,7 +1476,6 @@ void Instruction::execute() {
       const uint64_t* pg = operands[0].getAsVector<uint64_t>();
       const uint64_t* pn = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t count = 0;
 
@@ -1510,7 +1492,6 @@ void Instruction::execute() {
       const uint64_t* pg = operands[0].getAsVector<uint64_t>();
       const uint64_t* pn = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint64_t count = 0;
 
@@ -1527,7 +1508,6 @@ void Instruction::execute() {
       const uint64_t* pg = operands[0].getAsVector<uint64_t>();
       const uint64_t* pn = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t count = 0;
 
@@ -1631,19 +1611,19 @@ void Instruction::execute() {
     // TODO : Add support for patterns
     case Opcode::AArch64_DECB_XPiI: {  // decb xdn{, pattern{, MUL #imm}}
       const uint64_t n = operands[0].get<uint64_t>();
-      const uint64_t VL_bits = 512;
-      results[0] = n - (VL_bits / 8);
+      const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
+      results[0] = n - ((VL_bits / 8) * imm);
       break;
     }
     // TODO : Add support for patterns
     case Opcode::AArch64_DECD_XPiI: {  // decd xdn{, pattern{, MUL #imm}}
       const uint64_t n = operands[0].get<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       results[0] = n - (VL_bits / 64);
       break;
     }
     case Opcode::AArch64_DUPM_ZI: {  // dupm zd.t, #imm
-      const uint64_t VL_bits = 512;
+
       const uint64_t imm = static_cast<uint64_t>(metadata.operands[1].imm);
       uint64_t out[32] = {0};
       for (int i = 0; i < (VL_bits / 64); i++) {
@@ -1655,7 +1635,6 @@ void Instruction::execute() {
     case Opcode::AArch64_DUP_ZI_B: {  // dup zd.b, #imm{, shift}
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       int8_t out[256] = {0};
 
@@ -1669,7 +1648,6 @@ void Instruction::execute() {
     case Opcode::AArch64_DUP_ZI_D: {  // dup zd.d, #imm{, shift}
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
 
@@ -1683,7 +1661,6 @@ void Instruction::execute() {
     case Opcode::AArch64_DUP_ZI_H: {  // dup zd.h, #imm{, shift}
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       int16_t out[128] = {0};
 
@@ -1697,7 +1674,6 @@ void Instruction::execute() {
     case Opcode::AArch64_DUP_ZI_S: {  // dup zd.s, #imm{, shift}
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -1711,7 +1687,6 @@ void Instruction::execute() {
     case Opcode::AArch64_DUP_ZR_S: {  // dup zd.s, wn
       const int32_t n = operands[0].get<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -1725,7 +1700,6 @@ void Instruction::execute() {
     case Opcode::AArch64_DUP_ZR_D: {  // dup zd.d, xn
       const int64_t n = operands[0].get<int64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
 
@@ -1737,11 +1711,10 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_DUP_ZZI_D: {  // dup zd.d, zn.d[#imm]
-      const uint8_t index =
-          static_cast<uint8_t>(metadata.operands[1].vector_index);
+      const uint16_t index =
+          static_cast<uint16_t>(metadata.operands[1].vector_index);
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -1757,11 +1730,10 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_DUP_ZZI_S: {  // dup zd.s, zn.s[#imm]
-      const uint8_t index =
-          static_cast<uint8_t>(metadata.operands[1].vector_index);
+      const uint16_t index =
+          static_cast<uint16_t>(metadata.operands[1].vector_index);
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -1886,7 +1858,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0};
 
@@ -1904,7 +1875,6 @@ void Instruction::execute() {
       const uint8_t* dn = operands[1].getAsVector<uint8_t>();
       const uint8_t* m = operands[2].getAsVector<uint8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint8_t out[256] = {0};
 
@@ -1924,7 +1894,6 @@ void Instruction::execute() {
       const uint64_t* dn = operands[1].getAsVector<uint64_t>();
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -1944,7 +1913,6 @@ void Instruction::execute() {
       const uint16_t* dn = operands[1].getAsVector<uint16_t>();
       const uint16_t* m = operands[2].getAsVector<uint16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
 
@@ -1964,7 +1932,6 @@ void Instruction::execute() {
       const uint32_t* dn = operands[1].getAsVector<uint32_t>();
       const uint32_t* m = operands[2].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -2058,7 +2025,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* n = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -2079,7 +2045,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* n = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -2111,7 +2076,7 @@ void Instruction::execute() {
     case Opcode::AArch64_FADDA_VPZ_D: {  // fadda dd, pg/m, dn, zm.d
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* m = operands[3].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[2] = {operands[2].get<double>(), 0.0};
 
@@ -2215,7 +2180,6 @@ void Instruction::execute() {
       const double* d = operands[1].getAsVector<double>();
       const float con = metadata.operands[3].fp;
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -2235,7 +2199,6 @@ void Instruction::execute() {
       const float* d = operands[1].getAsVector<float>();
       const float con = metadata.operands[3].fp;
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -2254,7 +2217,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const double* b = operands[1].getAsVector<double>();
       const double* c = operands[2].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -2274,7 +2237,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const float* b = operands[1].getAsVector<float>();
       const float* c = operands[2].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -2293,7 +2256,7 @@ void Instruction::execute() {
     case Opcode::AArch64_FADD_ZZZ_D: {  // fadd zd.d, zn.d, zm.d
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -2307,7 +2270,7 @@ void Instruction::execute() {
     case Opcode::AArch64_FADD_ZZZ_S: {  // fadd zd.s, zn.s, zm.s
       const float* n = operands[0].getAsVector<float>();
       const float* m = operands[1].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -2363,7 +2326,6 @@ void Instruction::execute() {
       const double* n = operands[1].getAsVector<double>();
       const double* m = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2382,7 +2344,6 @@ void Instruction::execute() {
       const float* n = operands[1].getAsVector<float>();
       const float* m = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2401,7 +2362,6 @@ void Instruction::execute() {
       const double* n = operands[1].getAsVector<double>();
       const double m = static_cast<double>(metadata.operands[3].fp);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2420,7 +2380,6 @@ void Instruction::execute() {
       const float* n = operands[1].getAsVector<float>();
       const float m = static_cast<float>(metadata.operands[3].fp);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2481,7 +2440,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const double* n = operands[1].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2498,7 +2456,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const float* n = operands[1].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2516,7 +2473,6 @@ void Instruction::execute() {
       const double* n = operands[1].getAsVector<double>();
       const double* m = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2536,7 +2492,6 @@ void Instruction::execute() {
       const float* n = operands[1].getAsVector<float>();
       const float* m = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2592,7 +2547,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const double* n = operands[1].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2610,7 +2564,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const float* n = operands[1].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2629,7 +2582,6 @@ void Instruction::execute() {
       const float* n = operands[1].getAsVector<float>();
       const float m = static_cast<float>(metadata.operands[3].fp);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -2830,7 +2782,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* n = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       int32_t out[64] = {0};
 
@@ -2860,7 +2811,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* n = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
 
@@ -2886,7 +2836,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* n = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
 
@@ -2911,7 +2860,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* n = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -2969,7 +2917,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* n = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       float out[64] = {0};
 
@@ -2995,7 +2942,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* n = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3032,7 +2978,6 @@ void Instruction::execute() {
       const double* d = operands[1].getAsVector<double>();
       const double* m = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -3051,7 +2996,6 @@ void Instruction::execute() {
       const float* d = operands[1].getAsVector<float>();
       const float* m = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -3070,7 +3014,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* b = operands[2].getAsVector<double>();
       const double* c = operands[3].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3095,7 +3039,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_FDUP_ZI_D: {  // fdup zd.d, #imm
       const double imm = metadata.operands[1].fp;
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -3108,7 +3052,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_FDUP_ZI_S: {  // fdup zd.s, #imm
       const float imm = metadata.operands[1].fp;
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3139,7 +3083,6 @@ void Instruction::execute() {
       const double* b = operands[2].getAsVector<double>();
       const double* c = operands[3].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3161,7 +3104,6 @@ void Instruction::execute() {
       const float* b = operands[2].getAsVector<float>();
       const float* c = operands[3].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3257,7 +3199,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* b = operands[2].getAsVector<double>();
       const double* c = operands[3].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3278,7 +3220,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* b = operands[2].getAsVector<float>();
       const float* c = operands[3].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3326,7 +3268,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* b = operands[2].getAsVector<double>();
       const double* c = operands[3].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3347,7 +3289,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* b = operands[2].getAsVector<float>();
       const float* c = operands[3].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3442,7 +3384,6 @@ void Instruction::execute() {
       const double* n = operands[2].getAsVector<double>();
       const double* m = operands[3].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3464,7 +3405,6 @@ void Instruction::execute() {
       const float* b = operands[2].getAsVector<float>();
       const float* c = operands[3].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3554,7 +3494,7 @@ void Instruction::execute() {
     case Opcode::AArch64_FMUL_ZZZ_D: {  // fmul zd.d, zn.d, zm.d
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3568,7 +3508,7 @@ void Instruction::execute() {
     case Opcode::AArch64_FMUL_ZZZ_S: {  // fmul zd.s, zn.s, zm.s
       const float* n = operands[0].getAsVector<float>();
       const float* m = operands[1].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3583,7 +3523,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const double* n = operands[1].getAsVector<double>();
       const float fp = metadata.operands[3].fp;
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3603,7 +3543,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const float* n = operands[1].getAsVector<float>();
       const float fp = metadata.operands[3].fp;
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3623,7 +3563,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const double* n = operands[1].getAsVector<double>();
       const double* m = operands[2].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3643,7 +3583,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const float* n = operands[1].getAsVector<float>();
       const float* m = operands[2].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3671,7 +3611,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const double* n = operands[1].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3691,7 +3630,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const float* n = operands[1].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3725,7 +3663,6 @@ void Instruction::execute() {
       const double* n = operands[2].getAsVector<double>();
       const double* m = operands[3].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3746,7 +3683,6 @@ void Instruction::execute() {
       const float* n = operands[2].getAsVector<float>();
       const float* m = operands[3].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3767,7 +3703,6 @@ void Instruction::execute() {
       const double* m = operands[2].getAsVector<double>();
       const double* a = operands[3].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -3788,7 +3723,6 @@ void Instruction::execute() {
       const float* m = operands[2].getAsVector<float>();
       const float* a = operands[3].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -3838,7 +3772,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* n = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
 
@@ -3858,7 +3791,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* n = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -3967,7 +3899,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const double* n = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -3986,7 +3917,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const float* n = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4030,7 +3960,6 @@ void Instruction::execute() {
       const double* dn = operands[1].getAsVector<double>();
       const double* m = operands[2].getAsVector<double>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -4050,7 +3979,6 @@ void Instruction::execute() {
       const float* dn = operands[1].getAsVector<float>();
       const float* m = operands[2].getAsVector<float>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -4068,7 +3996,7 @@ void Instruction::execute() {
     case Opcode::AArch64_FSUB_ZZZ_D: {  // fsub zd.d, zn.d, zm.d
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -4082,7 +4010,7 @@ void Instruction::execute() {
     case Opcode::AArch64_FSUB_ZZZ_S: {  // fsub zd.s, zn.s, zm.s
       const float* n = operands[0].getAsVector<float>();
       const float* m = operands[1].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -4110,35 +4038,35 @@ void Instruction::execute() {
     case Opcode::AArch64_INCB_XPiI: {  // incb xdn{, pattern{, #imm}}
       const uint64_t n = operands[0].get<uint64_t>();
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
+
       results[0] = n + ((VL_bits / 8) * imm);
       break;
     }
     case Opcode::AArch64_INCD_XPiI: {  // incd xdn{, pattern{, #imm}}
       const uint64_t n = operands[0].get<uint64_t>();
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
+
       results[0] = n + ((VL_bits / 64) * imm);
       break;
     }
     case Opcode::AArch64_INCH_XPiI: {  // inch xdn{, pattern{, #imm}}
       const uint64_t n = operands[0].get<uint64_t>();
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
+
       results[0] = n + ((VL_bits / 16) * imm);
       break;
     }
     case Opcode::AArch64_INCW_XPiI: {  // incw xdn{, pattern{, #imm}}
       const uint64_t n = operands[0].get<uint64_t>();
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
+
       results[0] = n + ((VL_bits / 32) * imm);
       break;
     }
     case Opcode::AArch64_INCW_ZPiI: {  // incw zdn.s{, pattern{, #imm}}
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4150,7 +4078,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INCD_ZPiI: {  // incd zdn.d{, pattern{, #imm}}
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4162,7 +4090,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INCH_ZPiI: {  // inch zdn.h{, pattern{, #imm}}
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
       const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       int16_t out[128] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4174,7 +4102,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INCP_XP_B: {  // incp xdn, pm.b
       const uint64_t dn = operands[0].get<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint64_t count = 0;
 
@@ -4190,7 +4118,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INCP_XP_D: {  // incp xdn, pm.d
       const uint64_t dn = operands[0].get<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t count = 0;
 
@@ -4206,7 +4134,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INCP_XP_H: {  // incp xdn, pm.h
       const uint64_t dn = operands[0].get<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint64_t count = 0;
 
@@ -4222,7 +4150,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INCP_XP_S: {  // incp xdn, pm.s
       const uint64_t dn = operands[0].get<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint64_t count = 0;
 
@@ -4238,7 +4166,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_II_B: {  // index zd.b, #imm, #imm
       const int8_t imm1 = static_cast<int8_t>(metadata.operands[1].imm);
       const int8_t imm2 = static_cast<int8_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       int8_t out[256] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4250,7 +4178,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_II_H: {  // index zd.h, #imm, #imm
       const int16_t imm1 = static_cast<int16_t>(metadata.operands[1].imm);
       const int16_t imm2 = static_cast<int16_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       int16_t out[128] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4262,7 +4190,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_II_S: {  // index zd.s, #imm, #imm
       const int32_t imm1 = static_cast<int32_t>(metadata.operands[1].imm);
       const int32_t imm2 = static_cast<int32_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4274,7 +4202,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_II_D: {  // index zd.d, #imm, #imm
       const int64_t imm1 = static_cast<int64_t>(metadata.operands[1].imm);
       const int64_t imm2 = static_cast<int64_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4286,7 +4214,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RI_B: {  // index zd.b, wn, #imm
       const int8_t n = static_cast<int8_t>(operands[0].get<int32_t>());
       const int8_t imm = static_cast<int8_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       int8_t out[256] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4298,7 +4226,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RI_D: {  // index zd.d, xn, #imm
       const int64_t n = static_cast<int64_t>(operands[0].get<int64_t>());
       const int64_t imm = static_cast<int64_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4310,7 +4238,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RI_H: {  // index zd.h, wn, #imm
       const int16_t n = static_cast<int16_t>(operands[0].get<int32_t>());
       const int16_t imm = static_cast<int16_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       int16_t out[128] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4322,7 +4250,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RI_S: {  // index zd.s, wn, #imm
       const int32_t n = operands[0].get<int32_t>();
       const int32_t imm = static_cast<int32_t>(metadata.operands[2].imm);
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4334,7 +4262,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_IR_B: {  // index zd.b, #imm, wn
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
       const int8_t n = static_cast<int8_t>(operands[0].get<int32_t>());
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       int8_t out[256] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4346,7 +4274,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_IR_D: {  // index zd.d, #imm, xn
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
       const int64_t n = operands[0].get<int64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4358,7 +4286,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_IR_H: {  // index zd.h, #imm, wn
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
       const int16_t n = static_cast<int16_t>(operands[0].get<int32_t>());
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       int16_t out[128] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4370,7 +4298,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_IR_S: {  // index zd.s, #imm, wn
       const int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
       const int32_t n = operands[0].get<int32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4382,7 +4310,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RR_B: {  // index zd.b, wn, wm
       const int8_t n = static_cast<int8_t>(operands[0].get<int32_t>());
       const int8_t m = static_cast<int8_t>(operands[1].get<int32_t>());
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       int8_t out[256] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4394,7 +4322,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RR_D: {  // index zd.d, xn, xm
       const int64_t n = operands[0].get<int64_t>();
       const int64_t m = operands[1].get<int64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4406,7 +4334,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RR_H: {  // index zd.h, wn, wm
       const int16_t n = static_cast<int16_t>(operands[0].get<int32_t>());
       const int16_t m = static_cast<int16_t>(operands[1].get<int32_t>());
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       int16_t out[128] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4418,7 +4346,7 @@ void Instruction::execute() {
     case Opcode::AArch64_INDEX_RR_S: {  // index zd.s, wn, wm
       const int32_t n = operands[0].get<int32_t>();
       const int32_t m = operands[1].get<int32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
@@ -4517,10 +4445,10 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LD1RD_IMM: {  // ld1rd {zt.d}, pg/z, [xn, #imm]
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
-      uint8_t index = 0;
+      uint16_t index = 0;
       // Check if any lanes are active, otherwise set all to 0 and break early
       bool active = false;
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
@@ -4544,10 +4472,10 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LD1RW_IMM: {  // ld1rw {zt.s}, pg/z, [xn, #imm]
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
-      uint8_t index = 0;
+      uint16_t index = 0;
       // Check if any lanes are active, otherwise set all to 0 and break early
       bool active = false;
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
@@ -4680,9 +4608,9 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_LD1B: {  // ld1b  {zt.b}, pg/z, [xn, xm]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
-      uint8_t index = 0;
+      uint16_t index = 0;
       uint8_t out[256] = {0};
 
       for (int i = 0; i < partition_num; i++) {
@@ -4700,9 +4628,9 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_LD1D: {  // ld1d  {zt.d}, pg/z, [xn, xm, lsl #3]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
-      uint8_t index = 0;
+      uint16_t index = 0;
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
@@ -4721,9 +4649,9 @@ void Instruction::execute() {
     case Opcode::AArch64_LD1D_IMM_REAL: {  // ld1d  {zt.d}, pg/z, [xn{, #imm,
                                            // mul vl}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
-      uint8_t index = 0;
+      uint16_t index = 0;
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
@@ -4744,9 +4672,9 @@ void Instruction::execute() {
     case Opcode::AArch64_GLD1D_SCALED_REAL: {  // ld1d {zt.d}, pg/z, [xn, zm.d,
                                                // LSL #3]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
-      uint8_t index = 0;
+      uint16_t index = 0;
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
@@ -4762,11 +4690,11 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_GLD1D_IMM_REAL: {  // ld1d {zd.d}, pg/z, [zn.d{, #imm}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
-      uint8_t index = 0;
+      uint16_t index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
@@ -4780,11 +4708,11 @@ void Instruction::execute() {
     case Opcode::AArch64_GLD1SW_D_IMM_REAL: {  // ld1sw {zd.d}, pg/z, [zn.d{,
                                                // #imm}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
 
-      uint8_t index = 0;
+      uint16_t index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
@@ -4797,9 +4725,9 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_LD1H: {  // ld1h  {zt.h}, pg/z, [xn, xm, lsl #1]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
-      uint8_t index = 0;
+      uint16_t index = 0;
       uint16_t out[128] = {0};
 
       for (int i = 0; i < partition_num; i++) {
@@ -4817,9 +4745,9 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_LD1W: {  // ld1w  {zt.s}, pg/z, [xn, xm, lsl #2]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
-      uint8_t index = 0;
+      uint16_t index = 0;
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
@@ -4838,9 +4766,9 @@ void Instruction::execute() {
     case Opcode::AArch64_LD1W_IMM_REAL: {  // ld1w  {zt.s}, pg/z, [xn{, #imm,
                                            // mul vl}]
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
-      uint8_t index = 0;
+      uint16_t index = 0;
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
@@ -5196,14 +5124,14 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDR_PXI: {  // ldr pt, [xn{, #imm, mul vl}]
-      const uint64_t PL_bits = 64;
+      const uint64_t PL_bits = VL_bits / 8;
       const uint16_t partition_num = PL_bits / 8;
 
       uint64_t out[4] = {0};
       for (int i = 0; i < partition_num; i++) {
         uint8_t data = memoryData[i].get<uint8_t>();
         for (int j = 0; j < 8; j++) {
-          out[i / 8] |= (data & (1 << j)) ? 1ull << (j + (i * 8)) : 0;
+          out[i / 8] |= (data & (1 << j)) ? 1ull << ((j + (i * 8)) % 64) : 0;
         }
       }
 
@@ -5211,7 +5139,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_LDR_ZXI: {  // ldr zt, [xn{, #imm, mul vl}]
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint8_t out[256] = {0};
 
@@ -5279,7 +5207,6 @@ void Instruction::execute() {
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint32_t imm = static_cast<uint32_t>(metadata.operands[2].imm);
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -5322,7 +5249,6 @@ void Instruction::execute() {
       const uint8_t* n = operands[2].getAsVector<uint8_t>();
       const uint8_t* m = operands[3].getAsVector<uint8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint8_t out[256] = {0};
 
@@ -5343,7 +5269,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[2].getAsVector<uint64_t>();
       const uint64_t* m = operands[3].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -5364,7 +5289,6 @@ void Instruction::execute() {
       const uint16_t* n = operands[2].getAsVector<uint16_t>();
       const uint16_t* m = operands[3].getAsVector<uint16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
 
@@ -5385,7 +5309,6 @@ void Instruction::execute() {
       const uint32_t* n = operands[2].getAsVector<uint32_t>();
       const uint32_t* m = operands[3].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -5483,7 +5406,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const uint64_t* n = operands[2].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -5503,7 +5425,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -5523,7 +5444,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const uint32_t* n = operands[1].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -5583,7 +5503,6 @@ void Instruction::execute() {
       const uint8_t* m = operands[2].getAsVector<uint8_t>();
       uint8_t out[256] = {0};
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << (i % 64);
@@ -5602,7 +5521,6 @@ void Instruction::execute() {
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
       uint64_t out[32] = {0};
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
@@ -5621,7 +5539,6 @@ void Instruction::execute() {
       const uint16_t* m = operands[2].getAsVector<uint16_t>();
       uint16_t out[128] = {0};
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 32) * 2);
@@ -5640,7 +5557,6 @@ void Instruction::execute() {
       const uint32_t* m = operands[2].getAsVector<uint32_t>();
       uint32_t out[64] = {0};
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 16) * 4);
@@ -5755,14 +5671,14 @@ void Instruction::execute() {
       const uint64_t* g = operands[0].getAsVector<uint64_t>();
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       // Divide by 512 as we're operating in blocks of 64-bits
       // and each predicate bit represents 8 bits in Z registers or
       // more generally the VL notion.
-      const uint16_t partition_num = VL_bits / 512;
+      const uint16_t partition_num = (int)((VL_bits - 1) / 512);
       uint64_t out[4] = {0, 0, 0, 0};
 
-      for (int i = 0; i < partition_num; i++) {
+      for (int i = 0; i < partition_num + 1; i++) {
         // Or the two source registers in blocks of 64-bits with
         // the governing predicate as a mask.
         out[i] = g[i] & (n[i] | m[i]);
@@ -5776,7 +5692,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -5801,7 +5716,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_PTEST_PP: {  // ptest pg, pn.b
-      const uint64_t VL_bits = 512;
+
       const uint64_t* g = operands[0].getAsVector<uint64_t>();
       const uint64_t* s = operands[1].getAsVector<uint64_t>();
 
@@ -5817,7 +5732,7 @@ void Instruction::execute() {
       results[0] = out;
     }
     case Opcode::AArch64_PTRUE_B: {  // ptrue pd.b{, pattern}
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -5830,7 +5745,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_PTRUE_D: {  // ptrue pd.d{, pattern}
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -5843,7 +5758,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_PTRUE_H: {  // ptrue pd.h{, pattern}
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -5856,7 +5771,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_PTRUE_S: {  // ptrue pd.s{, pattern}
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -5869,14 +5784,14 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_PUNPKHI_PP: {  // punpkhi pd.h, pn.b
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = partition_num / 2; i < partition_num; i++) {
         if (n[i / 64] & 1ull << i % 64) {
-          out[index / 32] |= 1ull << index * 2;
+          out[index / 32] |= 1ull << ((index * 2) % 64);
         }
         index++;
       }
@@ -5886,13 +5801,13 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_PUNPKLO_PP: {  // punpklo pd.h, pn.b
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num / 2; i++) {
         if (n[i / 64] & 1ull << i % 64) {
-          out[i / 32] |= 1ull << i * 2;
+          out[i / 32] |= 1ull << ((i * 2) % 64);
         }
       }
 
@@ -5920,8 +5835,8 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_RDVLI_XI: {  // rdvl xd, #imm
       int8_t imm = static_cast<int8_t>(metadata.operands[1].imm);
-      const uint64_t VL_bits = 512;
-      results[0] = imm * (VL_bits / 8);
+
+      results[0] = (uint64_t)(imm * (VL_bits / 8));
       break;
     }
     case Opcode::AArch64_RET: {  // ret {xr}
@@ -5939,7 +5854,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_PP_B: {  // rev pd.b, pn.b
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -5958,7 +5873,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_PP_D: {  // rev pd.d, pn.d
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -5977,7 +5892,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_PP_H: {  // rev pd.h, pn.h
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -5996,7 +5911,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_PP_S: {  // rev pd.s, pn.s
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -6015,7 +5930,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_ZZ_B: {  // rev zd.b, zn.b
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint8_t out[256] = {0};
 
@@ -6029,7 +5944,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_ZZ_D: {  // rev zd.d, zn.d
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -6043,7 +5958,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_ZZ_H: {  // rev zd.h, zn.h
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
 
@@ -6057,7 +5972,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_REV_ZZ_S: {  // rev zd.s, zn.s
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -6106,7 +6021,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const int64_t* n = operands[2].getAsVector<int64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -6131,7 +6045,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const int64_t* n = operands[2].getAsVector<int64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       float out[64] = {0};
 
@@ -6157,7 +6070,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const int32_t* n = operands[2].getAsVector<int32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -6182,7 +6094,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const int32_t* n = operands[2].getAsVector<int32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -6276,7 +6187,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const uint64_t* n = operands[1].getAsVector<uint64_t>();
       const uint64_t* m = operands[2].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -6296,7 +6207,7 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const uint32_t* n = operands[1].getAsVector<uint32_t>();
       const uint32_t* m = operands[2].getAsVector<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -6339,7 +6250,6 @@ void Instruction::execute() {
       const int32_t* n = operands[0].getAsVector<int32_t>();
       int32_t imm = metadata.operands[2].imm;
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -6356,7 +6266,6 @@ void Instruction::execute() {
       const int32_t* n = operands[2].getAsVector<int32_t>();
       const int32_t* m = operands[3].getAsVector<int32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -6386,7 +6295,6 @@ void Instruction::execute() {
       const int32_t* n = operands[2].getAsVector<int32_t>();
       const int32_t* m = operands[3].getAsVector<int32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out[64] = {0};
 
@@ -6406,7 +6314,6 @@ void Instruction::execute() {
       const uint64_t* p = operands[0].getAsVector<uint64_t>();
       const int32_t* n = operands[1].getAsVector<int32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       int32_t out = INT32_MAX;
 
@@ -6479,9 +6386,9 @@ void Instruction::execute() {
     case Opcode::AArch64_ST1B: {  // st1b {zt.b}, pg, [xn, xm]
       const uint8_t* d = operands[0].getAsVector<uint8_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << (i % 64);
@@ -6496,9 +6403,9 @@ void Instruction::execute() {
     case Opcode::AArch64_SST1B_D: {  // st1b {zd.d}, pg, [xn, zm.d]
       const uint64_t* d = operands[0].getAsVector<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
@@ -6519,9 +6426,9 @@ void Instruction::execute() {
     case Opcode::AArch64_ST1D: {  // st1d {zt.d}, pg, [xn, xm, lsl #3]
       const uint64_t* d = operands[0].getAsVector<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
@@ -6536,9 +6443,9 @@ void Instruction::execute() {
     case Opcode::AArch64_ST1D_IMM: {  // st1d {zt.d}, pg, [xn{, #imm, mul vl}]
       const uint64_t* d = operands[0].getAsVector<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
@@ -6553,9 +6460,9 @@ void Instruction::execute() {
     case Opcode::AArch64_ST1W: {  // st1w {zt.s}, pg, [xn, xm, lsl #2]
       const uint32_t* d = operands[0].getAsVector<uint32_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 16) * 4);
@@ -6570,10 +6477,10 @@ void Instruction::execute() {
     case Opcode::AArch64_ST1W_D: {  // st1w {zt.d}, pg, [xn, xm, lsl #2]
       const uint64_t* d = operands[0].getAsVector<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
 
-      uint8_t index = 0;
+      uint16_t index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
@@ -6587,9 +6494,9 @@ void Instruction::execute() {
     case Opcode::AArch64_ST1W_IMM: {  // st1w {zt.s}, pg, [xn{, #imm, mul vl}]
       const uint32_t* d = operands[0].getAsVector<uint32_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 16) * 4);
@@ -6604,10 +6511,10 @@ void Instruction::execute() {
     case Opcode::AArch64_SST1W_D_IMM: {  // st1w {zt.d}, pg, [zn.d{, #imm}]
       const uint64_t* t = operands[0].getAsVector<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
 
-      uint8_t index = 0;
+      uint16_t index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
@@ -6620,10 +6527,10 @@ void Instruction::execute() {
     case Opcode::AArch64_SST1W_IMM: {  // st1w {zt.s}, pg, [zn.s{, #imm}]
       const uint32_t* t = operands[0].getAsVector<uint32_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
 
-      uint8_t index = 0;
+      uint16_t index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
@@ -6636,10 +6543,10 @@ void Instruction::execute() {
     case Opcode::AArch64_SST1D_IMM: {  // st1d {zd.d}, pg, [zn.d{, #imm}]
       const uint64_t* t = operands[0].getAsVector<uint64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
 
-      uint8_t index = 0;
+      uint16_t index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
@@ -6982,7 +6889,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_STR_PXI: {  // str pt, [xn{, #imm, mul vl}]
-      const uint64_t PL_bits = 64;
+      const uint64_t PL_bits = VL_bits / 8;
       const uint16_t partition_num = PL_bits / 8;
       const uint8_t* p = operands[0].getAsVector<uint8_t>();
 
@@ -6993,7 +6900,7 @@ void Instruction::execute() {
       break;
     }
     case Opcode::AArch64_STR_ZXI: {  // str zt, [xn{, #imm, mul vl}]
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       const uint8_t* z = operands[0].getAsVector<uint8_t>();
 
@@ -7252,7 +7159,6 @@ void Instruction::execute() {
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
       const uint8_t* m = operands[1].getAsVector<uint8_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint8_t out[256] = {0};
 
@@ -7266,7 +7172,6 @@ void Instruction::execute() {
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
       const uint16_t* m = operands[1].getAsVector<uint16_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
 
@@ -7280,7 +7185,6 @@ void Instruction::execute() {
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint32_t* m = operands[1].getAsVector<uint32_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -7294,7 +7198,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -7313,7 +7216,7 @@ void Instruction::execute() {
       const int64_t* d = operands[0].getAsVector<int64_t>();
       const uint64_t* p = operands[1].getAsVector<uint64_t>();
       const int64_t* n = operands[2].getAsVector<int64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       int64_t out[32] = {0};
 
@@ -7400,7 +7303,6 @@ void Instruction::execute() {
     case Opcode::AArch64_UQDECD_WPiI: {  // uqdecd wd{, pattern{, MUL #imm}}
       const uint32_t d = operands[0].get<uint32_t>();
       const uint8_t imm = metadata.operands[1].imm;
-      const uint64_t VL_bits = 512;
 
       // The range of possible values is [-128, UINT64_MAX - 8]
       // Since this range does not fit in any integral type,
@@ -7408,16 +7310,15 @@ void Instruction::execute() {
       // The end result must be saturated to fit in uint64_t.
       auto intermediate = double(d) - (imm * (VL_bits / 64u));
       if (intermediate < 0) {
-        results[0] = 0ull;
+        results[0] = (uint64_t)0;
       } else {
-        results[0] = d - (imm * (VL_bits / 64u));
+        results[0] = (uint64_t)(d - (imm * (VL_bits / 64u)));
       }
       break;
     }
     case Opcode::AArch64_UQDECD_XPiI: {  // uqdecd xd{, pattern{, MUL #imm}}
       const uint64_t d = operands[0].get<uint64_t>();
       const uint8_t imm = metadata.operands[1].imm;
-      const uint64_t VL_bits = 512;
 
       // The range of possible values is [-128, UINT64_MAX - 8]
       // Since this range does not fit in any integral type,
@@ -7425,16 +7326,15 @@ void Instruction::execute() {
       // The end result must be saturated to fit in uint64_t.
       auto intermediate = double(d) - (imm * (VL_bits / 64u));
       if (intermediate < 0) {
-        results[0] = 0ull;
+        results[0] = (uint64_t)0;
       } else {
-        results[0] = d - (imm * (VL_bits / 64u));
+        results[0] = (uint64_t)(d - (imm * (VL_bits / 64u)));
       }
       break;
     }
     case Opcode::AArch64_UQDECH_XPiI: {  // uqdech xd{, pattern{, MUL #imm}}
       const uint64_t d = operands[0].get<uint64_t>();
       const uint8_t imm = metadata.operands[1].imm;
-      const uint64_t VL_bits = 512;
 
       // The range of possible values is [-512, UINT64_MAX - 32]
       // Since this range does not fit in any integral type,
@@ -7442,16 +7342,15 @@ void Instruction::execute() {
       // The end result must be saturated to fit in uint64_t.
       auto intermediate = double(d) - (imm * (VL_bits / 16u));
       if (intermediate < 0) {
-        results[0] = 0ull;
+        results[0] = (uint64_t)0;
       } else {
-        results[0] = d - (imm * (VL_bits / 16u));
+        results[0] = (uint64_t)(d - (imm * (VL_bits / 16u)));
       }
       break;
     }
     case Opcode::AArch64_UQDECW_XPiI: {  // uqdecw xd{, pattern{, MUL #imm}}
       const uint64_t d = operands[0].get<uint64_t>();
       const uint8_t imm = metadata.operands[1].imm;
-      const uint64_t VL_bits = 512;
 
       // The range of possible values is [-256, UINT64_MAX - 16]
       // Since this range does not fit in any integral type,
@@ -7459,9 +7358,9 @@ void Instruction::execute() {
       // The end result must be saturated to fit in uint64_t.
       auto intermediate = double(d) - (imm * (VL_bits / 32u));
       if (intermediate < 0) {
-        results[0] = 0ull;
+        results[0] = (uint64_t)0;
       } else {
-        results[0] = d - (imm * (VL_bits / 32u));
+        results[0] = (uint64_t)(d - (imm * (VL_bits / 32u)));
       }
       break;
     }
@@ -7592,7 +7491,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_UUNPKHI_ZZ_D: {  // uunpkhi zd.d, zn.s
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -7604,7 +7503,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_UUNPKHI_ZZ_H: {  // uunpkhi zd.h, zn.b
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
 
@@ -7616,7 +7515,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_UUNPKHI_ZZ_S: {  // uunpkhi zd.s, zn.h
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -7628,7 +7527,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_UUNPKLO_ZZ_D: {  // uunpklo zd.d, zn.s
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[32] = {0};
 
@@ -7640,7 +7539,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_UUNPKLO_ZZ_H: {  // uunpklo zd.h, zn.b
       const uint8_t* n = operands[0].getAsVector<uint8_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint16_t out[128] = {0};
 
@@ -7652,7 +7551,7 @@ void Instruction::execute() {
     }
     case Opcode::AArch64_UUNPKLO_ZZ_S: {  // uunpklo zd.s, zn.h
       const uint16_t* n = operands[0].getAsVector<uint16_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -7665,7 +7564,7 @@ void Instruction::execute() {
     case Opcode::AArch64_UZP1_ZZZ_S: {  // uzp1 zd.s, zn.s, zm.s
       const uint32_t* n = operands[0].getAsVector<uint32_t>();
       const uint32_t* m = operands[1].getAsVector<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint32_t out[64] = {0};
 
@@ -7682,10 +7581,10 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PWW_B: {  // whilelo pd.b, wn, wm
       const uint32_t n = operands[0].get<uint32_t>();
       const uint32_t m = operands[1].get<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
@@ -7703,10 +7602,10 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PWW_D: {  // whilelo pd.d, wn, wm
       const uint32_t n = operands[0].get<uint32_t>();
       const uint32_t m = operands[1].get<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
@@ -7724,15 +7623,15 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PWW_H: {  // whilelo pd.h, wn, wm
       const uint32_t n = operands[0].get<uint32_t>();
       const uint32_t m = operands[1].get<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? s1ull << ((i % 32) * 2) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << ((i % 32) * 2) : 0;
         out[index / 32] = out[index / 32] | shifted_active;
         index++;
       }
@@ -7745,10 +7644,10 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PWW_S: {  // whilelo pd.s, wn, wm
       const uint32_t n = operands[0].get<uint32_t>();
       const uint32_t m = operands[1].get<uint32_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
@@ -7766,10 +7665,10 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PXX_B: {  // whilelo pd.b, xn, xm
       const uint64_t n = operands[0].get<uint64_t>();
       const uint64_t m = operands[1].get<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
@@ -7787,10 +7686,10 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PXX_D: {  // whilelo pd.d, xn, xm
       const uint64_t n = operands[0].get<uint64_t>();
       const uint64_t m = operands[1].get<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
@@ -7808,10 +7707,10 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PXX_H: {  // whilelo pd.h, xn, xm
       const uint64_t n = operands[0].get<uint64_t>();
       const uint64_t m = operands[1].get<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
@@ -7829,10 +7728,10 @@ void Instruction::execute() {
     case Opcode::AArch64_WHILELO_PXX_S: {  // whilelo pd.s, xn, xm
       const uint64_t n = operands[0].get<uint64_t>();
       const uint64_t m = operands[1].get<uint64_t>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
-      uint8_t index = 0;
+      uint16_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
@@ -7874,7 +7773,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -7901,7 +7799,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -7929,7 +7826,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -7957,7 +7853,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -7984,7 +7879,7 @@ void Instruction::execute() {
     case Opcode::AArch64_ZIP1_ZZZ_S: {  // zip1 zd.s, zn.s, zm.s
       const float* n = operands[0].getAsVector<float>();
       const float* m = operands[1].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -8006,7 +7901,7 @@ void Instruction::execute() {
     case Opcode::AArch64_ZIP1_ZZZ_D: {  // zip1 zd.d, zn.d, zm.d
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 
@@ -8029,7 +7924,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -8056,7 +7950,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -8084,7 +7977,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -8112,7 +8004,6 @@ void Instruction::execute() {
       const uint64_t* n = operands[0].getAsVector<uint64_t>();
       const uint64_t* m = operands[1].getAsVector<uint64_t>();
 
-      const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       uint64_t out[4] = {0, 0, 0, 0};
 
@@ -8139,7 +8030,7 @@ void Instruction::execute() {
     case Opcode::AArch64_ZIP2_ZZZ_S: {  // zip2 zd.s, zn.s, zm.s
       const float* n = operands[0].getAsVector<float>();
       const float* m = operands[1].getAsVector<float>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
 
@@ -8161,7 +8052,7 @@ void Instruction::execute() {
     case Opcode::AArch64_ZIP2_ZZZ_D: {  // zip2 zd.d, zn.d, zm.d
       const double* n = operands[0].getAsVector<double>();
       const double* m = operands[1].getAsVector<double>();
-      const uint64_t VL_bits = 512;
+
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
 

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -5488,7 +5488,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active)
           out[i] = n[i];
         else
@@ -5946,8 +5946,8 @@ void Instruction::execute() {
       int index = partition_num - 1;
       for (int i = 0; i < partition_num; i++) {
         uint64_t rev_shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index)));
-        uint64_t shifted_active = static_cast<uint64_t>(std::pow(2, (i)));
+            static_cast<uint64_t>(1ull << (index % 64));
+        uint64_t shifted_active = static_cast<uint64_t>(1ull << (i % 64));
         out[index / 64] |= ((n[i / 64] & shifted_active) == shifted_active)
                                ? rev_shifted_active
                                : 0;
@@ -5965,8 +5965,8 @@ void Instruction::execute() {
       int index = partition_num - 1;
       for (int i = 0; i < partition_num; i++) {
         uint64_t rev_shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 8)));
-        uint64_t shifted_active = static_cast<uint64_t>(std::pow(2, (i * 8)));
+            static_cast<uint64_t>(1ull << ((index % 8) * 8));
+        uint64_t shifted_active = static_cast<uint64_t>(1ull << ((i % 8) * 8));
         out[index / 8] |= ((n[i / 8] & shifted_active) == shifted_active)
                               ? rev_shifted_active
                               : 0;
@@ -5984,8 +5984,8 @@ void Instruction::execute() {
       int index = partition_num - 1;
       for (int i = 0; i < partition_num; i++) {
         uint64_t rev_shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 2)));
-        uint64_t shifted_active = static_cast<uint64_t>(std::pow(2, (i * 2)));
+            static_cast<uint64_t>(1ull << ((index % 32) * 2));
+        uint64_t shifted_active = static_cast<uint64_t>(1ull << ((i % 32) * 2));
         out[index / 32] |= ((n[i / 32] & shifted_active) == shifted_active)
                                ? rev_shifted_active
                                : 0;
@@ -6003,8 +6003,8 @@ void Instruction::execute() {
       int index = partition_num - 1;
       for (int i = 0; i < partition_num; i++) {
         uint64_t rev_shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 4)));
-        uint64_t shifted_active = static_cast<uint64_t>(std::pow(2, (i * 4)));
+            static_cast<uint64_t>(1ull << ((index % 16) * 4));
+        uint64_t shifted_active = static_cast<uint64_t>(1ull << ((i % 16) * 4));
         out[index / 16] |= ((n[i / 16] & shifted_active) == shifted_active)
                                ? rev_shifted_active
                                : 0;
@@ -7690,7 +7690,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? 1ull << i : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << (i % 64) : 0;
         out[index / 64] = out[index / 64] | shifted_active;
         index++;
       }
@@ -7711,7 +7711,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? 1ull << (i * 8) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << ((i % 8) * 8) : 0;
         out[index / 8] = out[index / 8] | shifted_active;
         index++;
       }
@@ -7732,7 +7732,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? std::pow(2, (i * 2)) : 0;
+        uint64_t shifted_active = (n + i) < m ? s1ull << ((i % 32) * 2) : 0;
         out[index / 32] = out[index / 32] | shifted_active;
         index++;
       }
@@ -7753,7 +7753,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? 1ull << (i * 4) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << ((i % 16) * 4) : 0;
         out[index / 16] = out[index / 16] | shifted_active;
         index++;
       }
@@ -7774,7 +7774,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? 1ull << i : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << (i % 64) : 0;
         out[index / 64] = out[index / 64] | shifted_active;
         index++;
       }
@@ -7795,7 +7795,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? 1ull << (i * 8) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << ((i % 8) * 8) : 0;
         out[index / 8] = out[index / 8] | shifted_active;
         index++;
       }
@@ -7816,7 +7816,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? std::pow(2, (i * 2)) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << ((i % 32) * 2) : 0;
         out[index / 32] = out[index / 32] | shifted_active;
         index++;
       }
@@ -7837,7 +7837,7 @@ void Instruction::execute() {
       for (int i = 0; i < partition_num; i++) {
         // Determine whether lane should be active and shift to align with
         // element in predicate register.
-        uint64_t shifted_active = (n + i) < m ? 1ull << (i * 4) : 0;
+        uint64_t shifted_active = (n + i) < m ? 1ull << ((i % 16) * 4) : 0;
         out[index / 16] = out[index / 16] | shifted_active;
         index++;
       }
@@ -7881,15 +7881,15 @@ void Instruction::execute() {
       bool interleave = false;
       int index = 0;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = static_cast<uint64_t>(std::pow(2, index));
+        uint64_t shifted_active = static_cast<uint64_t>(1ull << (index % 64));
         if (interleave) {
           out[i / 64] |= ((m[index / 64] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, i))
+                             ? static_cast<uint64_t>(1ull << (i % 64))
                              : 0;
           index++;
         } else {
           out[i / 64] |= ((n[index / 64] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, i))
+                             ? static_cast<uint64_t>(1ull << (i % 64))
                              : 0;
         }
         interleave = !interleave;
@@ -7909,15 +7909,15 @@ void Instruction::execute() {
       int index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 8)));
+            static_cast<uint64_t>(1ull << ((index % 8) * 8));
         if (interleave) {
           out[i / 8] |= ((m[index / 8] & shifted_active) == shifted_active)
-                            ? static_cast<uint64_t>(std::pow(2, (i * 8)))
+                            ? static_cast<uint64_t>(1ull << ((i % 8) * 8))
                             : 0;
           index++;
         } else {
           out[i / 8] |= ((n[index / 8] & shifted_active) == shifted_active)
-                            ? static_cast<uint64_t>(std::pow(2, (i * 8)))
+                            ? static_cast<uint64_t>(1ull << ((i % 8) * 8))
                             : 0;
         }
         interleave = !interleave;
@@ -7937,15 +7937,15 @@ void Instruction::execute() {
       int index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 2)));
+            static_cast<uint64_t>(1ull << ((index % 32) * 2));
         if (interleave) {
           out[i / 32] |= ((m[index / 32] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 2)))
+                             ? static_cast<uint64_t>(1ull << ((i % 32) * 2))
                              : 0;
           index++;
         } else {
           out[i / 32] |= ((n[index / 32] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 2)))
+                             ? static_cast<uint64_t>(1ull << ((i % 32) * 2))
                              : 0;
         }
         interleave = !interleave;
@@ -7965,15 +7965,15 @@ void Instruction::execute() {
       int index = 0;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 4)));
+            static_cast<uint64_t>(1ull << ((index % 16) * 4));
         if (interleave) {
           out[i / 16] |= ((m[index / 16] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 4)))
+                             ? static_cast<uint64_t>(1ull << ((i % 16) * 4))
                              : 0;
           index++;
         } else {
           out[i / 16] |= ((n[index / 16] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 4)))
+                             ? static_cast<uint64_t>(1ull << ((i % 16) * 4))
                              : 0;
         }
         interleave = !interleave;
@@ -8036,15 +8036,15 @@ void Instruction::execute() {
       bool interleave = false;
       int index = partition_num / 2;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = static_cast<uint64_t>(std::pow(2, index));
+        uint64_t shifted_active = static_cast<uint64_t>(1ull << (index % 64));
         if (interleave) {
           out[i / 64] |= ((m[index / 64] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, i))
+                             ? static_cast<uint64_t>(1ull << (i % 64))
                              : 0;
           index++;
         } else {
           out[i / 64] |= ((n[index / 64] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, i))
+                             ? static_cast<uint64_t>(1ull << (i % 64))
                              : 0;
         }
         interleave = !interleave;
@@ -8064,15 +8064,15 @@ void Instruction::execute() {
       int index = partition_num / 2;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 8)));
+            static_cast<uint64_t>(1ull << ((index % 8) * 8));
         if (interleave) {
           out[i / 8] |= ((m[index / 8] & shifted_active) == shifted_active)
-                            ? static_cast<uint64_t>(std::pow(2, (i * 8)))
+                            ? static_cast<uint64_t>(1ull << ((i % 8) * 8))
                             : 0;
           index++;
         } else {
           out[i / 8] |= ((n[index / 8] & shifted_active) == shifted_active)
-                            ? static_cast<uint64_t>(std::pow(2, (i * 8)))
+                            ? static_cast<uint64_t>(1ull << ((i % 8) * 8))
                             : 0;
         }
         interleave = !interleave;
@@ -8092,15 +8092,15 @@ void Instruction::execute() {
       int index = partition_num / 2;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 2)));
+            static_cast<uint64_t>(1ull << ((index % 32) * 2));
         if (interleave) {
           out[i / 32] |= ((m[index / 32] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 2)))
+                             ? static_cast<uint64_t>(1ull << ((i % 32) * 2))
                              : 0;
           index++;
         } else {
           out[i / 32] |= ((n[index / 32] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 2)))
+                             ? static_cast<uint64_t>(1ull << ((i % 32) * 2))
                              : 0;
         }
         interleave = !interleave;
@@ -8120,15 +8120,15 @@ void Instruction::execute() {
       int index = partition_num / 2;
       for (int i = 0; i < partition_num; i++) {
         uint64_t shifted_active =
-            static_cast<uint64_t>(std::pow(2, (index * 4)));
+            static_cast<uint64_t>(1ull << ((index % 16) * 4));
         if (interleave) {
           out[i / 16] |= ((m[index / 16] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 4)))
+                             ? static_cast<uint64_t>(1ull << ((i % 16) * 4))
                              : 0;
           index++;
         } else {
           out[i / 16] |= ((n[index / 16] & shifted_active) == shifted_active)
-                             ? static_cast<uint64_t>(std::pow(2, (i * 4)))
+                             ? static_cast<uint64_t>(1ull << ((i % 16) * 4))
                              : 0;
         }
         interleave = !interleave;

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -1268,7 +1268,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           out[i / 64] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1289,7 +1289,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i / 8] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1310,7 +1310,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 2));
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           out[i / 32] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1331,7 +1331,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i / 16] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1352,7 +1352,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           out[i / 64] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1373,7 +1373,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i / 8] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1394,7 +1394,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 2));
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           out[i / 32] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1415,7 +1415,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i / 16] |= (n[i] > m[i]) ? shifted_active : 0;
         }
@@ -1891,7 +1891,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           out[i / 64] |= ((n[i / 64] ^ m[i / 64]) & shifted_active);
         }
@@ -2220,7 +2220,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active)
           out[i] = d[i] + con;
         else
@@ -2240,7 +2240,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active)
           out[i] = d[i] + con;
         else
@@ -2486,7 +2486,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i / 8] |= (n[i] > 0.0) ? shifted_active : 0;
         }
@@ -2503,7 +2503,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i / 16] |= (n[i] > 0.0) ? shifted_active : 0;
         }
@@ -2597,7 +2597,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i / 8] |= (n[i] <= 0.0) ? shifted_active : 0;
         }
@@ -2615,7 +2615,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i / 16] |= (n[i] <= 0.0f) ? shifted_active : 0;
         }
@@ -2974,7 +2974,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[i] > std::numeric_limits<float>::max())
             out[(2 * i)] = std::numeric_limits<float>::max();
@@ -3000,7 +3000,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[(2 * i)] > std::numeric_limits<double>::max())
             out[i] = std::numeric_limits<double>::max();
@@ -3036,7 +3036,7 @@ void Instruction::execute() {
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = m[i] / d[i];
         } else {
@@ -3055,7 +3055,7 @@ void Instruction::execute() {
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = m[i] / d[i];
         } else {
@@ -3144,7 +3144,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = c[i] + (a[i] * b[i]);
         } else {
@@ -3331,7 +3331,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = a[i] + (-b[i] * c[i]);
         } else {
@@ -3447,7 +3447,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = m[i] + (-d[i] * n[i]);
         } else {
@@ -3730,7 +3730,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active)
           out[i] = -d[i] + (n[i] * m[i]);
         else
@@ -3751,7 +3751,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active)
           out[i] = -d[i] + (n[i] * m[i]);
         else
@@ -3971,7 +3971,7 @@ void Instruction::execute() {
       const uint16_t partition_num = VL_bits / 64;
       double out[32] = {0};
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = ::sqrt(n[i]);
         } else {
@@ -4750,7 +4750,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = memoryData[index].get<uint64_t>();
           index++;
@@ -4768,7 +4768,7 @@ void Instruction::execute() {
 
       uint8_t index = 0;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = memoryData[index].get<uint64_t>();
           index++;
@@ -4786,7 +4786,7 @@ void Instruction::execute() {
 
       uint8_t index = 0;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = static_cast<int64_t>(memoryData[index].get<int32_t>());
           index++;
@@ -4803,7 +4803,7 @@ void Instruction::execute() {
       uint16_t out[128] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 2));
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           out[i] = memoryData[index].get<uint16_t>();
           index++;
@@ -5508,7 +5508,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active)
           out[i] = n[i];
         else
@@ -5528,7 +5528,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active)
           out[i] = n[i];
         else
@@ -5586,7 +5586,7 @@ void Instruction::execute() {
       const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 8;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, i);
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           out[i] = static_cast<uint8_t>(n[i] * m[i]);
         } else {
@@ -5605,7 +5605,7 @@ void Instruction::execute() {
       const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 64;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = static_cast<uint64_t>(n[i] * m[i]);
         } else {
@@ -5624,7 +5624,7 @@ void Instruction::execute() {
       const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 16;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 2));
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           out[i] = static_cast<uint16_t>(n[i] * m[i]);
         } else {
@@ -5643,7 +5643,7 @@ void Instruction::execute() {
       const uint64_t VL_bits = 512;
       const uint16_t partition_num = VL_bits / 32;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = static_cast<uint32_t>(n[i] * m[i]);
         } else {
@@ -5848,7 +5848,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 2));
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         out[i / 32] |= shifted_active;
       }
 
@@ -6111,7 +6111,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[i] < std::numeric_limits<double>::lowest())
             out[i] = std::numeric_limits<double>::lowest();
@@ -6136,7 +6136,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[i] > std::numeric_limits<float>::max())
             out[(2 * i)] = std::numeric_limits<float>::max();
@@ -6162,7 +6162,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[(2 * i)] > std::numeric_limits<double>::max())
             out[i] = std::numeric_limits<double>::max();
@@ -6187,7 +6187,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           if (n[i] < std::numeric_limits<float>::lowest())
             out[i] = std::numeric_limits<float>::lowest();
@@ -6575,7 +6575,7 @@ void Instruction::execute() {
 
       uint8_t index = 0;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = static_cast<uint32_t>(d[i]);
           index++;
@@ -6609,7 +6609,7 @@ void Instruction::execute() {
 
       uint8_t index = 0;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = t[i];
           index++;
@@ -6625,7 +6625,7 @@ void Instruction::execute() {
 
       uint8_t index = 0;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 4));
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           memoryData[index] = t[i];
           index++;
@@ -6641,7 +6641,7 @@ void Instruction::execute() {
 
       uint8_t index = 0;
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = t[i];
           index++;
@@ -7318,7 +7318,7 @@ void Instruction::execute() {
       int64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = std::pow(2, (i * 8));
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           // Cast to 32-bit to get 'least significant sub-element'
           // Then cast back to 64-bit to sign-extend this 'sub-element'

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -680,7 +680,7 @@ void Instruction::execute() {
       uint8_t out[256] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << i;
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           out[i] = dn[i] & m[i];
         } else {
@@ -700,7 +700,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = dn[i] & m[i];
         } else {
@@ -720,7 +720,7 @@ void Instruction::execute() {
       uint16_t out[128] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 2);
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           out[i] = dn[i] & m[i];
         } else {
@@ -740,7 +740,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = dn[i] & m[i];
         } else {
@@ -1481,7 +1481,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << i;
+        uint64_t shifted_active = 1ull << (i % 64);
         if (pg[i / 64] & shifted_active) {
           count += (pn[i / 64] & shifted_active) ? 1 : 0;
         }
@@ -1498,7 +1498,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (pg[i / 8] & shifted_active) {
           count += (pn[i / 8] & shifted_active) ? 1 : 0;
         }
@@ -1515,7 +1515,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 2);
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (pg[i / 32] & shifted_active) {
           count += (pn[i / 32] & shifted_active) ? 1 : 0;
         }
@@ -1532,7 +1532,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (pg[i / 16] & shifted_active) {
           count += (pn[i / 16] & shifted_active) ? 1 : 0;
         }
@@ -2063,7 +2063,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = ::fabs(n[i]);
         } else {
@@ -2084,7 +2084,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = ::fabs(n[i]);
         } else {
@@ -2116,7 +2116,7 @@ void Instruction::execute() {
       double out[2] = {operands[2].get<double>(), 0.0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[0] += m[i];
         }
@@ -2259,7 +2259,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = b[i] + c[i];
         } else {
@@ -2279,7 +2279,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = b[i] + c[i];
         } else {
@@ -2835,7 +2835,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[i] > 2147483647) {
             out[(2 * i)] = 2147483647;
@@ -2865,7 +2865,7 @@ void Instruction::execute() {
       int64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[i] > INT64_MAX) {
             out[i] = INT64_MAX;
@@ -2891,7 +2891,7 @@ void Instruction::execute() {
       int64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           if (n[(2 * i)] > INT64_MAX)
             out[i] = INT64_MAX;
@@ -2916,7 +2916,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           if (n[i] > INT32_MAX) {
             out[i] = INT32_MAX;
@@ -3075,7 +3075,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = b[i] / c[i];
         } else {
@@ -3166,7 +3166,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = c[i] + (a[i] * b[i]);
         } else {
@@ -3262,7 +3262,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = a[i] + (b[i] * c[i]);
         } else {
@@ -3283,7 +3283,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = a[i] + (b[i] * c[i]);
         } else {
@@ -3352,7 +3352,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = a[i] + (-b[i] * c[i]);
         } else {
@@ -3469,7 +3469,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = c[i] + (-a[i] * b[i]);
         } else {
@@ -3588,7 +3588,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = n[i] * fp;
         } else {
@@ -3608,7 +3608,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = n[i] * fp;
         } else {
@@ -3628,7 +3628,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = n[i] * m[i];
         } else {
@@ -3648,7 +3648,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = n[i] * m[i];
         } else {
@@ -3676,7 +3676,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = -n[i];
         } else {
@@ -3696,7 +3696,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = -n[i];
         } else {
@@ -3772,7 +3772,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = -a[i] + n[i] * m[i];
         } else {
@@ -3793,7 +3793,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = -a[i] + n[i] * m[i];
         } else {
@@ -3843,7 +3843,7 @@ void Instruction::execute() {
       int64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = doubleRoundToNearestTiesToEven(n[i]);
         } else {
@@ -3863,7 +3863,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = floatRoundToNearestTiesToEven(n[i]);
         } else {
@@ -3990,7 +3990,7 @@ void Instruction::execute() {
       const uint16_t partition_num = VL_bits / 32;
       float out[64] = {0};
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = ::sqrt(n[i]);
         } else {
@@ -4035,7 +4035,7 @@ void Instruction::execute() {
       double out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = dn[i] - m[i];
         } else {
@@ -4055,7 +4055,7 @@ void Instruction::execute() {
       float out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = dn[i] - m[i];
         } else {
@@ -4179,7 +4179,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << i;
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           count++;
         }
@@ -4195,7 +4195,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           count++;
         }
@@ -4211,7 +4211,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 2);
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           count++;
         }
@@ -4227,7 +4227,7 @@ void Instruction::execute() {
       uint64_t count = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           count++;
         }
@@ -4686,7 +4686,7 @@ void Instruction::execute() {
       uint8_t out[256] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << i;
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           out[i] = memoryData[index].get<uint8_t>();
           index++;
@@ -4706,7 +4706,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = memoryData[index].get<uint64_t>();
           index++;
@@ -4727,7 +4727,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = memoryData[index].get<uint64_t>();
           index++;
@@ -4823,7 +4823,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = memoryData[index].get<uint32_t>();
           index++;
@@ -4844,7 +4844,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = memoryData[index].get<uint32_t>();
           index++;
@@ -5327,7 +5327,7 @@ void Instruction::execute() {
       uint8_t out[256] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << i;
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           out[i] = d[i] + (n[i] * m[i]);
         } else {
@@ -5348,7 +5348,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = d[i] + (n[i] * m[i]);
         } else {
@@ -5369,7 +5369,7 @@ void Instruction::execute() {
       uint16_t out[128] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 2);
+        uint64_t shifted_active = 1ull << ((i % 32) * 2);
         if (p[i / 32] & shifted_active) {
           out[i] = d[i] + (n[i] * m[i]);
         } else {
@@ -5390,7 +5390,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = d[i] + (n[i] * m[i]);
         } else {
@@ -5822,7 +5822,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << i;
+        uint64_t shifted_active = 1ull << (i % 64);
         out[i / 64] |= shifted_active;
       }
 
@@ -5835,7 +5835,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         out[i / 8] |= shifted_active;
       }
 
@@ -5861,7 +5861,7 @@ void Instruction::execute() {
       uint64_t out[4] = {0, 0, 0, 0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         out[i / 16] |= shifted_active;
       }
       results[0] = out;
@@ -6281,7 +6281,7 @@ void Instruction::execute() {
       uint64_t out[32] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           out[i] = n[i];
         } else {
@@ -6301,7 +6301,7 @@ void Instruction::execute() {
       uint32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = n[i];
         } else {
@@ -6361,7 +6361,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = std::max(n[i], m[i]);
         } else {
@@ -6391,7 +6391,7 @@ void Instruction::execute() {
       int32_t out[64] = {0};
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out[i] = std::min(n[i], m[i]);
         } else {
@@ -6411,7 +6411,7 @@ void Instruction::execute() {
       int32_t out = INT32_MAX;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           out = std::min(out, n[i]);
         }
@@ -6484,7 +6484,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << i;
+        uint64_t shifted_active = 1ull << (i % 64);
         if (p[i / 64] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -6501,7 +6501,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = static_cast<uint8_t>(d[i]);
           index++;
@@ -6524,7 +6524,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -6541,7 +6541,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 8);
+        uint64_t shifted_active = 1ull << ((i % 8) * 8);
         if (p[i / 8] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -6558,7 +6558,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           memoryData[index] = d[i];
           index++;
@@ -6592,7 +6592,7 @@ void Instruction::execute() {
       uint8_t index = 0;
 
       for (int i = 0; i < partition_num; i++) {
-        uint64_t shifted_active = 1ull << (i * 4);
+        uint64_t shifted_active = 1ull << ((i % 16) * 4);
         if (p[i / 16] & shifted_active) {
           memoryData[index] = d[i];
           index++;

--- a/test/regression/RegressionTest.cc
+++ b/test/regression/RegressionTest.cc
@@ -95,7 +95,7 @@ void RegressionTest::run(const char* source, const char* triple) {
   // Create a branch predictor for a pipelined core
   simeng::BTBPredictor predictor(8);
   // Create the core model
-  switch (GetParam()) {
+  switch (std::get<0>(GetParam())) {
     case EMULATION:
       core_ = std::make_unique<simeng::models::emulation::Core>(
           instructionMemory, *flatDataMemory, entryPoint, processMemorySize_,

--- a/test/regression/RegressionTest.hh
+++ b/test/regression/RegressionTest.hh
@@ -16,21 +16,6 @@
 /** The different types of core model that can be used in tests. */
 enum CoreType { EMULATION, INORDER, OUTOFORDER };
 
-/** A helper function to convert a `CoreType` to a human-readable string. */
-inline std::string coreTypeToString(
-    const testing::TestParamInfo<CoreType> val) {
-  switch (val.param) {
-    case EMULATION:
-      return "emulation";
-    case INORDER:
-      return "inorder";
-    case OUTOFORDER:
-      return "outoforder";
-    default:
-      return "unknown";
-  }
-}
-
 /** The base class for all regression tests.
  *
  * This is a googletest fixture which is parameterisable on a builtin core
@@ -42,7 +27,8 @@ inline std::string coreTypeToString(
  * methods are provided to query the state of the core and memory after
  * execution has completed.
  */
-class RegressionTest : public ::testing::TestWithParam<CoreType> {
+class RegressionTest
+    : public ::testing::TestWithParam<std::tuple<CoreType, YAML::Node>> {
  protected:
   virtual ~RegressionTest();
 

--- a/test/regression/aarch64/AArch64RegressionTest.cc
+++ b/test/regression/aarch64/AArch64RegressionTest.cc
@@ -11,7 +11,7 @@ void AArch64RegressionTest::run(const char* source) {
 
 YAML::Node AArch64RegressionTest::generateConfig() const {
   YAML::Node config = YAML::Load(AARCH64_CONFIG);
-  switch (GetParam()) {
+  switch (std::get<0>(GetParam())) {
     case EMULATION:
       config["Core"]["Simulation-Mode"] = "emulation";
       break;
@@ -21,6 +21,16 @@ YAML::Node AArch64RegressionTest::generateConfig() const {
     case OUTOFORDER:
       config["Core"]["Simulation-Mode"] = "outoforder";
       break;
+  }
+
+  YAML::Node additionalConfig = std::get<1>(GetParam());
+  // Merge specific aarch64 config options
+  if (additionalConfig["Vector-Length"].IsDefined() &&
+      !(additionalConfig["Vector-Length"].IsNull())) {
+    config["Core"]["Vector-Length"] =
+        additionalConfig["Vector-Length"].as<uint64_t>();
+  } else {
+    config["Core"]["Vector-Length"] = 512;
   }
   return config;
 }

--- a/test/regression/aarch64/AArch64RegressionTest.hh
+++ b/test/regression/aarch64/AArch64RegressionTest.hh
@@ -270,7 +270,7 @@ class AArch64RegressionTest : public RegressionTest {
     for (int i = 0; i < grouped_lanes; i++) {
       if (pattern[i % pattern.size()]) {
         generatedArray[(int)(i * byte_arrangement) / 64] |=
-            (uint64_t)std::pow(2, (i * byte_arrangement) % 64);
+            1ull << ((i * byte_arrangement) % 64);
       }
     }
     return generatedArray;

--- a/test/regression/aarch64/AArch64RegressionTest.hh
+++ b/test/regression/aarch64/AArch64RegressionTest.hh
@@ -17,6 +17,53 @@
    "60, 61]}}, Reservation-Stations: {'0': {Size: 60, Ports: [0]}}, "          \
    "Execution-Units: {'0': {Pipelined: true}}}")
 
+/** A helper function to convert the supplied parameters of
+ * INSTANTIATE_TEST_SUITE_P into test name. */
+inline std::string paramToString(
+    const testing::TestParamInfo<std::tuple<CoreType, YAML::Node>> val) {
+  YAML::Node config = YAML::Load(AARCH64_CONFIG);
+
+  // Get core type as string
+  std::string coreString = "";
+  switch (std::get<0>(val.param)) {
+    case EMULATION:
+      coreString = "emulation";
+      break;
+    case INORDER:
+      coreString = "inorder";
+      break;
+    case OUTOFORDER:
+      coreString = "outoforder";
+      break;
+    default:
+      coreString = "unknown";
+      break;
+  }
+  // Get vector length as string
+  std::string vectorLengthString = "";
+  if (std::get<1>(val.param)["Vector-Length"].IsDefined() &&
+      !(std::get<1>(val.param)["Vector-Length"].IsNull())) {
+    vectorLengthString =
+        "WithVL" + std::get<1>(val.param)["Vector-Length"].as<std::string>();
+  }
+  return coreString + vectorLengthString;
+}
+
+/** A helper function to generate all coreType vector-length pairs. */
+inline std::vector<std::tuple<CoreType, YAML::Node>> genCoreTypeVLPairs(
+    CoreType type) {
+  std::vector<std::tuple<CoreType, YAML::Node>> coreVLPairs;
+  YAML::Node vlNode;
+  vlNode["Vector-Length"] = 512;
+  coreVLPairs.push_back(std::make_tuple(type, vlNode));
+  // for (uint64_t i = 128; i < 2049; i += 128) {
+  //   YAML::Node vlNode;
+  //   vlNode["Vector-Length"] = i;
+  //   coreVLPairs.push_back(std::make_tuple(type, vlNode));
+  // }
+  return coreVLPairs;
+}
+
 /** A helper macro to run a snippet of Armv8 assembly code, returning from the
  * calling function if a fatal error occurs. Four bytes containing zeros are
  * appended to the source to ensure that the program will terminate with an
@@ -155,4 +202,87 @@ class AArch64RegressionTest : public RegressionTest {
 
   /** Get the overflow flag from the NZCV register. */
   bool getOverflowFlag() const;
+
+  /** Generate an array representing a NEON register from a source vector and a
+   * number of elements defined by a number of bytes used. */
+  template <typename T>
+  std::array<T, (256 / sizeof(T))> fillNeon(std::vector<T> src,
+                                            int num_bytes) const {
+    // Create array to be returned and fill with a default value of 0
+    std::array<T, (256 / sizeof(T))> generatedArray;
+    generatedArray.fill(0);
+    // Fill array by cycling through source elements
+    for (int i = 0; i < (num_bytes / sizeof(T)); i++) {
+      generatedArray[i] = src[i % src.size()];
+    }
+    return generatedArray;
+  }
+
+  /** Generate an array representing a NEON register by combining two source
+   * vectors and a number of elements defined by a number of bytes used. */
+  template <typename T>
+  std::array<T, (256 / sizeof(T))> fillNeonCombined(std::vector<T> srcA,
+                                                    std::vector<T> srcB,
+                                                    int num_bytes) const {
+    // Create array to be returned and fill with a default value of 0
+    std::array<T, (256 / sizeof(T))> generatedArray;
+    generatedArray.fill(0);
+    // Fill array by cycling through source elements
+    int num_elements = (num_bytes / sizeof(T)) / 2;
+    for (int i = 0; i < num_elements; i++) {
+      generatedArray[i] = srcA[i % srcA.size()];
+      generatedArray[i + num_elements] = srcB[i % srcB.size()];
+    }
+    return generatedArray;
+  }
+
+  /** Fill an array dest of T entries, representing the initialHeapData_, from a
+   * source vector and a number of entries. */
+  template <typename T>
+  void fillHeap(T* dest, std::vector<T> src, int entries) const {
+    // Fill destination by cycling through source elements
+    for (int i = 0; i < entries; i++) {
+      dest[i] = src[i % src.size()];
+    }
+  }
+
+  /** Fill an array dest of T entries, representing the initialHeapData_, by
+   * combining two source vectors and a number of entries. */
+  template <typename T>
+  void fillHeapCombined(T* dest, std::vector<T> srcA, std::vector<T> srcB,
+                        int entries) const {
+    // Fill destination by cycling through source elements
+    for (int i = 0; i < entries / 2; i++) {
+      dest[i] = srcA[i % srcA.size()];
+      dest[i + (entries / 2)] = srcB[i % srcB.size()];
+    }
+  }
+
+  /** Generate an array representing a PREDICATE register from a number of
+   * lanes, a pattern and a vector arrangement used in bytes. */
+  std::array<uint64_t, 4> fillPred(int num_lanes, std::vector<uint8_t> pattern,
+                                   int byte_arrangement) const {
+    // Create array to be returned and fill with a default value of 0
+    std::array<uint64_t, 4> generatedArray;
+    generatedArray.fill(0);
+    // Get number of lanes accounting for byte_arrangement
+    int grouped_lanes = (num_lanes % byte_arrangement != 0)
+                            ? std::ceil((double)num_lanes / byte_arrangement)
+                            : (num_lanes / byte_arrangement);
+    // Activate number of lanes
+    for (int i = 0; i < grouped_lanes; i++) {
+      if (pattern[i % pattern.size()]) {
+        generatedArray[(int)(i * byte_arrangement) / 64] |=
+            (uint64_t)std::pow(2, (i * byte_arrangement) % 64);
+      }
+    }
+    return generatedArray;
+  }
+
+  /** The current vector-length being used by the test suite. */
+  const uint64_t VL =
+      (std::get<1>(GetParam())["Vector-Length"].IsDefined() &&
+       !(std::get<1>(GetParam())["Vector-Length"].IsNull()))
+          ? std::get<1>(GetParam())["Vector-Length"].as<uint64_t>()
+          : 0;
 };

--- a/test/regression/aarch64/AArch64RegressionTest.hh
+++ b/test/regression/aarch64/AArch64RegressionTest.hh
@@ -53,14 +53,11 @@ inline std::string paramToString(
 inline std::vector<std::tuple<CoreType, YAML::Node>> genCoreTypeVLPairs(
     CoreType type) {
   std::vector<std::tuple<CoreType, YAML::Node>> coreVLPairs;
-  YAML::Node vlNode;
-  vlNode["Vector-Length"] = 512;
-  coreVLPairs.push_back(std::make_tuple(type, vlNode));
-  // for (uint64_t i = 128; i < 2049; i += 128) {
-  //   YAML::Node vlNode;
-  //   vlNode["Vector-Length"] = i;
-  //   coreVLPairs.push_back(std::make_tuple(type, vlNode));
-  // }
+  for (uint64_t i = 128; i <= 2048; i += 128) {
+    YAML::Node vlNode;
+    vlNode["Vector-Length"] = i;
+    coreVLPairs.push_back(std::make_tuple(type, vlNode));
+  }
   return coreVLPairs;
 }
 

--- a/test/regression/aarch64/Exception.cc
+++ b/test/regression/aarch64/Exception.cc
@@ -14,8 +14,11 @@ TEST_P(Exception, misaligned_pc) {
   EXPECT_EQ(stdout_.substr(0, sizeof(err) - 1), err);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, Exception,
-                         ::testing::Values(EMULATION, INORDER, OUTOFORDER),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(
+    AArch64, Exception,
+    ::testing::Values(std::make_tuple(EMULATION, YAML::Load("{}")),
+                      std::make_tuple(INORDER, YAML::Load("{}")),
+                      std::make_tuple(OUTOFORDER, YAML::Load("{}"))),
+    paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/LoadStoreQueue.cc
+++ b/test/regression/aarch64/LoadStoreQueue.cc
@@ -90,7 +90,9 @@ TEST_P(LoadStoreQueue, SpeculativeInvalidLoad) {
   )");
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, LoadStoreQueue, ::testing::Values(OUTOFORDER),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, LoadStoreQueue,
+                         ::testing::Values(std::make_tuple(OUTOFORDER,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/SmokeTest.cc
+++ b/test/regression/aarch64/SmokeTest.cc
@@ -57,8 +57,11 @@ TEST_P(SmokeTest, heap) {
   EXPECT_EQ(getMemoryValue<uint32_t>(process_->getHeapStart() + 4), 42u);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, SmokeTest,
-                         ::testing::Values(EMULATION, INORDER, OUTOFORDER),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(
+    AArch64, SmokeTest,
+    ::testing::Values(std::make_tuple(EMULATION, YAML::Load("{}")),
+                      std::make_tuple(INORDER, YAML::Load("{}")),
+                      std::make_tuple(OUTOFORDER, YAML::Load("{}"))),
+    paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -809,8 +809,11 @@ TEST_P(Syscall, ftruncate) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(23), 0);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, Syscall,
-                         ::testing::Values(EMULATION, INORDER, OUTOFORDER),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(
+    AArch64, Syscall,
+    ::testing::Values(std::make_tuple(EMULATION, YAML::Load("{}")),
+                      std::make_tuple(INORDER, YAML::Load("{}")),
+                      std::make_tuple(OUTOFORDER, YAML::Load("{}"))),
+    paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/SystemRegisters.cc
+++ b/test/regression/aarch64/SystemRegisters.cc
@@ -71,8 +71,11 @@ TEST_P(SystemRegister, sysreg_access) {
   EXPECT_EQ(getSystemRegister(0xde82), 42);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, SystemRegister,
-                         ::testing::Values(EMULATION, INORDER, OUTOFORDER),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(
+    AArch64, SystemRegister,
+    ::testing::Values(std::make_tuple(EMULATION, YAML::Load("{}")),
+                      std::make_tuple(INORDER, YAML::Load("{}")),
+                      std::make_tuple(OUTOFORDER, YAML::Load("{}"))),
+    paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/arithmetic.cc
+++ b/test/regression/aarch64/instructions/arithmetic.cc
@@ -654,7 +654,9 @@ TEST_P(InstArithmetic, umsubl) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(3), (7ul << 48) - (255 * 15));
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstArithmetic, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstArithmetic,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/bitmanip.cc
+++ b/test/regression/aarch64/instructions/bitmanip.cc
@@ -267,7 +267,9 @@ TEST_P(InstBitmanip, ubfm) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(4), 0x0000000007A00000ull);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstBitmanip, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstBitmanip,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/comparison.cc
+++ b/test/regression/aarch64/instructions/comparison.cc
@@ -349,7 +349,9 @@ TEST_P(InstComparison, tstx) {
   EXPECT_EQ(getNZCV(), 0b1000);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstComparison, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstComparison,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/conditional.cc
+++ b/test/regression/aarch64/instructions/conditional.cc
@@ -252,7 +252,9 @@ TEST_P(InstConditional, tbz) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(2), 15u);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstConditional, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstConditional,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/divide.cc
+++ b/test/regression/aarch64/instructions/divide.cc
@@ -61,7 +61,9 @@ TEST_P(InstDiv, udiv) {
   EXPECT_EQ(getGeneralRegister<uint32_t>(3), 0u);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstDiv, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstDiv,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/float.cc
+++ b/test/regression/aarch64/instructions/float.cc
@@ -1514,7 +1514,9 @@ TEST_P(InstFloat, ucvtf) {
   CHECK_NEON(11, float, {0.f, 0.f, 0.f, 0.f});
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstFloat, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstFloat,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/load.cc
+++ b/test/regression/aarch64/instructions/load.cc
@@ -987,7 +987,9 @@ TEST_P(InstLoad, ldxr) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(4), 512);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstLoad, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstLoad,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/logical.cc
+++ b/test/regression/aarch64/instructions/logical.cc
@@ -477,7 +477,9 @@ TEST_P(InstLogical, orn) {
             UINT64_C(-1) & ~(UINT64_C(0b0101) << 60));
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstLogical, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstLogical,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/misc.cc
+++ b/test/regression/aarch64/instructions/misc.cc
@@ -45,7 +45,9 @@ TEST_P(InstMisc, ret) {
   EXPECT_EQ(getGeneralRegister<uint32_t>(2), 0);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstMisc, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstMisc,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/multiply.cc
+++ b/test/regression/aarch64/instructions/multiply.cc
@@ -89,7 +89,9 @@ TEST_P(InstMul, umaddl) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(4), 0x0000002A00000000);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstMul, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstMul,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/neon.cc
+++ b/test/regression/aarch64/instructions/neon.cc
@@ -2677,7 +2677,9 @@ TEST_P(InstNeon, xtn) {
   CHECK_NEON(2, uint16_t, {42, (1u << 15), UINT16_MAX, 7, 0, 0, 0, 0});
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstNeon, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstNeon,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/store.cc
+++ b/test/regression/aarch64/instructions/store.cc
@@ -554,7 +554,9 @@ TEST_P(InstStore, sturh) {
   EXPECT_EQ(getMemoryValue<uint16_t>(process_->getStackPointer() - 4), 128u);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstStore, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstStore,
+                         ::testing::Values(std::make_tuple(EMULATION,
+                                                           YAML::Load("{}"))),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/sve.cc
+++ b/test/regression/aarch64/instructions/sve.cc
@@ -722,14 +722,14 @@ TEST_P(InstSve, cnt) {
     cntw x6, all, mul #3
     cntd x7, all, mul #3
   )");
-  EXPECT_EQ(getGeneralRegister<uint64_t>(0), 64);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(1), 32);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(2), 16);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(3), 8);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(4), 192);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(5), 96);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(6), 48);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(7), 24);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(0), VL / 8);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(1), VL / 16);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(2), VL / 32);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(3), VL / 64);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(4), (VL / 8) * 3);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(5), (VL / 16) * 3);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(6), (VL / 32) * 3);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(7), (VL / 64) * 3);
 }
 
 TEST_P(InstSve, cntp) {
@@ -6355,7 +6355,8 @@ TEST_P(InstSve, zip) {
               0.75, -0.5, 0.75, -0.5, 0.75});
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, InstSve, ::testing::Values(EMULATION),
-                         coreTypeToString);
+INSTANTIATE_TEST_SUITE_P(AArch64, InstSve,
+                         ::testing::ValuesIn(genCoreTypeVLPairs(EMULATION)),
+                         paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/instructions/sve.cc
+++ b/test/regression/aarch64/instructions/sve.cc
@@ -2420,7 +2420,7 @@ TEST_P(InstSve, fmsb) {
   CHECK_NEON(2, float, fillNeonCombined<float>(fresults, fsrcB, VL / 8));
 
   // Double
-  initialHeapData_.resize(VL / 8);
+  initialHeapData_.resize(VL / 4);
   double* dheap = reinterpret_cast<double*>(initialHeapData_.data());
   std::vector<double> dsrcA = {1.0, -42.76, -0.125, 0.0};
   std::vector<double> dsrcB = {-34.71, -0.917, 0.0, 80.72};

--- a/test/unit/ISATest.cc
+++ b/test/unit/ISATest.cc
@@ -8,11 +8,12 @@ namespace {
 // Test that we can create an AArch64 Architecture object
 TEST(ISATest, CreateAArch64) {
   simeng::kernel::Linux kernel;
+  YAML::Node config =
+      YAML::Load("{Core: {Simulation-Mode: emulation, Vector-Length: 512}}");
   // Pass a config file with only the options required by the aarch64
   // architecture class to function
   std::unique_ptr<simeng::arch::Architecture> isa =
-      std::make_unique<simeng::arch::aarch64::Architecture>(
-          kernel, YAML::Load("{Core: {Simulation-Mode: emulation}}"));
+      std::make_unique<simeng::arch::aarch64::Architecture>(kernel, config);
 
   EXPECT_GT(isa->getRegisterFileStructures().size(), 0);
 }


### PR DESCRIPTION
This PR enables the configuration of the vector length used by the simulated SVE instructions. The test suite has been updated to reflect the use of vector length values from 128 up to 2048.