### PR TITLE
Updated jenkins armclang build script to use new armclang22 compiler

### DIFF
--- a/.jenkins/build_arm22.sh
+++ b/.jenkins/build_arm22.sh
@@ -6,14 +6,13 @@ source .jenkins/build_test_run.sh
 checkout
 
 ## Setup environment
-module load cdt/20.03
 export CMAKE_C_COMPILER=cc
 export CMAKE_CXX_COMPILER=CC
 
 ## Load compilers/libraries
-echo "Compiler Armclang 20.0"
-module swap PrgEnv-cray PrgEnv-allinea
-module swap Generic-AArch64/SUSE/12/arm-linux-compiler/20.0 ThunderX2CN99/SUSE/12/arm-linux-compiler-20.0/armpl/20.0.0
+echo "Compiler Armclang 22.0.2"
+module use /software/arm64/modulefiles
+module load tools/arm-compiler-sles
 module load tools/cmake
 
 ## Build, test, and run SimEng


### PR DESCRIPTION
The old armclang20 compiler we were using has an associated license which has now expired. The most recent armclang compilers don't need a compiler so the Isambard support team has installed the armclang22 compiler which we'll now use for our Jenkins CI.

I've added everyone with active or upcoming PRs as reviewers so you're all aware of this. You'll need to rebase `dev` onto your branches to pass the Jenkins armclang build pipeline.