### PR TITLE
Fix for sve FNEG (predicated) instruction

### DIFF
--- a/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
+++ b/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
@@ -139,16 +139,15 @@ class AuxFunc {
 
   // Rounding function that rounds a double to nearest integer (64-bit). In
   // event of a tie (i.e. 7.5) it will be rounded to the nearest even number.
-  static int64_t doubleRoundToNearestTiesToEven(double input) {
-    if (std::fabs(input - std::trunc(input)) == 0.5) {
-      if (static_cast<int64_t>(input - 0.5) % 2 == 0) {
-        return static_cast<int64_t>(input - 0.5);
-      } else {
-        return static_cast<int64_t>(input + 0.5);
-      }
+  template <typename IN, typename OUT>
+  static OUT doubleRoundToNearestTiesToEven(IN input) {
+    IN half = static_cast<IN>(0.5);
+    if (std::fabs(input - std::trunc(input)) == half) {
+      OUT truncd = static_cast<OUT>(std::trunc(input));
+      return ((truncd % 2 == 0) ? truncd : (truncd + 1));
     }
     // Otherwise round to nearest
-    return static_cast<int64_t>(std::round(input));
+    return static_cast<OUT>(std::round(input));
   }
 
   /** Extend `value` according to `extendType`, and left-shift the result by

--- a/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
+++ b/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
@@ -268,6 +268,10 @@ class AuxFunc {
 
     // Get pattern string
     std::string pattern(operandStr.substr(operandStr.find(",") + 2));
+    if (pattern.find(',') != std::string::npos) {
+      pattern.erase(pattern.find(","));
+    }
+
     if (pattern == "pow2") {
       int n = 1;
       while (elements >= std::pow(2, n)) {
@@ -304,6 +308,8 @@ class AuxFunc {
       return elements - (elements % 4);
     else if (pattern == "mul3")
       return elements - (elements % 3);
+    else if (pattern == "all")
+      return elements;
 
     return 0;
   }

--- a/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
+++ b/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
@@ -140,10 +140,11 @@ class AuxFunc {
   // Rounding function that rounds a double to nearest integer (64-bit). In
   // event of a tie (i.e. 7.5) it will be rounded to the nearest even number.
   template <typename IN, typename OUT>
-  static OUT doubleRoundToNearestTiesToEven(IN input) {
+  static OUT roundToNearestTiesToEven(IN input) {
     IN half = static_cast<IN>(0.5);
     if (std::fabs(input - std::trunc(input)) == half) {
       OUT truncd = static_cast<OUT>(std::trunc(input));
+
       return ((truncd % 2 == 0) ? truncd : (truncd + 1));
     }
     // Otherwise round to nearest

--- a/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
+++ b/src/include/simeng/arch/aarch64/helpers/auxiliaryFunctions.hh
@@ -144,8 +144,10 @@ class AuxFunc {
     IN half = static_cast<IN>(0.5);
     if (std::fabs(input - std::trunc(input)) == half) {
       OUT truncd = static_cast<OUT>(std::trunc(input));
-
-      return ((truncd % 2 == 0) ? truncd : (truncd + 1));
+      // if value is negative, then may need to -1 from truncd, else may need to
+      // +1.
+      OUT addand = (truncd > 0) ? 1 : -1;
+      return ((truncd % 2 == 0) ? truncd : (truncd + addand));
     }
     // Otherwise round to nearest
     return static_cast<OUT>(std::round(input));

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -162,7 +162,10 @@ class sveHelp {
       const simeng::arch::aarch64::InstructionMetadata& metadata,
       const uint16_t VL_bits) {
     const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-    return (uint64_t)((VL_bits / (sizeof(T) * 8)) * imm);
+
+    const uint16_t elems =
+        AuxFunc::sveGetPattern(metadata.operandStr, (sizeof(T) * 8), VL_bits);
+    return (uint64_t)(elems * imm);
   }
 
   /** Helper function for SVE instructions with the format `cntp xd, pg, pn`.

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -1072,7 +1072,7 @@ class sveHelp {
     return {out, 256};
   }
 
-  /** Helper function for SVE instructions with the format `mul zd, pg/m, zn,
+  /** Helper function for SVE instructions with the format `mul zdn, pg/m, zdn,
    * <zm, #imm>`.
    * T represents the type of operands (e.g. for zn.d, T = uint64_t).
    * Returns correctly formatted RegisterValue. */

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -758,7 +758,7 @@ class sveHelp {
     for (int i = 0; i < partition_num; i++) {
       uint64_t shifted_active = 1ull << ((i % (64 / sizeof(N))) * sizeof(N));
       if (p[i / (64 / sizeof(N))] & shifted_active) {
-        out[i] = AuxFunc::doubleRoundToNearestTiesToEven<N, D>(n[i]);
+        out[i] = AuxFunc::roundToNearestTiesToEven<N, D>(n[i]);
       } else {
         out[i] = d[i];
       }

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -249,7 +249,7 @@ class sveHelp {
    * Returns single value of type uint64_t. */
   // TODO : Add support for patterns
   template <typename T>
-  static uint64_t sveDec_scalar(
+  static int64_t sveDec_scalar(
       std::array<RegisterValue, Instruction::MAX_SOURCE_REGISTERS>& operands,
       const simeng::arch::aarch64::InstructionMetadata& metadata,
       const uint16_t VL_bits) {
@@ -789,17 +789,19 @@ class sveHelp {
   }
 
   /** Helper function for SVE instructions with the format `inc<b, d, h, w>
-   * xdn{, pattern{, #imm}}`.
+   * xdn{, pattern{, MUL #imm}}`.
    * T represents the type of operation (e.g. for INCB, T = int8_t).
    * Returns single value of type uint64_t. */
   template <typename T>
-  static uint64_t sveInc_gprImm(
+  static int64_t sveInc_gprImm(
       std::array<RegisterValue, Instruction::MAX_SOURCE_REGISTERS>& operands,
       const simeng::arch::aarch64::InstructionMetadata& metadata,
       const uint16_t VL_bits) {
-    const uint64_t n = operands[0].get<uint64_t>();
+    const int64_t n = operands[0].get<int64_t>();
     const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-    uint64_t out = n + ((VL_bits / (sizeof(T) * 8)) * imm);
+    const uint16_t elems =
+        AuxFunc::sveGetPattern(metadata.operandStr, sizeof(T) * 8, VL_bits);
+    int64_t out = n + (elems * imm);
     return out;
   }
 

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -792,7 +792,7 @@ class sveHelp {
   /** Helper function for SVE instructions with the format `inc<b, d, h, w>
    * xdn{, pattern{, MUL #imm}}`.
    * T represents the type of operation (e.g. for INCB, T = int8_t).
-   * Returns single value of type uint64_t. */
+   * Returns single value of type int64_t. */
   template <typename T>
   static int64_t sveInc_gprImm(
       std::array<RegisterValue, Instruction::MAX_SOURCE_REGISTERS>& operands,

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -336,7 +336,7 @@ class sveHelp {
   }
 
   /** Helper function for SVE instructions with the format `fadda rd,
-   * pg/m, rn, zm`.
+   * pg, rn, zm`.
    * T represents the type of operands (e.g. for zm.d, T = uint64_t).
    * Returns correctly formatted RegisterValue. */
   template <typename T>
@@ -741,7 +741,7 @@ class sveHelp {
    * zn`.
    * D represents the destination vector register type (e.g. zd.s would be
    * int32_t).
-   * N represents the source vector register type (e.g. zd.d would be
+   * N represents the source vector register type (e.g. zn.d would be
    * double).
    * Returns correctly formatted RegisterValue. */
   template <typename D, typename N>
@@ -757,10 +757,11 @@ class sveHelp {
 
     for (int i = 0; i < partition_num; i++) {
       uint64_t shifted_active = 1ull << ((i % (64 / sizeof(N))) * sizeof(N));
-      if (p[i / (64 / sizeof(N))] & shifted_active)
-        out[i] = AuxFunc::doubleRoundToNearestTiesToEven(n[i]);
-      else
+      if (p[i / (64 / sizeof(N))] & shifted_active) {
+        out[i] = AuxFunc::doubleRoundToNearestTiesToEven<N, D>(n[i]);
+      } else {
         out[i] = d[i];
+      }
     }
     return {out, 256};
   }
@@ -904,7 +905,7 @@ class sveHelp {
   }
 
   /** Helper function for SVE instructions with the format `<AND, EOR, ...>
-   * zd, pg/z, zn, zm`.
+   * zd, pg/m, zn, zm`.
    * T represents the type of operands (e.g. for zn.d, T = uint64_t).
    * Returns correctly formatted RegisterValue. */
   template <typename T>
@@ -1258,7 +1259,7 @@ class sveHelp {
     return {out, 256};
   }
 
-  /** Helper function for SVE instructions with the format `sel zd, pg/z, zn,
+  /** Helper function for SVE instructions with the format `sel zd, pg, zn,
    * zm`.
    * T represents the type of operands (e.g. for zn.d, T = uint64_t).
    * Returns correctly formatted RegisterValue. */

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -253,9 +253,11 @@ class sveHelp {
       std::array<RegisterValue, Instruction::MAX_SOURCE_REGISTERS>& operands,
       const simeng::arch::aarch64::InstructionMetadata& metadata,
       const uint16_t VL_bits) {
-    const uint64_t n = operands[0].get<uint64_t>();
+    const int64_t n = operands[0].get<int64_t>();
     const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
-    return (n - ((VL_bits / (sizeof(T) * 8)) * imm));
+    const uint16_t elems =
+        AuxFunc::sveGetPattern(metadata.operandStr, sizeof(T) * 8, VL_bits);
+    return (n - (elems * imm));
   }
 
   /** Helper function for SVE instructions with the format `dup zd, <#imm{,

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -247,7 +247,6 @@ class sveHelp {
    * pattern{, MUL #imm}}`.
    * T represents the type of operation (e.g. for DECD, T = uint64_t).
    * Returns single value of type uint64_t. */
-  // TODO : Add support for patterns
   template <typename T>
   static int64_t sveDec_scalar(
       std::array<RegisterValue, Instruction::MAX_SOURCE_REGISTERS>& operands,
@@ -257,7 +256,7 @@ class sveHelp {
     const uint8_t imm = static_cast<uint8_t>(metadata.operands[1].imm);
     const uint16_t elems =
         AuxFunc::sveGetPattern(metadata.operandStr, sizeof(T) * 8, VL_bits);
-    return (n - (elems * imm));
+    return (n - static_cast<int64_t>(elems * imm));
   }
 
   /** Helper function for SVE instructions with the format `dup zd, <#imm{,

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -819,9 +819,11 @@ class sveHelp {
 
     const uint16_t partition_num = VL_bits / (sizeof(T) * 8);
     typename std::make_signed<T>::type out[256 / sizeof(T)] = {0};
+    const uint16_t elems =
+        AuxFunc::sveGetPattern(metadata.operandStr, sizeof(T) * 8, VL_bits);
 
     for (int i = 0; i < partition_num; i++) {
-      out[i] = n[i] + ((VL_bits / (sizeof(T) * 8)) * imm);
+      out[i] = n[i] + (elems * imm);
     }
     return {out, 256};
   }

--- a/src/include/simeng/arch/aarch64/helpers/sve.hh
+++ b/src/include/simeng/arch/aarch64/helpers/sve.hh
@@ -668,8 +668,9 @@ class sveHelp {
   static RegisterValue sveFnegPredicated(
       std::array<RegisterValue, Instruction::MAX_SOURCE_REGISTERS>& operands,
       const uint16_t VL_bits) {
-    const uint64_t* p = operands[0].getAsVector<uint64_t>();
-    const T* n = operands[1].getAsVector<T>();
+    const T* d = operands[0].getAsVector<T>();
+    const uint64_t* p = operands[1].getAsVector<uint64_t>();
+    const T* n = operands[2].getAsVector<T>();
 
     const uint16_t partition_num = VL_bits / (sizeof(T) * 8);
     T out[256 / sizeof(T)] = {0};
@@ -679,7 +680,7 @@ class sveHelp {
       if (p[i / (64 / sizeof(T))] & shifted_active)
         out[i] = -n[i];
       else
-        out[i] = n[i];
+        out[i] = d[i];
     }
     return {out, 256};
   }

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -380,10 +380,6 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       [[fallthrough]];
     case Opcode::AArch64_FMUL_ZZZ_S:
       [[fallthrough]];
-    case Opcode::AArch64_FNEG_ZPmZ_D:
-      [[fallthrough]];
-    case Opcode::AArch64_FNEG_ZPmZ_S:
-      [[fallthrough]];
     case Opcode::AArch64_SMAX_ZI_S:
       [[fallthrough]];
     case Opcode::AArch64_SMINV_VPZ_S:
@@ -415,6 +411,10 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
     case Opcode::AArch64_FCPY_ZPmI_D:
       [[fallthrough]];
     case Opcode::AArch64_FCPY_ZPmI_S:
+      [[fallthrough]];
+    case Opcode::AArch64_FNEG_ZPmZ_D:
+      [[fallthrough]];
+    case Opcode::AArch64_FNEG_ZPmZ_S:
       [[fallthrough]];
     case Opcode::AArch64_FRINTN_ZPmZ_D:
       [[fallthrough]];

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -7153,12 +7153,12 @@ void Instruction::execute() {
       }
       case Opcode::AArch64_INCB_XPiI: {  // incb xdn{, pattern{, #imm}}
         results[0] =
-            sveHelp::sveInc_gprImm<uint8_t>(operands, metadata, VL_bits);
+            sveHelp::sveInc_gprImm<int8_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_INCD_XPiI: {  // incd xdn{, pattern{, #imm}}
         results[0] =
-            sveHelp::sveInc_gprImm<uint64_t>(operands, metadata, VL_bits);
+            sveHelp::sveInc_gprImm<int64_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_INCD_ZPiI: {  // incd zdn.d{, pattern{, #imm}}
@@ -7167,7 +7167,7 @@ void Instruction::execute() {
       }
       case Opcode::AArch64_INCH_XPiI: {  // inch xdn{, pattern{, #imm}}
         results[0] =
-            sveHelp::sveInc_gprImm<uint16_t>(operands, metadata, VL_bits);
+            sveHelp::sveInc_gprImm<int16_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_INCH_ZPiI: {  // inch zdn.h{, pattern{, #imm}}
@@ -7204,7 +7204,7 @@ void Instruction::execute() {
       }
       case Opcode::AArch64_INCW_XPiI: {  // incw xdn{, pattern{, #imm}}
         results[0] =
-            sveHelp::sveInc_gprImm<uint32_t>(operands, metadata, VL_bits);
+            sveHelp::sveInc_gprImm<int32_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_INCW_ZPiI: {  // incw zdn.s{, pattern{, #imm}}

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -7162,7 +7162,7 @@ void Instruction::execute() {
         break;
       }
       case Opcode::AArch64_INCD_ZPiI: {  // incd zdn.d{, pattern{, #imm}}
-        results[0] = sveHelp::sveInc_imm<uint64_t>(operands, metadata, VL_bits);
+        results[0] = sveHelp::sveInc_imm<int64_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_INCH_XPiI: {  // inch xdn{, pattern{, #imm}}
@@ -7171,7 +7171,7 @@ void Instruction::execute() {
         break;
       }
       case Opcode::AArch64_INCH_ZPiI: {  // inch zdn.h{, pattern{, #imm}}
-        results[0] = sveHelp::sveInc_imm<uint16_t>(operands, metadata, VL_bits);
+        results[0] = sveHelp::sveInc_imm<int16_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_INCP_XP_B: {  // incp xdn, pm.b
@@ -7208,7 +7208,7 @@ void Instruction::execute() {
         break;
       }
       case Opcode::AArch64_INCW_ZPiI: {  // incw zdn.s{, pattern{, #imm}}
-        results[0] = sveHelp::sveInc_imm<uint32_t>(operands, metadata, VL_bits);
+        results[0] = sveHelp::sveInc_imm<int32_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_INDEX_II_B: {  // index zd.b, #imm, #imm

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -2559,12 +2559,12 @@ void Instruction::execute() {
       }
       case Opcode::AArch64_DECB_XPiI: {  // decb xdn{, pattern{, MUL #imm}}
         results[0] =
-            sveHelp::sveDec_scalar<uint8_t>(operands, metadata, VL_bits);
+            sveHelp::sveDec_scalar<int8_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_DECD_XPiI: {  // decd xdn{, pattern{, MUL #imm}}
         results[0] =
-            sveHelp::sveDec_scalar<uint64_t>(operands, metadata, VL_bits);
+            sveHelp::sveDec_scalar<int64_t>(operands, metadata, VL_bits);
         break;
       }
       case Opcode::AArch64_DECD_ZPiI: {

--- a/test/regression/aarch64/instructions/sve.cc
+++ b/test/regression/aarch64/instructions/sve.cc
@@ -1341,6 +1341,36 @@ TEST_P(InstSve, cnt) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(5), (VL / 16) * 3);
   EXPECT_EQ(getGeneralRegister<uint64_t>(6), (VL / 32) * 3);
   EXPECT_EQ(getGeneralRegister<uint64_t>(7), (VL / 64) * 3);
+
+  // pattern != all
+  RUN_AARCH64(R"(
+    cntb x0, pow2, mul #2
+    cnth x1, vl1, mul #2
+    cntw x2, vl2, mul #2
+    cntd x3, vl5, mul #2
+    cntb x4, vl7, mul #2
+    cnth x5, vl32, mul #2
+    cntw x6, vl128, mul #2
+    cntd x7, mul4, mul #2
+  )");
+  uint16_t maxElemsB = VL / 8;
+  uint16_t maxElemsH = VL / 16;
+  uint16_t maxElemsS = VL / 32;
+  uint16_t maxElemsD = VL / 64;
+  uint16_t n = 1;
+  while (maxElemsB >= std::pow(2, n)) {
+    n = n + 1;
+  }
+  uint16_t pow2B = std::pow(2, n - 1);
+
+  EXPECT_EQ(getGeneralRegister<uint64_t>(0), pow2B * 2);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(1), maxElemsH >= 1 ? (1 * 2) : 0);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(2), maxElemsS >= 2 ? (2 * 2) : 0);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(3), maxElemsD >= 5 ? (5 * 2) : 0);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(4), maxElemsB >= 7 ? (7 * 2) : 0);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(5), maxElemsH >= 32 ? (32 * 2) : 0);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(6), maxElemsS >= 128 ? (128 * 2) : 0);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(7), (maxElemsD - (maxElemsD % 4)) * 2);
 }
 
 TEST_P(InstSve, cntp) {

--- a/test/regression/aarch64/instructions/sve.cc
+++ b/test/regression/aarch64/instructions/sve.cc
@@ -2092,6 +2092,51 @@ TEST_P(InstSve, inc) {
              fillNeon<int64_t>({(int64_t)(3 + ((VL / 64)))}, (VL / 8)));
   CHECK_NEON(5, int64_t,
              fillNeon<int64_t>({(int64_t)(84 + ((VL / 64) * 5))}, (VL / 8)));
+
+  // pattern != all
+  // Vector Variants
+  RUN_AARCH64(R"(
+    dup z0.s, #15
+    dup z1.s, #37
+    dup z2.h, #25
+    dup z3.h, #19
+    dup z4.d, #3
+    dup z5.d, #84
+
+    incw z0.s, pow2, mul #3
+    incw z1.s, mul3, mul #2
+    inch z2.h, vl2, mul #3
+    inch z3.h, vl128, mul #3
+    incd z4.d, vl7, mul #3
+    incd z5.d, vl1, mul#3 
+  )");
+  n = 1;
+  while (maxElemsS >= std::pow(2, n)) {
+    n = n + 1;
+  }
+  uint16_t pow2S = std::pow(2, n - 1);
+
+  CHECK_NEON(0, int32_t,
+             fillNeon<int32_t>({(int32_t)(15 + (pow2S * 3))}, (VL / 8)));
+  CHECK_NEON(
+      1, int32_t,
+      fillNeon<int32_t>({(int32_t)(37 + ((maxElemsS - (maxElemsS % 3)) * 2))},
+                        (VL / 8)));
+  CHECK_NEON(
+      2, int16_t,
+      fillNeon<int16_t>({(int16_t)((maxElemsH >= 2) ? (25 + (2 * 3)) : 25)},
+                        (VL / 8)));
+  CHECK_NEON(
+      3, int16_t,
+      fillNeon<int16_t>({(int16_t)((maxElemsH >= 128) ? (19 + (128 * 3)) : 19)},
+                        (VL / 8)));
+  CHECK_NEON(4, int64_t,
+             fillNeon<int64_t>(
+                 {(int64_t)((maxElemsD >= 7) ? (3 + (7 * 3)) : 3)}, (VL / 8)));
+  CHECK_NEON(
+      5, int64_t,
+      fillNeon<int64_t>({(int64_t)((maxElemsD >= 1) ? (84 + (1 * 3)) : 84)},
+                        (VL / 8)));
 }
 
 TEST_P(InstSve, fabs) {


### PR DESCRIPTION
Fixes output error present for miniBUDE when compiled with GCC-10.3.0 targeting armv8.4-a+sve, caused by an incorrect implementation of the FNEG sve instruction. 

Additionally, other SVE instructions were updated to accomodate for optional patterns.