### PR TITLE
New core creation

### DIFF
--- a/configs/a64fx.yaml
+++ b/configs/a64fx.yaml
@@ -241,7 +241,7 @@ Latencies:
 CPU-Info:
   # Set Generate-Special-Dir to 'T' to generate the special files directory, or to 'F' to not.
   # (Not generating the special files directory may require the user to copy over files manually)
-  Generate-Special-Dir: T
+  Generate-Special-Dir: true
   # Core-Count MUST be 1 as multi-core is not supported at this time. (A64FX true value is 48)
   Core-Count: 1
   # Socket-Count MUST be 1 as multi-socket simulations are not supported at this time. (A64FX true value is 1)

--- a/configs/a64fx.yaml
+++ b/configs/a64fx.yaml
@@ -37,7 +37,11 @@ Branch-Predictor:
   Global-History-Length: 11
   RAS-entries: 8
   Fallback-Static-Predictor: "Always-Taken"
-L1-Cache:
+Data-Memory:
+  Interface-Type: Fixed
+Instruction-Memory:
+  Interface-Type: Flat
+LSQ-L1-Interface:
   Access-Latency: 5
   Exclusive: True
   Load-Bandwidth: 128

--- a/configs/a64fx.yaml
+++ b/configs/a64fx.yaml
@@ -37,9 +37,9 @@ Branch-Predictor:
   Global-History-Length: 11
   RAS-entries: 8
   Fallback-Static-Predictor: "Always-Taken"
-Data-Memory:
+L1-Data-Memory:
   Interface-Type: Fixed
-Instruction-Memory:
+L1-Instruction-Memory:
   Interface-Type: Flat
 LSQ-L1-Interface:
   Access-Latency: 5
@@ -243,9 +243,9 @@ Latencies:
 # CPU-Info mainly used to generate a replica of the special (or system) file directory 
 # structure
 CPU-Info:
-  # Set Generate-Special-Dir to 'T' to generate the special files directory, or to 'F' to not.
+  # Set Generate-Special-Dir to True to generate the special files directory, or to False to not.
   # (Not generating the special files directory may require the user to copy over files manually)
-  Generate-Special-Dir: true
+  Generate-Special-Dir: True
   # Core-Count MUST be 1 as multi-core is not supported at this time. (A64FX true value is 48)
   Core-Count: 1
   # Socket-Count MUST be 1 as multi-socket simulations are not supported at this time. (A64FX true value is 1)

--- a/configs/m1_firestorm.yaml
+++ b/configs/m1_firestorm.yaml
@@ -278,7 +278,7 @@ Latencies:
     Execution-Latency: 3
     Execution-Throughput: 1
 CPU-Info:
-  Generate-Special-Dir: T
+  Generate-Special-Dir: true
   Core-Count: 1
   Socket-Count: 1
   SMT: 1

--- a/configs/m1_firestorm.yaml
+++ b/configs/m1_firestorm.yaml
@@ -30,7 +30,11 @@ Branch-Predictor:
   Global-History-Length: 11 
   RAS-entries: 8 
   Fallback-Static-Predictor: "Always-Taken" 
-L1-Cache:
+Data-Memory:
+  Interface-Type: Fixed
+Instruction-Memory:
+  Interface-Type: Flat
+LSQ-L1-Interface:
   Access-Latency: 3
   Exclusive: False
   L1 Load Bandwidth: 48

--- a/configs/m1_firestorm.yaml
+++ b/configs/m1_firestorm.yaml
@@ -281,11 +281,19 @@ Latencies:
       - SCALAR
     Execution-Latency: 3
     Execution-Throughput: 1
+# CPU-Info mainly used to generate a replica of the special (or system) file directory 
+# structure
 CPU-Info:
+  # Set Generate-Special-Dir to True to generate the special files directory, or to False to not.
+  # (Not generating the special files directory may require the user to copy over files manually)
   Generate-Special-Dir: True
+  # Core-Count MUST be 1 as multi-core is not supported at this time. (A64FX true value is 48)
   Core-Count: 1
+  # Socket-Count MUST be 1 as multi-socket simulations are not supported at this time. (A64FX true value is 1)
   Socket-Count: 1
+  # SMT MUST be 1 as Simultanious-Multi-Threading is not supported at this time. (A64FX true value is 1)
   SMT: 1
+  # Below are the values needed to generate /proc/cpuinfo
   BogoMIPS: 48.00
   Features: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint
   CPU-Implementer: "0x46"
@@ -293,5 +301,7 @@ CPU-Info:
   CPU-Variant: "0x1"
   CPU-Part: "0x001"
   CPU-Revision: 0
+  # Package-Count is used to generate 
+  # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
 

--- a/configs/m1_firestorm.yaml
+++ b/configs/m1_firestorm.yaml
@@ -29,10 +29,10 @@ Branch-Predictor:
   Saturating-Count-Bits: 2  
   Global-History-Length: 11 
   RAS-entries: 8 
-  Fallback-Static-Predictor: "Always-Taken" 
-Data-Memory:
+  Fallback-Static-Predictor: "Always-Taken"
+L1-Data-Memory:
   Interface-Type: Fixed
-Instruction-Memory:
+L1-Instruction-Memory:
   Interface-Type: Flat
 LSQ-L1-Interface:
   Access-Latency: 3
@@ -282,7 +282,7 @@ Latencies:
     Execution-Latency: 3
     Execution-Throughput: 1
 CPU-Info:
-  Generate-Special-Dir: true
+  Generate-Special-Dir: True
   Core-Count: 1
   Socket-Count: 1
   SMT: 1

--- a/configs/tx2.yaml
+++ b/configs/tx2.yaml
@@ -35,7 +35,11 @@ Branch-Predictor:
   Global-History-Length: 10
   RAS-entries: 5
   Fallback-Static-Predictor: "Always-Taken"
-L1-Cache:
+Data-Memory:
+  Interface-Type: Fixed
+Instruction-Memory:
+  Interface-Type: Flat
+LSQ-L1-Interface:
   Access-Latency: 4
   Exclusive: False
   Load-Bandwidth: 32

--- a/configs/tx2.yaml
+++ b/configs/tx2.yaml
@@ -35,9 +35,9 @@ Branch-Predictor:
   Global-History-Length: 10
   RAS-entries: 5
   Fallback-Static-Predictor: "Always-Taken"
-Data-Memory:
+L1-Data-Memory:
   Interface-Type: Fixed
-Instruction-Memory:
+L1-Instruction-Memory:
   Interface-Type: Flat
 LSQ-L1-Interface:
   Access-Latency: 4
@@ -163,9 +163,9 @@ Latencies:
 # CPU-Info mainly used to generate a replica of the special (or system) file directory 
 # structure
 CPU-Info:
-  # Set Generate-Special-Dir to 'T' to generate the special files directory, or to 'F' to not.
+  # Set Generate-Special-Dir to True to generate the special files directory, or to False to not.
   # (Not generating the special files directory may require the user to copy over files manually)
-  Generate-Special-Dir: true
+  Generate-Special-Dir: True
   # Core-Count MUST be 1 as multi-core is not supported at this time. (TX2 true value is 32)
   Core-Count: 1
   # Socket-Count MUST be 1 as multi-socket simulations are not supported at this time. (TX2 true value is 2)

--- a/configs/tx2.yaml
+++ b/configs/tx2.yaml
@@ -161,7 +161,7 @@ Latencies:
 CPU-Info:
   # Set Generate-Special-Dir to 'T' to generate the special files directory, or to 'F' to not.
   # (Not generating the special files directory may require the user to copy over files manually)
-  Generate-Special-Dir: T
+  Generate-Special-Dir: true
   # Core-Count MUST be 1 as multi-core is not supported at this time. (TX2 true value is 32)
   Core-Count: 1
   # Socket-Count MUST be 1 as multi-socket simulations are not supported at this time. (TX2 true value is 2)

--- a/src/include/simeng/BranchPredictor.hh
+++ b/src/include/simeng/BranchPredictor.hh
@@ -5,6 +5,7 @@
 
 namespace simeng {
 
+/** The types of branches recognised. */
 enum class BranchType {
   Conditional = 0,
   LoopClosing,

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -35,9 +35,6 @@ class CoreInstance {
   /** Constructor with a config file path. */
   CoreInstance(std::string configPath);
 
-  /** Constructor with a pre-constructed config file. */
-  CoreInstance(YAML::Node config);
-
   ~CoreInstance();
 
   /** Construct the SimEng linux process object from an executable ELF file and

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -84,10 +84,10 @@ class CoreInstance {
   std::unique_ptr<simeng::kernel::LinuxProcess> process_ = nullptr;
 
   /** The size of the process memory. */
-  size_t processMemorySize_;
+  uint64_t processMemorySize_;
 
   /** The process memory space. */
-  char* processMemory_;
+  std::shared_ptr<char> processMemory_;
 
   /** The SimEng kernel object. */
   simeng::kernel::Linux kernel_;

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -43,13 +43,15 @@ enum class SimulationMode { Emulation, InOrderPipelined, OutOfOrder };
 /** A class to create a SimEng core instance from a supplied config. */
 class CoreInstance {
  public:
-  /** Default constructor with command line arguments but no passed
+  /** Default constructor with an executable and its arguments but no model
    * configuration. */
-  CoreInstance(int argc, char** argv);
+  CoreInstance(std::string executablePath,
+               std::vector<std::string> executableArgs);
 
-  /** Constructor with with command line arguments and a configuration file
-   * path. */
-  CoreInstance(int argc, char** argv, std::string configPath);
+  /** Constructor with an executable, its arguments, and a model configuration.
+   */
+  CoreInstance(std::string configPath, std::string executablePath,
+               std::vector<std::string> executableArgs);
 
   ~CoreInstance();
 
@@ -87,7 +89,8 @@ class CoreInstance {
  private:
   /** Generate the appropriate simulation objects as parameterised by the
    * configuration.*/
-  void generateCoreModel(int argc, char** argv);
+  void generateCoreModel(std::string executablePath,
+                         std::vector<std::string> executableArgs);
 
   /** Extract simulation mode from config file. */
   void setSimulationMode();
@@ -95,7 +98,8 @@ class CoreInstance {
   /** Construct the SimEng linux process object from command line arguments.
    * Empty command line arguments denote the usage of hardcoded
    * instructions held in the hex_ array. */
-  void createProcess(int argc, char** argv);
+  void createProcess(std::string executablePath,
+                     std::vector<std::string> executableArgs);
 
   /** Construct the process memory from the generated process_ object. */
   void createProcessMemory();

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -22,10 +22,8 @@
 #include "simeng/pipeline/BalancedPortAllocator.hh"
 #include "yaml-cpp/yaml.h"
 
-// Out-of-order test; counts down from 1024*1024, with an independent `orr`
-// at the start of each branch. With an instruction latency of 2 or greater,
-// the `orr` at the start of the next loop should issue/execute while the
-// preceding branch is waiting on the result from the `subs`.
+// Instruction set used when no executable is provided; counts down from
+// 1024*1024, with an independent `orr` at the start of each branch.
 uint32_t hex_[] = {
     0x320C03E0,  // orr w0, wzr, #1048576
     0x320003E1,  // orr w0, wzr, #1
@@ -67,6 +65,9 @@ class CoreInstance {
 
   /** Getter for the set simulation mode. */
   const SimulationMode getSimulationMode() const;
+
+  /** Getter for the set simulation mode in a string format. */
+  const std::string getSimulationModeString() const;
 
   /** Getter for the create core object. */
   std::shared_ptr<simeng::Core> getCore() const;
@@ -123,9 +124,6 @@ class CoreInstance {
   /** The SimEng Linux kernel object. */
   simeng::kernel::Linux kernel_;
 
-  /** Whether or not the createCore() function must be manually called. */
-  bool manualCreateCore_ = false;
-
   /** Whether or not the dataMemory_ must be set manually. */
   bool setDataMemory_ = false;
 
@@ -146,6 +144,10 @@ class CoreInstance {
 
   /** The simulation mode in use, defaulting to emulation. */
   SimulationMode mode_ = SimulationMode::Emulation;
+
+  /** A string format for the simulation mode in use, defaulting to emulation.
+   */
+  std::string modeString_ = "Emulation";
 
   /** Reference to the SimEng data memory object. */
   std::shared_ptr<simeng::MemoryInterface> dataMemory_ = nullptr;

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -22,7 +22,7 @@
 #include "simeng/pipeline/BalancedPortAllocator.hh"
 #include "yaml-cpp/yaml.h"
 
-// Instruction set used when no executable is provided; counts down from
+// Program used when no executable is provided; counts down from
 // 1024*1024, with an independent `orr` at the start of each branch.
 uint32_t hex_[] = {
     0x320C03E0,  // orr w0, wzr, #1048576

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -67,6 +67,12 @@ class CoreInstance {
   /** Getter for the set simulation mode. */
   const SimulationMode getSimulationMode() const;
 
+  /** Getter for a shared pointer to the created process image. */
+  std::shared_ptr<char> getProcessImage() const;
+
+  /** Getter for the size of the created process image. */
+  const uint64_t getProcessImageSize() const;
+
  private:
   /** Extract simulation mode from config file. */
   void setSimulationMode();

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -24,6 +24,7 @@
 
 namespace simeng {
 
+/** The available modes of simulation. */
 enum class SimulationMode { Emulation, InOrderPipelined, OutOfOrder };
 
 /** A class to create a SimEng core instance from a supplied config. */
@@ -58,7 +59,8 @@ class CoreInstance {
   /** Set the SimEng L1 data cache memory. */
   void setL1DataMemory(std::shared_ptr<simeng::MemoryInterface> memRef);
 
-  /** Construct the core and all its associated simulation objects. */
+  /** Construct the core and all its associated simulation objects after the
+   * process and memory interfaces have been instantiated. */
   std::shared_ptr<simeng::Core> createCore();
 
   /** Construct the special file directory. */
@@ -92,7 +94,7 @@ class CoreInstance {
   /** The process memory space. */
   std::shared_ptr<char> processMemory_;
 
-  /** The SimEng kernel object. */
+  /** The SimEng Linux kernel object. */
   simeng::kernel::Linux kernel_;
 
   /** Reference to the SimEng architecture object. */

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <string>
+
+#include "simeng/AlwaysNotTakenPredictor.hh"
+#include "simeng/Core.hh"
+#include "simeng/Elf.hh"
+#include "simeng/FixedLatencyMemoryInterface.hh"
+#include "simeng/FlatMemoryInterface.hh"
+#include "simeng/GenericPredictor.hh"
+#include "simeng/ModelConfig.hh"
+#include "simeng/SpecialFileDirGen.hh"
+#include "simeng/arch/Architecture.hh"
+#include "simeng/arch/aarch64/Architecture.hh"
+#include "simeng/arch/aarch64/Instruction.hh"
+#include "simeng/arch/aarch64/MicroDecoder.hh"
+#include "simeng/kernel/Linux.hh"
+#include "simeng/models/emulation/Core.hh"
+#include "simeng/models/inorder/Core.hh"
+#include "simeng/models/outoforder/Core.hh"
+#include "simeng/pipeline/A64FXPortAllocator.hh"
+#include "simeng/pipeline/BalancedPortAllocator.hh"
+#include "yaml-cpp/yaml.h"
+
+namespace simeng {
+
+enum class SimulationMode { Emulation, InOrderPipelined, OutOfOrder };
+
+/** A class to create a SimEng core instance from a supplied config. */
+class CoreInstance {
+ public:
+  /** Default constructor with a no passed configuration. */
+  CoreInstance();
+
+  /** Constructor with a config file path. */
+  CoreInstance(std::string configPath);
+
+  /** Constructor with a pre-constructed config file. */
+  CoreInstance(YAML::Node config);
+
+  ~CoreInstance();
+
+  /** Construct the SimEng linux process object from an executable ELF file and
+   * its command-line arguments. */
+  void createProcess(const std::vector<std::string>& commandLine);
+
+  /** Construct the SimEng linux process object from an span of instructions. */
+  void createProcess(span<char> instructions);
+
+  /** Construct the SimEng L1 instruction cache memory. */
+  std::shared_ptr<simeng::MemoryInterface> createL1InstructionMemory(
+      const simeng::MemInterfaceType type);
+
+  /** Set the SimEng L1 instruction cache memory. */
+  void setL1InstructionMemory(std::shared_ptr<simeng::MemoryInterface> memRef);
+
+  /** Construct the SimEng L1 data cache memory. */
+  std::shared_ptr<simeng::MemoryInterface> createL1DataMemory(
+      const simeng::MemInterfaceType type);
+
+  /** Set the SimEng L1 data cache memory. */
+  void setL1DataMemory(std::shared_ptr<simeng::MemoryInterface> memRef);
+
+  /** Construct the core and all its associated simulation objects. */
+  std::shared_ptr<simeng::Core> createCore();
+
+  /** Construct the special file directory. */
+  void createSpecialFileDirectory();
+
+  /** Getter for the set CPU clock speed. */
+  const float getClockFrequency() const;
+
+  /** Getter for the set virtual counter timer frequency. */
+  const uint32_t getTimerFrequency() const;
+
+  /** Getter for the set simulation mode. */
+  const SimulationMode getSimulationMode() const;
+
+ private:
+  /** Extract simulation mode from config file. */
+  void setSimulationMode();
+
+  /** Construct the process memory from the generated process_ object. */
+  void createProcessMemory();
+
+  /** The config file describing the modelled core to be created. */
+  YAML::Node config_;
+
+  /** Reference to the SimEng linux process object. */
+  std::unique_ptr<simeng::kernel::LinuxProcess> process_ = nullptr;
+
+  /** The size of the process memory. */
+  size_t processMemorySize_;
+
+  /** The process memory space. */
+  char* processMemory_;
+
+  /** The SimEng kernel object. */
+  simeng::kernel::Linux kernel_;
+
+  /** Reference to the SimEng architecture object. */
+  std::unique_ptr<simeng::arch::Architecture> arch_ = nullptr;
+
+  /** Reference to the SimEng branch predictor object. */
+  std::unique_ptr<simeng::BranchPredictor> predictor_ = nullptr;
+
+  /** Reference to the SimEng port allocator object. */
+  std::unique_ptr<simeng::pipeline::PortAllocator> portAllocator_ = nullptr;
+
+  /** Reference to the SimEng core object. */
+  std::shared_ptr<simeng::Core> core_ = nullptr;
+
+  /** The simulation mode in use, defaulting to emualtion. */
+  SimulationMode mode_ = SimulationMode::Emulation;
+
+  /** Reference to the SimEng instruction memory object. */
+  std::shared_ptr<simeng::MemoryInterface> instructionMemory_ = nullptr;
+
+  /** Reference to the SimEng data memory object. */
+  std::shared_ptr<simeng::MemoryInterface> dataMemory_ = nullptr;
+
+  /** CPU clock speed. */
+  float clockFreq_ = 0;
+
+  /** Virtual counter timer frequency. */
+  uint32_t timerFreq_ = 0;
+};
+
+}  // namespace simeng

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -67,12 +67,6 @@ class CoreInstance {
   /** Construct the special file directory. */
   void createSpecialFileDirectory();
 
-  /** Getter for the set CPU clock speed. */
-  const float getClockFrequency() const;
-
-  /** Getter for the set virtual counter timer frequency. */
-  const uint32_t getTimerFrequency() const;
-
   /** Getter for the set simulation mode. */
   const SimulationMode getSimulationMode() const;
 
@@ -110,7 +104,7 @@ class CoreInstance {
   /** Reference to the SimEng core object. */
   std::shared_ptr<simeng::Core> core_ = nullptr;
 
-  /** The simulation mode in use, defaulting to emualtion. */
+  /** The simulation mode in use, defaulting to emulation. */
   SimulationMode mode_ = SimulationMode::Emulation;
 
   /** Reference to the SimEng instruction memory object. */
@@ -118,12 +112,6 @@ class CoreInstance {
 
   /** Reference to the SimEng data memory object. */
   std::shared_ptr<simeng::MemoryInterface> dataMemory_ = nullptr;
-
-  /** CPU clock speed. */
-  float clockFreq_ = 0;
-
-  /** Virtual counter timer frequency. */
-  uint32_t timerFreq_ = 0;
 };
 
 }  // namespace simeng

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -22,6 +22,21 @@
 #include "simeng/pipeline/BalancedPortAllocator.hh"
 #include "yaml-cpp/yaml.h"
 
+// Out-of-order test; counts down from 1024*1024, with an independent `orr`
+// at the start of each branch. With an instruction latency of 2 or greater,
+// the `orr` at the start of the next loop should issue/execute while the
+// preceding branch is waiting on the result from the `subs`.
+uint32_t hex_[] = {
+    0x320C03E0,  // orr w0, wzr, #1048576
+    0x320003E1,  // orr w0, wzr, #1
+    0x71000400,  // subs w0, w0, #1
+    0x54FFFFC1,  // b.ne -8
+                 // .exit:
+    0xD2800000,  // mov x0, #0
+    0xD2800BC8,  // mov x8, #94
+    0xD4000001,  // svc #0
+};
+
 namespace simeng {
 
 /** The available modes of simulation. */
@@ -30,44 +45,37 @@ enum class SimulationMode { Emulation, InOrderPipelined, OutOfOrder };
 /** A class to create a SimEng core instance from a supplied config. */
 class CoreInstance {
  public:
-  /** Default constructor with a no passed configuration. */
-  CoreInstance();
+  /** Default constructor with command line arguments but no passed
+   * configuration. */
+  CoreInstance(int argc, char** argv);
 
-  /** Constructor with a config file path. */
-  CoreInstance(std::string configPath);
+  /** Constructor with with command line arguments and a configuration file
+   * path. */
+  CoreInstance(int argc, char** argv, std::string configPath);
 
   ~CoreInstance();
 
-  /** Construct the SimEng linux process object from an executable ELF file and
-   * its command-line arguments. */
-  void createProcess(const std::vector<std::string>& commandLine);
-
-  /** Construct the SimEng linux process object from an span of instructions. */
-  void createProcess(span<char> instructions);
-
-  /** Construct the SimEng L1 instruction cache memory. */
-  std::shared_ptr<simeng::MemoryInterface> createL1InstructionMemory(
-      const simeng::MemInterfaceType type);
-
   /** Set the SimEng L1 instruction cache memory. */
   void setL1InstructionMemory(std::shared_ptr<simeng::MemoryInterface> memRef);
-
-  /** Construct the SimEng L1 data cache memory. */
-  std::shared_ptr<simeng::MemoryInterface> createL1DataMemory(
-      const simeng::MemInterfaceType type);
 
   /** Set the SimEng L1 data cache memory. */
   void setL1DataMemory(std::shared_ptr<simeng::MemoryInterface> memRef);
 
   /** Construct the core and all its associated simulation objects after the
    * process and memory interfaces have been instantiated. */
-  std::shared_ptr<simeng::Core> createCore();
-
-  /** Construct the special file directory. */
-  void createSpecialFileDirectory();
+  void createCore();
 
   /** Getter for the set simulation mode. */
   const SimulationMode getSimulationMode() const;
+
+  /** Getter for the create core object. */
+  std::shared_ptr<simeng::Core> getCore() const;
+
+  /** Getter for the create data memory object. */
+  std::shared_ptr<simeng::MemoryInterface> getDataMemory() const;
+
+  /** Getter for the create instruction memory object. */
+  std::shared_ptr<simeng::MemoryInterface> getInstructionMemory() const;
 
   /** Getter for a shared pointer to the created process image. */
   std::shared_ptr<char> getProcessImage() const;
@@ -76,11 +84,29 @@ class CoreInstance {
   const uint64_t getProcessImageSize() const;
 
  private:
+  /** Generate the appropriate simulation objects as parameterised by the
+   * configuration.*/
+  void generateCoreModel(int argc, char** argv);
+
   /** Extract simulation mode from config file. */
   void setSimulationMode();
 
+  /** Construct the SimEng linux process object from command line arguments.
+   * Empty command line arguments denote the usage of hardcoded
+   * instructions held in the hex_ array. */
+  void createProcess(int argc, char** argv);
+
   /** Construct the process memory from the generated process_ object. */
   void createProcessMemory();
+
+  /** Construct the SimEng L1 instruction cache memory. */
+  void createL1InstructionMemory(const simeng::MemInterfaceType type);
+
+  /** Construct the SimEng L1 data cache memory. */
+  void createL1DataMemory(const simeng::MemInterfaceType type);
+
+  /** Construct the special file directory. */
+  void createSpecialFileDirectory();
 
   /** The config file describing the modelled core to be created. */
   YAML::Node config_;
@@ -97,6 +123,15 @@ class CoreInstance {
   /** The SimEng Linux kernel object. */
   simeng::kernel::Linux kernel_;
 
+  /** Whether or not the createCore() function must be manually called. */
+  bool manualCreateCore_ = false;
+
+  /** Whether or not the dataMemory_ must be set manually. */
+  bool setDataMemory_ = false;
+
+  /** Whether or not the instructionMemory_ must be set manually. */
+  bool setInstructionMemory_ = false;
+
   /** Reference to the SimEng architecture object. */
   std::unique_ptr<simeng::arch::Architecture> arch_ = nullptr;
 
@@ -112,11 +147,11 @@ class CoreInstance {
   /** The simulation mode in use, defaulting to emulation. */
   SimulationMode mode_ = SimulationMode::Emulation;
 
-  /** Reference to the SimEng instruction memory object. */
-  std::shared_ptr<simeng::MemoryInterface> instructionMemory_ = nullptr;
-
   /** Reference to the SimEng data memory object. */
   std::shared_ptr<simeng::MemoryInterface> dataMemory_ = nullptr;
+
+  /** Reference to the SimEng instruction memory object. */
+  std::shared_ptr<simeng::MemoryInterface> instructionMemory_ = nullptr;
 };
 
 }  // namespace simeng

--- a/src/include/simeng/MemoryInterface.hh
+++ b/src/include/simeng/MemoryInterface.hh
@@ -5,6 +5,8 @@
 
 namespace simeng {
 
+enum class MemInterfaceType { Flat, Fixed };
+
 /** A generic memory access target; describes a region of memory to access. */
 struct MemoryAccessTarget {
   /** The address to access. */

--- a/src/include/simeng/MemoryInterface.hh
+++ b/src/include/simeng/MemoryInterface.hh
@@ -5,9 +5,13 @@
 
 namespace simeng {
 
-/** The available memory interface types. Flat providing a zero access latency
- * and Fixed a set non-zero access latency. */
-enum class MemInterfaceType { Flat, Fixed };
+/** The available memory interface types. */
+enum class MemInterfaceType {
+  Flat,     // A zero access latency interface
+  Fixed,    // A fixed, non-zero, access latency interface
+  External  // An interface generated outside of the standard SimEng
+            // instantiation
+};
 
 /** A generic memory access target; describes a region of memory to access. */
 struct MemoryAccessTarget {

--- a/src/include/simeng/MemoryInterface.hh
+++ b/src/include/simeng/MemoryInterface.hh
@@ -5,6 +5,8 @@
 
 namespace simeng {
 
+/** The available memory interface types. Flat providing a zero access latency
+ * and Fixed a set non-zero access latency. */
 enum class MemInterfaceType { Flat, Fixed };
 
 /** A generic memory access target; describes a region of memory to access. */

--- a/src/include/simeng/ModelConfig.hh
+++ b/src/include/simeng/ModelConfig.hh
@@ -14,32 +14,34 @@
 #include "simeng/arch/aarch64/Instruction.hh"
 #include "yaml-cpp/yaml.h"
 
-#define DEFAULT_CONFIG                                                        \
-  ("{Core: {Simulation-Mode: inorderpipelined, Clock-Frequency: 2.5, "        \
-   "Timer-Frequency: 100, Micro-Operations: True, Vector-Length: 512}, "      \
-   "Fetch: {Fetch-Block-Size: 32, Loop-Buffer-Size: 64, "                     \
-   "Loop-Detection-Threshold: 4}, Process-Image: {Heap-Size: 10485760, "      \
-   "Stack-Size: 1048576}, Register-Set: {GeneralPurpose-Count: 154, "         \
-   "FloatingPoint/SVE-Count: 90, Predicate-Count: 17, Conditional-Count: "    \
-   "128}, Pipeline-Widths: {Commit: 4, Dispatch-Rate: 4, FrontEnd: 4, "       \
-   "LSQ-Completion: 2}, Queue-Sizes: {ROB: 180, Load: 64, Store: 36}, "       \
-   "Branch-Predictor: {BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, "          \
-   "Global-History-Length: 10, RAS-entries: 5, Fallback-Static-Predictor: "   \
-   "2}, L1-Cache: {Access-Latency: 4, Exclusive: False, Load-Bandwidth: 32, " \
-   "Store-Bandwidth: 16, Permitted-Requests-Per-Cycle: 2, "                   \
-   "Permitted-Loads-Per-Cycle: 2, Permitted-Stores-Per-Cycle: 1}, Ports: "    \
-   "{'0': {Portname: Port 0, Instruction-Group-Support: [1, 8, 14]}, '1': "   \
-   "{Portname: Port 1, Instruction-Group-Support: [0, 14]}, '2': {Portname: " \
-   "Port 2, Instruction-Group-Support: [1, 8, 71]}, '3': {Portname: Port 4, " \
-   "Instruction-Group-Support: [67]}, '4': {Portname: Port 5, "               \
-   "Instruction-Group-Support: [67]}, '5': {Portname: Port 3, "               \
-   "Instruction-Group-Support: [70]}}, Reservation-Stations: {'0': {Size: "   \
-   "60, Ports: [0, 1, 2, 3, 4, 5]}}, Execution-Units: {'0': {Pipelined: "     \
-   "true}, '1': {Pipelined: true}, '2': {Pipelined: true}, '3': {Pipelined: " \
-   "true}, '4': {Pipelined: true}, '5': {Pipelined: true}}, CPU-Info: "       \
-   "{Generate-Special-Dir: false, Core-Count: 1, Socket-Count: 1, SMT: 1, "   \
-   "BogoMIPS: 200.00, Features: fp asimd evtstrm atomics cpuid, "             \
-   "CPU-Implementer: 0x0, CPU-Architecture: 0, CPU-Variant: 0x0, CPU-Part: "  \
+#define DEFAULT_CONFIG                                                         \
+  ("{Core: {Simulation-Mode: inorderpipelined, Clock-Frequency: 2.5, "         \
+   "Timer-Frequency: 100, Micro-Operations: True, Vector-Length: 512}, "       \
+   "Fetch: {Fetch-Block-Size: 32, Loop-Buffer-Size: 64, "                      \
+   "Loop-Detection-Threshold: 4}, Process-Image: {Heap-Size: 10485760, "       \
+   "Stack-Size: 1048576}, Register-Set: {GeneralPurpose-Count: 154, "          \
+   "FloatingPoint/SVE-Count: 90, Predicate-Count: 17, Conditional-Count: "     \
+   "128}, Pipeline-Widths: {Commit: 4, Dispatch-Rate: 4, FrontEnd: 4, "        \
+   "LSQ-Completion: 2}, Queue-Sizes: {ROB: 180, Load: 64, Store: 36}, "        \
+   "Branch-Predictor: {BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, "           \
+   "Global-History-Length: 10, RAS-entries: 5, Fallback-Static-Predictor: "    \
+   "2}, Data-Memory: {Interface-Type: Flat}, Instruction-Memory: "             \
+   "{Interface-Type: Flat}, LSQ-L1-Interface: {Access-Latency: 4, Exclusive: " \
+   "False, Load-Bandwidth: 32, Store-Bandwidth: 16, "                          \
+   "Permitted-Requests-Per-Cycle: 2, Permitted-Loads-Per-Cycle: 2, "           \
+   "Permitted-Stores-Per-Cycle: 1}, Ports: {'0': {Portname: Port 0, "          \
+   "Instruction-Group-Support: [1, 8, 14]}, '1': {Portname: Port 1, "          \
+   "Instruction-Group-Support: [0, 14]}, '2': {Portname: Port 2, "             \
+   "Instruction-Group-Support: [1, 8, 71]}, '3': {Portname: Port 4, "          \
+   "Instruction-Group-Support: [67]}, '4': {Portname: Port 5, "                \
+   "Instruction-Group-Support: [67]}, '5': {Portname: Port 3, "                \
+   "Instruction-Group-Support: [70]}}, Reservation-Stations: {'0': {Size: "    \
+   "60, Ports: [0, 1, 2, 3, 4, 5]}}, Execution-Units: {'0': {Pipelined: "      \
+   "true}, '1': {Pipelined: true}, '2': {Pipelined: true}, '3': "              \
+   "{Pipelined:true}, '4': {Pipelined: true}, '5': {Pipelined: true}}, "       \
+   "CPU-Info: {Generate-Special-Dir: false, Core-Count: 1, Socket-Count: 1, "  \
+   "SMT: 1, BogoMIPS: 200.00, Features: fp asimd evtstrm atomics cpuid, "      \
+   "CPU-Implementer: 0x0, CPU-Architecture: 0, CPU-Variant: 0x0, CPU-Part: "   \
    "0x0, CPU-Revision: 0, Package-Count: 1}}")
 
 namespace simeng {

--- a/src/include/simeng/ModelConfig.hh
+++ b/src/include/simeng/ModelConfig.hh
@@ -37,7 +37,7 @@
    "60, Ports: [0, 1, 2, 3, 4, 5]}}, Execution-Units: {'0': {Pipelined: "     \
    "true}, '1': {Pipelined: true}, '2': {Pipelined: true}, '3': {Pipelined: " \
    "true}, '4': {Pipelined: true}, '5': {Pipelined: true}}, CPU-Info: "       \
-   "{Generate-Special-Dir: F, Core-Count: 1, Socket-Count: 1, SMT: 1, "       \
+   "{Generate-Special-Dir: false, Core-Count: 1, Socket-Count: 1, SMT: 1, "   \
    "BogoMIPS: 200.00, Features: fp asimd evtstrm atomics cpuid, "             \
    "CPU-Implementer: 0x0, CPU-Architecture: 0, CPU-Variant: 0x0, CPU-Part: "  \
    "0x0, CPU-Revision: 0, Package-Count: 1}}")

--- a/src/include/simeng/ModelConfig.hh
+++ b/src/include/simeng/ModelConfig.hh
@@ -25,7 +25,7 @@
    "LSQ-Completion: 2}, Queue-Sizes: {ROB: 180, Load: 64, Store: 36}, "        \
    "Branch-Predictor: {BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, "           \
    "Global-History-Length: 10, RAS-entries: 5, Fallback-Static-Predictor: "    \
-   "2}, Data-Memory: {Interface-Type: Flat}, Instruction-Memory: "             \
+   "2}, L1-Data-Memory: {Interface-Type: Flat}, L1-Instruction-Memory: "       \
    "{Interface-Type: Flat}, LSQ-L1-Interface: {Access-Latency: 4, Exclusive: " \
    "False, Load-Bandwidth: 32, Store-Bandwidth: 16, "                          \
    "Permitted-Requests-Per-Cycle: 2, Permitted-Loads-Per-Cycle: 2, "           \

--- a/src/include/simeng/arch/Architecture.hh
+++ b/src/include/simeng/arch/Architecture.hh
@@ -14,6 +14,7 @@ using MacroOp = std::vector<std::shared_ptr<Instruction>>;
 
 namespace arch {
 
+/** The types of changes that can be made to values within the process state. */
 enum class ChangeType { REPLACEMENT, INCREMENT, DECREMENT };
 
 /** A structure describing a set of changes to the process state. */

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -174,6 +174,7 @@ struct ExecutionInfo {
   std::vector<uint8_t> ports = {};
 };
 
+/** The various exceptions that can be raised by an individual instruction. */
 enum class InstructionException {
   None = 0,
   EncodingUnallocated,

--- a/src/include/simeng/models/inorder/Core.hh
+++ b/src/include/simeng/models/inorder/Core.hh
@@ -20,7 +20,7 @@ class Core : public simeng::Core {
   /** Construct a core model, providing an ISA and branch predictor to use,
    * along with a pointer and size of instruction memory, and a pointer to
    * process memory. */
-  Core(FlatMemoryInterface& instructionMemory, FlatMemoryInterface& dataMemory,
+  Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
        uint64_t processMemorySize, uint64_t entryPoint,
        const arch::Architecture& isa, BranchPredictor& branchPredictor);
 

--- a/src/include/simeng/pipeline/FetchUnit.hh
+++ b/src/include/simeng/pipeline/FetchUnit.hh
@@ -9,6 +9,7 @@
 namespace simeng {
 namespace pipeline {
 
+/** The various states of the loop buffer. */
 enum class LoopBufferState {
   IDLE = 0,  // No operations
   WAITING,   // Waiting to find boundary instruction in fetch stream

--- a/src/include/simeng/pipeline/LoadStoreQueue.hh
+++ b/src/include/simeng/pipeline/LoadStoreQueue.hh
@@ -13,6 +13,7 @@
 namespace simeng {
 namespace pipeline {
 
+/** The memory access types which are processed. */
 enum accessType { LOAD = 0, STORE };
 
 /** A requestQueue_ entry. */

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SIMENG_SOURCES
     AlwaysNotTakenPredictor.cc
     ArchitecturalRegisterFileSet.cc
     CMakeLists.txt
+    CoreInstance.cc
     Elf.cc
     FixedLatencyMemoryInterface.cc
     FlatMemoryInterface.cc
@@ -37,7 +38,7 @@ set(SIMENG_SOURCES
     RegisterFileSet.cc
     RegisterValue.cc
     SpecialFileDirGen.cc
-    )
+)
 
 configure_file(${capstone_SOURCE_DIR}/arch/AArch64/AArch64GenInstrInfo.inc AArch64GenInstrInfo.inc COPYONLY)
 

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -56,7 +56,7 @@ void CoreInstance::generateCoreModel(int argc, char** argv) {
   }
 
   // Create the core if neither memory interfaces are externally constructed
-  if (setDataMemory_ || setInstructionMemory_) createCore();
+  if (!(setDataMemory_ || setInstructionMemory_)) createCore();
 
   return;
 }
@@ -67,11 +67,11 @@ void CoreInstance::setSimulationMode() {
   if (config_["Core"]["Simulation-Mode"].as<std::string>() ==
       "inorderpipelined") {
     mode_ = SimulationMode::InOrderPipelined;
-    modeString_ = "Out-of-Order";
+    modeString_ = "In-Order Pipelined";
   } else if (config_["Core"]["Simulation-Mode"].as<std::string>() ==
              "outoforder") {
     mode_ = SimulationMode::OutOfOrder;
-    modeString_ = "In-Order Pipelined";
+    modeString_ = "Out-of-Order";
   }
 
   return;

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -157,10 +157,6 @@ std::shared_ptr<simeng::Core> CoreInstance::createCore() {
     exit(1);
   }
 
-  // Get frequnecy information
-  clockFreq_ = config_["Core"]["Clock-Frequency"].as<float>();
-  timerFreq_ = config_["Core"]["Timer-Frequency"].as<uint32_t>();
-
   // Construct architecture object
   arch_ =
       std::make_unique<simeng::arch::aarch64::Architecture>(kernel_, config_);
@@ -230,10 +226,6 @@ void CoreInstance::createSpecialFileDirectory() {
 
   return;
 }
-
-const float CoreInstance::getClockFrequency() const { return clockFreq_; }
-
-const uint32_t CoreInstance::getTimerFrequency() const { return timerFreq_; }
 
 const SimulationMode CoreInstance::getSimulationMode() const { return mode_; }
 

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -214,7 +214,7 @@ std::shared_ptr<simeng::Core> CoreInstance::createCore() {
 void CoreInstance::createSpecialFileDirectory() {
   simeng::SpecialFileDirGen SFdir = simeng::SpecialFileDirGen(config_);
   // Create the Special Files directory if indicated to do so in Config
-  if (config_["CPU-Info"]["Generate-Special-Dir"].as<std::string>() == "T") {
+  if (config_["CPU-Info"]["Generate-Special-Dir"].as<bool>() == true) {
     // Remove any current special files dir
     SFdir.RemoveExistingSFDir();
     // Create new special files dir

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -1,0 +1,240 @@
+#include "simeng/CoreInstance.hh"
+
+namespace simeng {
+
+CoreInstance::CoreInstance() {
+  config_ = YAML::Load(DEFAULT_CONFIG);
+  setSimulationMode();
+}
+
+CoreInstance::CoreInstance(std::string configPath) {
+  config_ = simeng::ModelConfig(configPath).getConfigFile();
+  setSimulationMode();
+}
+
+CoreInstance::CoreInstance(YAML::Node config) {
+  config_ = config;
+  setSimulationMode();
+}
+
+CoreInstance::~CoreInstance() {}
+
+void CoreInstance::setSimulationMode() {
+  // Get simualtion mode as defined by the set configuration
+  if (config_["Core"]["Simulation-Mode"].as<std::string>() ==
+      "inorderpipelined") {
+    mode_ = SimulationMode::InOrderPipelined;
+  } else if (config_["Core"]["Simulation-Mode"].as<std::string>() ==
+             "outoforder") {
+    mode_ = SimulationMode::OutOfOrder;
+  }
+}
+
+void CoreInstance::createProcessMemory() {
+  // Get the process image
+  auto processImage = process_->getProcessImage();
+
+  // Allocate a region of memory for the process memory
+  processMemorySize_ = processImage.size();
+  processMemory_ = new char[processMemorySize_]();
+
+  // Fill the process memory with the generated process image
+  std::copy(processImage.begin(), processImage.end(), processMemory_);
+}
+
+void CoreInstance::createProcess(const std::vector<std::string>& commandLine) {
+  process_ =
+      std::make_unique<simeng::kernel::LinuxProcess>(commandLine, config_);
+
+  // Raise error if created process is not valid
+  if (!process_->isValid()) {
+    std::cerr << "Could not read/parse " << commandLine[0] << std::endl;
+    exit(1);
+  }
+
+  // Create the process memory space from the generated process image
+  createProcessMemory();
+
+  // Create the OS kernel with the process
+  kernel_.createProcess(*process_.get());
+
+  return;
+}
+
+void CoreInstance::createProcess(span<char> instructions) {
+  process_ =
+      std::make_unique<simeng::kernel::LinuxProcess>(instructions, config_);
+
+  // Raise error if created process is not valid
+  if (!process_->isValid()) {
+    std::cerr << "Could not create process based on supplied instruction span"
+              << std::endl;
+    exit(1);
+  }
+
+  // Create the process memory space from the generated process image
+  createProcessMemory();
+
+  // Create the OS kernel with the process
+  kernel_.createProcess(*process_.get());
+
+  return;
+}
+
+std::shared_ptr<simeng::MemoryInterface>
+CoreInstance::createL1InstructionMemory(const simeng::MemInterfaceType type) {
+  // Currently, only a flat memory interface can be used for the instruction
+  // memory
+  if (type != simeng::MemInterfaceType::Flat) {
+    std::cerr << "Incompatible instruction memory interface type requested"
+              << std::endl;
+    exit(1);
+  }
+
+  // Create a L1I cache instance based on type supplied
+  if (type == simeng::MemInterfaceType::Flat) {
+    instructionMemory_ = std::make_shared<simeng::FlatMemoryInterface>(
+        processMemory_, processMemorySize_);
+  } else if (type == simeng::MemInterfaceType::Fixed) {
+    instructionMemory_ = std::make_shared<simeng::FixedLatencyMemoryInterface>(
+        processMemory_, processMemorySize_,
+        config_["L1-Cache"]["Access-Latency"].as<uint16_t>());
+  }
+
+  return instructionMemory_;
+}
+
+void CoreInstance::setL1InstructionMemory(
+    std::shared_ptr<simeng::MemoryInterface> memRef) {
+  // Set the L1I cache instance to use
+  instructionMemory_ = memRef;
+  return;
+}
+
+std::shared_ptr<simeng::MemoryInterface> CoreInstance::createL1DataMemory(
+    const simeng::MemInterfaceType type) {
+  // Currently, if the core in use is emulation or in-order, only a flat data
+  // memory interface can be used
+  if (mode_ == SimulationMode::Emulation ||
+      mode_ == SimulationMode::InOrderPipelined) {
+    if (type != simeng::MemInterfaceType::Flat) {
+      std::cerr << "Incompatible instruction memory interface type requested"
+                << std::endl;
+      exit(1);
+    }
+  }
+
+  // Create a L1D cache instance based on type supplied
+  if (type == simeng::MemInterfaceType::Flat) {
+    dataMemory_ = std::make_shared<simeng::FlatMemoryInterface>(
+        processMemory_, processMemorySize_);
+  } else if (type == simeng::MemInterfaceType::Fixed) {
+    dataMemory_ = std::make_shared<simeng::FixedLatencyMemoryInterface>(
+        processMemory_, processMemorySize_,
+        config_["L1-Cache"]["Access-Latency"].as<uint16_t>());
+  }
+
+  return dataMemory_;
+}
+
+void CoreInstance::setL1DataMemory(
+    std::shared_ptr<simeng::MemoryInterface> memRef) {
+  // Set the L1D cache instance to use
+  dataMemory_ = memRef;
+  return;
+}
+
+std::shared_ptr<simeng::Core> CoreInstance::createCore() {
+  // Ensure all appropriate creation functions have been called
+  if (instructionMemory_ == nullptr) {
+    std::cerr << "Instruction memory not instantiated or set" << std::endl;
+    exit(1);
+  } else if (dataMemory_ == nullptr) {
+    std::cerr << "Data memory not instantiated or set" << std::endl;
+    exit(1);
+  } else if (process_ == nullptr) {
+    std::cerr << "Process not instantiated or set" << std::endl;
+    exit(1);
+  }
+
+  // Get frequnecy information
+  clockFreq_ = config_["Core"]["Clock-Frequency"].as<float>();
+  timerFreq_ = config_["Core"]["Timer-Frequency"].as<uint32_t>();
+
+  // Construct architecture object
+  arch_ =
+      std::make_unique<simeng::arch::aarch64::Architecture>(kernel_, config_);
+
+  // Construct branch predictor object
+  predictor_ = std::make_unique<simeng::GenericPredictor>(config_);
+
+  // Extract port arrangement from config file
+  auto config_ports = config_["Ports"];
+  std::vector<std::vector<uint16_t>> portArrangement(config_ports.size());
+  for (size_t i = 0; i < config_ports.size(); i++) {
+    auto config_groups = config_ports[i]["Instruction-Group-Support"];
+    // Read groups in associated port
+    for (size_t j = 0; j < config_groups.size(); j++) {
+      portArrangement[i].push_back(config_groups[j].as<uint16_t>());
+    }
+  }
+  portAllocator_ = std::make_unique<simeng::pipeline::BalancedPortAllocator>(
+      portArrangement);
+
+  // Configure reservation station arrangment
+  std::vector<std::pair<uint8_t, uint64_t>> rsArrangement;
+  for (size_t i = 0; i < config_["Reservation-Stations"].size(); i++) {
+    // Iterate over each reservation station in config
+    auto reservation_station = config_["Reservation-Stations"][i];
+    for (size_t j = 0; j < reservation_station["Ports"].size(); j++) {
+      // Iterate over issue ports in reservation station
+      uint8_t port = reservation_station["Ports"][j].as<uint8_t>();
+      if (rsArrangement.size() < port + 1) {
+        // Resize vector to match number of execution ports available across all
+        // reservation stations
+        rsArrangement.resize(port + 1);
+      }
+      // Map an execution port to a reservation station
+      rsArrangement[port] = {i, reservation_station["Size"].as<uint16_t>()};
+    }
+  }
+
+  // Construct the core object based on the defined simulation mode
+  uint64_t entryPoint = process_->getEntryPoint();
+  if (mode_ == SimulationMode::Emulation) {
+    core_ = std::make_shared<simeng::models::emulation::Core>(
+        *instructionMemory_, *dataMemory_, entryPoint, processMemorySize_,
+        *arch_);
+  } else if (mode_ == SimulationMode::InOrderPipelined) {
+    core_ = std::make_shared<simeng::models::inorder::Core>(
+        *instructionMemory_, *dataMemory_, processMemorySize_, entryPoint,
+        *arch_, *predictor_);
+  } else if (mode_ == SimulationMode::OutOfOrder) {
+    core_ = std::make_shared<simeng::models::outoforder::Core>(
+        *instructionMemory_, *dataMemory_, processMemorySize_, entryPoint,
+        *arch_, *predictor_, *portAllocator_, rsArrangement, config_);
+  }
+
+  return core_;
+}
+
+void CoreInstance::createSpecialFileDirectory() {
+  simeng::SpecialFileDirGen SFdir = simeng::SpecialFileDirGen(config_);
+  // Create the Special Files directory if indicated to do so in Config
+  if (config_["CPU-Info"]["Generate-Special-Dir"].as<std::string>() == "T") {
+    // Remove any current special files dir
+    SFdir.RemoveExistingSFDir();
+    // Create new special files dir
+    SFdir.GenerateSFDir();
+  }
+
+  return;
+}
+
+const float CoreInstance::getClockFrequency() const { return clockFreq_; }
+
+const uint32_t CoreInstance::getTimerFrequency() const { return timerFreq_; }
+
+const SimulationMode CoreInstance::getSimulationMode() const { return mode_; }
+
+}  // namespace simeng

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -31,15 +31,9 @@ void CoreInstance::setSimulationMode() {
 }
 
 void CoreInstance::createProcessMemory() {
-  // Get the process image
-  auto processImage = process_->getProcessImage();
-
-  // Allocate a region of memory for the process memory
-  processMemorySize_ = processImage.size();
-  processMemory_ = new char[processMemorySize_]();
-
-  // Fill the process memory with the generated process image
-  std::copy(processImage.begin(), processImage.end(), processMemory_);
+  // Get the process image and its size
+  processMemory_ = process_->getProcessImage();
+  processMemorySize_ = process_->getProcessImageSize();
 }
 
 void CoreInstance::createProcess(const std::vector<std::string>& commandLine) {
@@ -94,10 +88,10 @@ CoreInstance::createL1InstructionMemory(const simeng::MemInterfaceType type) {
   // Create a L1I cache instance based on type supplied
   if (type == simeng::MemInterfaceType::Flat) {
     instructionMemory_ = std::make_shared<simeng::FlatMemoryInterface>(
-        processMemory_, processMemorySize_);
+        processMemory_.get(), processMemorySize_);
   } else if (type == simeng::MemInterfaceType::Fixed) {
     instructionMemory_ = std::make_shared<simeng::FixedLatencyMemoryInterface>(
-        processMemory_, processMemorySize_,
+        processMemory_.get(), processMemorySize_,
         config_["L1-Cache"]["Access-Latency"].as<uint16_t>());
   }
 
@@ -127,10 +121,10 @@ std::shared_ptr<simeng::MemoryInterface> CoreInstance::createL1DataMemory(
   // Create a L1D cache instance based on type supplied
   if (type == simeng::MemInterfaceType::Flat) {
     dataMemory_ = std::make_shared<simeng::FlatMemoryInterface>(
-        processMemory_, processMemorySize_);
+        processMemory_.get(), processMemorySize_);
   } else if (type == simeng::MemInterfaceType::Fixed) {
     dataMemory_ = std::make_shared<simeng::FixedLatencyMemoryInterface>(
-        processMemory_, processMemorySize_,
+        processMemory_.get(), processMemorySize_,
         config_["L1-Cache"]["Access-Latency"].as<uint16_t>());
   }
 

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -224,6 +224,14 @@ void CoreInstance::createSpecialFileDirectory() {
   return;
 }
 
+std::shared_ptr<char> CoreInstance::getProcessImage() const {
+  return processMemory_;
+}
+
+const uint64_t CoreInstance::getProcessImageSize() const {
+  return processMemorySize_;
+}
+
 const SimulationMode CoreInstance::getSimulationMode() const { return mode_; }
 
 }  // namespace simeng

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -24,7 +24,7 @@ void CoreInstance::generateCoreModel(int argc, char** argv) {
   // Convert Data-Memory's Interface-Type value from a string to
   // simeng::MemInterfaceType
   std::string dType_string =
-      config_["Data-Memory"]["Interface-Type"].as<std::string>();
+      config_["L1-Data-Memory"]["Interface-Type"].as<std::string>();
   simeng::MemInterfaceType dType = simeng::MemInterfaceType::Flat;
   if (dType_string == "Fixed") {
     dType = simeng::MemInterfaceType::Fixed;
@@ -42,7 +42,7 @@ void CoreInstance::generateCoreModel(int argc, char** argv) {
   // Convert Instruction-Memory's Interface-Type value from a string to
   // simeng::MemInterfaceType
   std::string iType_string =
-      config_["Instruction-Memory"]["Interface-Type"].as<std::string>();
+      config_["L1-Instruction-Memory"]["Interface-Type"].as<std::string>();
   simeng::MemInterfaceType iType = simeng::MemInterfaceType::Flat;
   if (iType_string == "Fixed") {
     iType = simeng::MemInterfaceType::Fixed;

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -176,12 +176,12 @@ void CoreInstance::setL1DataMemory(
 
 void CoreInstance::createCore() {
   // If memory interfaces must be manually set, ensure they have been
-  if (setDataMemory_ && dataMemory_ == nullptr) {
+  if (setDataMemory_ && (dataMemory_ == nullptr)) {
     std::cerr << "Data memory not set. External Data memory must be manually "
                  "set using the setL1DataMemory(...) function."
               << std::endl;
     exit(1);
-  } else if (setInstructionMemory_ && instructionMemory_ == nullptr) {
+  } else if (setInstructionMemory_ && (instructionMemory_ == nullptr)) {
     std::cerr << "Instruction memory not set. External instruction memory "
                  "interface must be manually set using the "
                  "setL1InstructionMemory(...) function."
@@ -249,9 +249,9 @@ void CoreInstance::createCore() {
 }
 
 void CoreInstance::createSpecialFileDirectory() {
-  simeng::SpecialFileDirGen SFdir = simeng::SpecialFileDirGen(config_);
   // Create the Special Files directory if indicated to do so in Config
   if (config_["CPU-Info"]["Generate-Special-Dir"].as<bool>() == true) {
+    simeng::SpecialFileDirGen SFdir = simeng::SpecialFileDirGen(config_);
     // Remove any current special files dir
     SFdir.RemoveExistingSFDir();
     // Create new special files dir
@@ -264,7 +264,7 @@ void CoreInstance::createSpecialFileDirectory() {
 const SimulationMode CoreInstance::getSimulationMode() const { return mode_; }
 
 std::shared_ptr<simeng::Core> CoreInstance::getCore() const {
-  if (manualCreateCore_ && core_ == nullptr) {
+  if (manualCreateCore_ && (core_ == nullptr)) {
     std::cerr << "Core object not constructed and marked as needed to be "
                  "manually created via the createCore() function. If either "
                  "data or instruction memory interfaces are marked as an "
@@ -277,7 +277,7 @@ std::shared_ptr<simeng::Core> CoreInstance::getCore() const {
 }
 
 std::shared_ptr<simeng::MemoryInterface> CoreInstance::getDataMemory() const {
-  if (setDataMemory_) {
+  if (setDataMemory_ && (dataMemory_ == nullptr)) {
     std::cerr << "`External` data memory object not set." << std::endl;
     exit(1);
   }
@@ -286,7 +286,7 @@ std::shared_ptr<simeng::MemoryInterface> CoreInstance::getDataMemory() const {
 
 std::shared_ptr<simeng::MemoryInterface> CoreInstance::getInstructionMemory()
     const {
-  if (setInstructionMemory_) {
+  if (setInstructionMemory_ && (instructionMemory_ == nullptr)) {
     std::cerr << "`External` instruction memory object not set." << std::endl;
     exit(1);
   }

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -135,21 +135,8 @@ void ModelConfig::validate() {
   }
   subFields.clear();
 
-  // Instruction Memory
-  root = "Instruction-Memory";
-  subFields = {"Interface-Type"};
-  nodeChecker<std::string>(
-      configFile_[root][subFields[0]], root + " " + subFields[0],
-      std::vector<std::string>{"Flat", "Fixed", "External"},
-      ExpectedValue::String);
-  // Currently, fixed instruction memory interfaces are unsupported
-  if (configFile_[root][subFields[0]].as<std::string>() != "Flat") {
-    invalid_ << "\t- Non-Flat instruction memory interface types are currently "
-                "unsupported\n";
-  }
-
   // Data Memory
-  root = "Data-Memory";
+  root = "L1-Data-Memory";
   subFields = {"Interface-Type"};
   nodeChecker<std::string>(
       configFile_[root][subFields[0]], root + " " + subFields[0],
@@ -164,6 +151,19 @@ void ModelConfig::validate() {
                   "currently unsupported for 'emulation' and "
                   "'inorderpipelined' simulation modes\n";
     }
+  }
+
+  // Instruction Memory
+  root = "L1-Instruction-Memory";
+  subFields = {"Interface-Type"};
+  nodeChecker<std::string>(
+      configFile_[root][subFields[0]], root + " " + subFields[0],
+      std::vector<std::string>{"Flat", "Fixed", "External"},
+      ExpectedValue::String);
+  // Currently, fixed instruction memory interfaces are unsupported
+  if (configFile_[root][subFields[0]].as<std::string>() != "Flat") {
+    invalid_ << "\t- Non-Flat instruction memory interface types are currently "
+                "unsupported\n";
   }
 
   // LSQ-L1-Interface

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -135,8 +135,39 @@ void ModelConfig::validate() {
   }
   subFields.clear();
 
-  // L1-Cache
-  root = "L1-Cache";
+  // Instruction Memory
+  root = "Instruction-Memory";
+  subFields = {"Interface-Type"};
+  nodeChecker<std::string>(
+      configFile_[root][subFields[0]], root + " " + subFields[0],
+      std::vector<std::string>{"Flat", "Fixed", "External"},
+      ExpectedValue::String);
+  // Currently, fixed instruction memory interfaces are unsupported
+  if (configFile_[root][subFields[0]].as<std::string>() != "Flat") {
+    invalid_ << "\t- Non-Flat instruction memory interface types are currently "
+                "unsupported\n";
+  }
+
+  // Data Memory
+  root = "Data-Memory";
+  subFields = {"Interface-Type"};
+  nodeChecker<std::string>(
+      configFile_[root][subFields[0]], root + " " + subFields[0],
+      std::vector<std::string>{"Flat", "Fixed", "External"},
+      ExpectedValue::String);
+  // Currently, fixed instruction memory interfaces are unsupported for
+  // emulation and inorder simulation modes
+  if (configFile_[root][subFields[0]].as<std::string>() != "Flat") {
+    std::string mode = configFile_["Core"]["Simulation-Mode"].as<std::string>();
+    if (mode == "emulation" || mode == "inorderpipelined") {
+      invalid_ << "\t- Non-Flat data memory interface types are "
+                  "currently unsupported for 'emulation' and "
+                  "'inorderpipelined' simulation modes\n";
+    }
+  }
+
+  // LSQ-L1-Interface
+  root = "LSQ-L1-Interface";
   subFields = {"Access-Latency",
                "Exclusive",
                "Load-Bandwidth",

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -446,8 +446,8 @@ void ModelConfig::validate() {
                "CPU-Part",
                "CPU-Revision",
                "Package-Count"};
-  nodeChecker<std::string>(configFile_[root][subFields[0]], subFields[0],
-                           {"T", "F", ""}, ExpectedValue::String, "F");
+  nodeChecker<bool>(configFile_[root][subFields[0]], subFields[0],
+                    std::vector<bool>{false, true}, ExpectedValue::Bool, false);
   nodeChecker<unsigned int>(configFile_[root][subFields[1]], subFields[1],
                             std::make_pair(1, UINT_MAX),
                             ExpectedValue::UInteger, 1);

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -13,10 +13,9 @@ namespace inorder {
 const unsigned int blockSize = 16;
 const unsigned int clockFrequency = 2.5 * 1e9;
 
-Core::Core(FlatMemoryInterface& instructionMemory,
-           FlatMemoryInterface& dataMemory, uint64_t processMemorySize,
-           uint64_t entryPoint, const arch::Architecture& isa,
-           BranchPredictor& branchPredictor)
+Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
+           uint64_t processMemorySize, uint64_t entryPoint,
+           const arch::Architecture& isa, BranchPredictor& branchPredictor)
     : dataMemory_(dataMemory),
       isa_(isa),
       registerFileSet_(isa.getRegisterFileStructures()),

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -59,12 +59,15 @@ Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
           [this](auto regs, auto values) {
             dispatchIssueUnit_.forwardOperands(regs, values);
           },
-          config["L1-Cache"]["Exclusive"].as<bool>(),
-          config["L1-Cache"]["Load-Bandwidth"].as<uint16_t>(),
-          config["L1-Cache"]["Store-Bandwidth"].as<uint16_t>(),
-          config["L1-Cache"]["Permitted-Requests-Per-Cycle"].as<uint16_t>(),
-          config["L1-Cache"]["Permitted-Loads-Per-Cycle"].as<uint16_t>(),
-          config["L1-Cache"]["Permitted-Stores-Per-Cycle"].as<uint16_t>()),
+          config["LSQ-L1-Interface"]["Exclusive"].as<bool>(),
+          config["LSQ-L1-Interface"]["Load-Bandwidth"].as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Store-Bandwidth"].as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Permitted-Requests-Per-Cycle"]
+              .as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Permitted-Loads-Per-Cycle"]
+              .as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Permitted-Stores-Per-Cycle"]
+              .as<uint16_t>()),
       fetchUnit_(fetchToDecodeBuffer_, instructionMemory, processMemorySize,
                  entryPoint, config["Fetch"]["Fetch-Block-Size"].as<uint16_t>(),
                  isa, branchPredictor),

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -43,16 +43,28 @@ int main(int argc, char** argv) {
 
   // Create the instance of the core to be simulated
   std::unique_ptr<simeng::CoreInstance> coreInstance;
+  std::string executablePath = "";
+  std::vector<std::string> executableArgs = {};
+
+  // Determine if a config file has been supplied.
   if (argc > 1) {
-    // Pass the cli arguments, excluding the invoking command and
-    // config path, and the config path (argv[1]) to the CoreInstance
-    // constructor
-    coreInstance =
-        std::make_unique<simeng::CoreInstance>(argc - 2, argv + 2, argv[1]);
+    // Determine if an executable has been supplied
+    if (argc > 2) {
+      executablePath = std::string(argv[2]);
+      // Create a vector of any potential executable arguments from their
+      // relative position within the argv variable
+      char** startOfArgs = argv + 3;
+      int numberofArgs = argc - 3;
+      executableArgs =
+          std::vector<std::string>(startOfArgs, startOfArgs + numberofArgs);
+    }
+    coreInstance = std::make_unique<simeng::CoreInstance>(
+        std::string(argv[1]), executablePath, executableArgs);
   } else {
-    // Pass the cli arguments, excluding the invoking command, to the
-    // CoreInstance constructor
-    coreInstance = std::make_unique<simeng::CoreInstance>(argc - 1, argv);
+    // Without a config file, no executable can be supplied so pass default
+    // (empty) values for executable information
+    coreInstance =
+        std::make_unique<simeng::CoreInstance>(executablePath, executableArgs);
   }
 
   // Get simulation objects needed to forward simulation

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -205,12 +205,6 @@ int main(int argc, char** argv) {
             << std::round(khz) << " kHz, " << std::setprecision(2) << mips
             << " MIPS)" << std::endl;
 
-  // If Special Files directory was created, now remove it
-  // if (config["CPU-Info"]["Generate-Special-Dir"].as<std::string>() == "T") {
-  // Remove special files dir
-  // SFdir.RemoveExistingSFDir();
-  //}
-
 // Print build metadata and core statistics in YAML format
 // to facilitate parsing. Print "YAML-SEQ" to indicate beginning
 // of YAML formatted data.

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -44,144 +44,33 @@ int main(int argc, char** argv) {
   // Create the instance of the core to be simulated
   std::unique_ptr<simeng::CoreInstance> coreInstance;
   if (argc > 1) {
-    coreInstance = std::make_unique<simeng::CoreInstance>(argv[1]);
+    coreInstance =
+        std::make_unique<simeng::CoreInstance>(argc - 2, argv + 2, argv[1]);
   } else {
-    coreInstance = std::make_unique<simeng::CoreInstance>();
-  }
-
-  // Extract path of binary to be run if available
-  std::string executablePath = "";
-  if (argc > 2) {
-    executablePath = std::string(argv[2]);
-  }
-
-  if (executablePath.length() > 0) {
-    // Attempt to create the process image from the specified command-line
-    std::vector<std::string> commandLine(argv + 2, argv + argc);
-    coreInstance->createProcess(commandLine);
-  } else {
-    // Create the process image directly
-
-    // char* memory = new char[1024]();
-
-    // Simple program demonstrating various instructions
-    // uint32_t hex[] = {
-    //     0x320003E0,  // orr w0, wzr, #1
-    //     0x321F0001,  // orr w1, w0, #2
-    //     0xB90003E1,  // str w1, [sp]
-    //     0xB94003E0,  // ldr w0, [sp]
-    //     0xF94003E0,  // ldr x0, [sp]
-    //     0x14000002,  // b #8
-    //     0x320003E0,  // orr w0, wzr, #1
-    //     0x32000002,  // orr w2, w0, #1
-    //     0x71000420,  // subs w0, w1, #1
-    // };
-
-    // Simple loop; counts down from 1024*1024
-    // uint32_t hex[] = {
-    //     // 0x321E03E0,  // orr w0, wzr, #4
-    //     0x320C03E0,  // orr w0, wzr, #1048576
-    //     // 0x321603E0, // orr w0, wzr, #1024
-    //     0x71000400,  // subs w0, w0, #1
-    //     // 0x320003E0, // orr w0, wzr, #1
-    //     // 0x71000400, // subs w0, w0, #1
-    //     0x54FFFFE1,  // b.ne -4
-    // };
-
-    // Out-of-order test; counts down from 1024*1024, with an independent `orr`
-    // at the start of each branch. With an instruction latency of 2 or greater,
-    // the `orr` at the start of the next loop should issue/execute while the
-    // preceding branch is waiting on the result from the `subs`.
-    uint32_t hex[] = {
-        // 0x321E03E0,  // orr w0, wzr, #4
-        // 0x321603E0,  // orr w0, wzr, #1024
-        0x320C03E0,  // orr w0, wzr, #1048576
-        0x320003E1,  // orr w0, wzr, #1
-        0x71000400,  // subs w0, w0, #1
-        // 0x00000000,  // invalid
-        0x54FFFFC1,  // b.ne -8
-                     // .exit:
-        0xD2800000,  // mov x0, #0
-        0xD2800BC8,  // mov x8, #94
-        0xD4000001,  // svc #0
-    };
-
-    // Load/store consistency test; a simple bubble sort algorithm
-    // uint32_t hex[] = {
-    //     0x320003E0,  //   orr w0, wzr, #1
-    //     0x51000400,  //   sub w0, w0, #1
-
-    //     0x11013001,  //   add w1, w0, #76
-    //                  // .start:
-    //     0x11000002,  //   add w2, w0, #0
-    //                  // .compare:
-    //     0xB9400044,  //   ldr w4, [x2, 0]
-    //     0xB9400445,  //   ldr w5, [x2, 4]
-    //     0x4B0400A6,  //   sub w6, w5, w4
-    //     0x37F80046,  //   tbnz w6, #31, #8 (.swap)
-    //     0x14000003,  //   b #12 (.next)
-    //                  // .swap:
-    //     0xB9000444,  //   str w4, [x2, 4]
-    //     0xB9000045,  //   str w5, [x2, 0]
-    //                  // .next:
-    //     0x11001042,  //   add w2, w2, #4
-    //     0x4B010046,  //   sub w6, w2, w1
-    //     0x37FFFEE6,  //   tbnz w6, #31, #-36 (.compare)
-    //     0x51001021,  //   sub w1, w1, #4
-    //     0x4B010006,  //   sub w6, w0, w1
-    //     0x37FFFE66,  //   tbnz w6, #31, #-52 (.start)
-    // };
-
-    // Force a load/store ordering violation
-    // uint32_t hex[] = {
-    //     0x320003E0,  //   orr w0, wzr, #1
-    //     0x51000400,  //   sub w0, w0, #1
-
-    //     0x11000002,  //   add w2, w0, #0
-    //     0x11013001,  //   add w1, w0, #76
-
-    //     0xB9000041,  //   str w1, [x2]
-    //     0xB9400043,  //   ldr w3, [x2]
-    //     0xB9000443,  //   str w3, [x2, 4]
-    // };
-
-    // Some arbitrary values to sort
-    // std::vector<int> memoryValues = {9,  6, 7, 20, 5,   0,  80, 2,  1,  6,
-    //                                  17, 4, 3, 22, 117, 11, 4,  12, 10, 18};
-    // memcpy(memory, memoryValues.data(), memoryValues.size() * sizeof(int));
-
-    coreInstance->createProcess(
-        simeng::span<char>(reinterpret_cast<char*>(hex), sizeof(hex)));
+    coreInstance = std::make_unique<simeng::CoreInstance>(argc - 1, argv);
   }
 
   // Get simualtion mode and data memory interface type
   simeng::SimulationMode mode = coreInstance->getSimulationMode();
-  simeng::MemInterfaceType L1Dtype = simeng::MemInterfaceType::Flat;
   std::string modeString = "Emulation";
   if (mode == simeng::SimulationMode::OutOfOrder) {
     modeString = "Out-of-Order";
-    L1Dtype = simeng::MemInterfaceType::Fixed;
   } else if (mode == simeng::SimulationMode::InOrderPipelined) {
     modeString = "In-Order Pipelined";
   }
 
-  // Create memory interfaces
+  // Get simulation objects needed to forward simulation
+  std::shared_ptr<simeng::Core> core = coreInstance->getCore();
   std::shared_ptr<simeng::MemoryInterface> dataMemory =
-      coreInstance->createL1DataMemory(L1Dtype);
+      coreInstance->getDataMemory();
   std::shared_ptr<simeng::MemoryInterface> instructionMemory =
-      coreInstance->createL1InstructionMemory(simeng::MemInterfaceType::Flat);
-
-  // Create core
-  std::shared_ptr<simeng::Core> core = coreInstance->createCore();
-
-  // Create Special Files directory if indicated to do so in Config
-  coreInstance->createSpecialFileDirectory();
+      coreInstance->getInstructionMemory();
 
   // Run simulation
   std::cout << "Running in " << modeString << " mode\n";
   std::cout << "Starting..." << std::endl;
-  auto startTime = std::chrono::high_resolution_clock::now();
   int iterations = 0;
+  auto startTime = std::chrono::high_resolution_clock::now();
   iterations = simulate(*core, *dataMemory, *instructionMemory);
 
   // Get timing information

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -44,9 +44,14 @@ int main(int argc, char** argv) {
   // Create the instance of the core to be simulated
   std::unique_ptr<simeng::CoreInstance> coreInstance;
   if (argc > 1) {
+    // Pass the cli arguments, excluding the invoking command and
+    // config path, and the config path (argv[1]) to the CoreInstance
+    // constructor
     coreInstance =
         std::make_unique<simeng::CoreInstance>(argc - 2, argv + 2, argv[1]);
   } else {
+    // Pass the cli arguments, excluding the invoking command, to the
+    // CoreInstance constructor
     coreInstance = std::make_unique<simeng::CoreInstance>(argc - 1, argv);
   }
 

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -161,8 +161,7 @@ int main(int argc, char** argv) {
   if (mode == simeng::SimulationMode::OutOfOrder) {
     modeString = "Out-of-Order";
     L1Dtype = simeng::MemInterfaceType::Fixed;
-  }
-  if (mode == simeng::SimulationMode::InOrderPipelined) {
+  } else if (mode == simeng::SimulationMode::InOrderPipelined) {
     modeString = "In-Order Pipelined";
   }
 

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -55,15 +55,6 @@ int main(int argc, char** argv) {
     coreInstance = std::make_unique<simeng::CoreInstance>(argc - 1, argv);
   }
 
-  // Get simualtion mode and data memory interface type
-  simeng::SimulationMode mode = coreInstance->getSimulationMode();
-  std::string modeString = "Emulation";
-  if (mode == simeng::SimulationMode::OutOfOrder) {
-    modeString = "Out-of-Order";
-  } else if (mode == simeng::SimulationMode::InOrderPipelined) {
-    modeString = "In-Order Pipelined";
-  }
-
   // Get simulation objects needed to forward simulation
   std::shared_ptr<simeng::Core> core = coreInstance->getCore();
   std::shared_ptr<simeng::MemoryInterface> dataMemory =
@@ -72,7 +63,8 @@ int main(int argc, char** argv) {
       coreInstance->getInstructionMemory();
 
   // Run simulation
-  std::cout << "Running in " << modeString << " mode\n";
+  std::cout << "Running in " << coreInstance->getSimulationModeString()
+            << " mode\n";
   std::cout << "Starting..." << std::endl;
   int iterations = 0;
   auto startTime = std::chrono::high_resolution_clock::now();

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -11,15 +11,10 @@
 #include "simeng/SpecialFileDirGen.hh"
 #include "simeng/version.hh"
 
-float clockFreq;
-uint32_t timerFreq;
-
 /** Tick the provided core model until it halts. */
 int simulate(simeng::Core& core, simeng::MemoryInterface& dataMemory,
              simeng::MemoryInterface& instructionMemory) {
   uint64_t iterations = 0;
-  uint64_t vitrualCounter = 0;
-  double timerModulo = (clockFreq * 1e9) / (timerFreq * 1e6);
 
   // Tick the core and memory interfaces until the program has halted
   while (!core.hasHalted() || dataMemory.hasPendingRequests()) {
@@ -182,10 +177,6 @@ int main(int argc, char** argv) {
 
   // Create Special Files directory if indicated to do so in Config
   coreInstance->createSpecialFileDirectory();
-
-  // Get clockFreq and timerFreq variables from passed config
-  clockFreq = coreInstance->getClockFrequency();
-  timerFreq = coreInstance->getTimerFrequency();
 
   // Run simulation
   std::cout << "Running in " << modeString << " mode\n";

--- a/test/regression/aarch64/AArch64RegressionTest.hh
+++ b/test/regression/aarch64/AArch64RegressionTest.hh
@@ -4,23 +4,23 @@
 #include "simeng/arch/aarch64/Architecture.hh"
 #include "simeng/arch/aarch64/Instruction.hh"
 
-#define AARCH64_CONFIG                                                        \
-  ("{Core: {Simulation-Mode: emulation, Clock-Frequency: 2.5, "               \
-   "Timer-Frequency: 100, Micro-Operations: False}, Fetch: "                  \
-   "{Fetch-Block-Size: 32, Loop-Buffer-Size: 64, Loop-Detection-Threshold: "  \
-   "4}, Process-Image: {Heap-Size: 100000, Stack-Size: 100000}, "             \
-   "Register-Set: {GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "  \
-   "Predicate-Count: 17, Conditional-Count: 128}, Pipeline-Widths: { "        \
-   "Commit:4, Dispatch-Rate: 4, FrontEnd: 4, LSQ-Completion: 2}, "            \
-   "Queue-Sizes: {ROB:180, Load: 64, Store: 36}, Branch-Predictor: "          \
-   "{BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, Global-History-Length: 10, " \
-   "RAS-entries: 5, Fallback-Static-Predictor: 2}, Data-Memory: "             \
-   "{Interface-Type: Flat}, Instruction-Memory: {Interface-Type: Flat}, "     \
-   "LSQ-L1-Interface: {Access-Latency: 4, Exclusive:False, Load-Bandwidth: "  \
-   "32, Store-Bandwidth: 16, Permitted-Requests-Per-Cycle: 2, "               \
-   "Permitted-Loads-Per-Cycle: 2, Permitted-Stores-Per-Cycle: 1}, Ports: "    \
-   "{'0': {Portname: Port 0, Instruction-Group-Support: [0, 14, 52, 66, 67, " \
-   "70, 71]}}, Reservation-Stations: {'0': {Size: 60, Ports: [0]}}, "         \
+#define AARCH64_CONFIG                                                         \
+  ("{Core: {Simulation-Mode: emulation, Clock-Frequency: 2.5, "                \
+   "Timer-Frequency: 100, Micro-Operations: False}, Fetch: "                   \
+   "{Fetch-Block-Size: 32, Loop-Buffer-Size: 64, Loop-Detection-Threshold: "   \
+   "4}, Process-Image: {Heap-Size: 100000, Stack-Size: 100000}, "              \
+   "Register-Set: {GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "   \
+   "Predicate-Count: 17, Conditional-Count: 128}, Pipeline-Widths: { Commit: " \
+   "4, Dispatch-Rate: 4, FrontEnd: 4, LSQ-Completion: 2}, Queue-Sizes: {ROB: " \
+   "180, Load: 64, Store: 36}, Branch-Predictor: {BTB-Tag-Bits: 11, "          \
+   "Saturating-Count-Bits: 2, Global-History-Length: 10, RAS-entries: 5, "     \
+   "Fallback-Static-Predictor: 2}, Data-Memory: {Interface-Type: Flat}, "      \
+   "Instruction-Memory: {Interface-Type: Flat}, LSQ-L1-Interface: "            \
+   "{Access-Latency: 4, Exclusive: False, Load-Bandwidth: 32, "                \
+   "Store-Bandwidth: 16, Permitted-Requests-Per-Cycle: 2, "                    \
+   "Permitted-Loads-Per-Cycle: 2, Permitted-Stores-Per-Cycle: 1}, Ports: "     \
+   "{'0': {Portname: Port 0, Instruction-Group-Support: [0, 14, 52, 66, 67, "  \
+   "70, 71]}}, Reservation-Stations: {'0': {Size: 60, Ports: [0]}}, "          \
    "Execution-Units: {'0': {Pipelined: true}}}")
 
 /** A helper function to convert the supplied parameters of

--- a/test/regression/aarch64/AArch64RegressionTest.hh
+++ b/test/regression/aarch64/AArch64RegressionTest.hh
@@ -4,23 +4,24 @@
 #include "simeng/arch/aarch64/Architecture.hh"
 #include "simeng/arch/aarch64/Instruction.hh"
 
-#define AARCH64_CONFIG                                                         \
-  ("{Core: {Simulation-Mode: emulation, Clock-Frequency: 2.5, "                \
-   "Timer-Frequency: 100, Micro-Operations: False}, Fetch: "                   \
-   "{Fetch-Block-Size: 32, Loop-Buffer-Size: 64, Loop-Detection-Threshold: "   \
-   "4}, Process-Image: {Heap-Size: 100000, Stack-Size: 100000}, "              \
-   "Register-Set: {GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "   \
-   "Predicate-Count: 17, Conditional-Count: 128}, Pipeline-Widths: { Commit: " \
-   "4, Dispatch-Rate: 4, FrontEnd: 4, LSQ-Completion: 2}, Queue-Sizes: {ROB: " \
-   "180, Load: 64, Store: 36}, Branch-Predictor: {BTB-Tag-Bits: 11, "          \
-   "Saturating-Count-Bits: 2, Global-History-Length: 10, RAS-entries: 5, "     \
-   "Fallback-Static-Predictor: 2}, L1-Cache: {Access-Latency: 4, Exclusive: "  \
-   "False, Load-Bandwidth: 32, Store-Bandwidth: 16, "                          \
-   "Permitted-Requests-Per-Cycle: 2, Permitted-Loads-Per-Cycle: 2, "           \
-   "Permitted-Stores-Per-Cycle: 1}, Ports: {'0': {Portname: Port 0, "          \
-   "Instruction-Group-Support: [0, 14, 52, 66, 67, 70, 71]}}, "                \
-   "Reservation-Stations: {'0': {Size: 60, Ports: [0]}}, Execution-Units: "    \
-   "{'0': {Pipelined: true}}}")
+#define AARCH64_CONFIG                                                        \
+  ("{Core: {Simulation-Mode: emulation, Clock-Frequency: 2.5, "               \
+   "Timer-Frequency: 100, Micro-Operations: False}, Fetch: "                  \
+   "{Fetch-Block-Size: 32, Loop-Buffer-Size: 64, Loop-Detection-Threshold: "  \
+   "4}, Process-Image: {Heap-Size: 100000, Stack-Size: 100000}, "             \
+   "Register-Set: {GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "  \
+   "Predicate-Count: 17, Conditional-Count: 128}, Pipeline-Widths: { "        \
+   "Commit:4, Dispatch-Rate: 4, FrontEnd: 4, LSQ-Completion: 2}, "            \
+   "Queue-Sizes: {ROB:180, Load: 64, Store: 36}, Branch-Predictor: "          \
+   "{BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, Global-History-Length: 10, " \
+   "RAS-entries: 5, Fallback-Static-Predictor: 2}, Data-Memory: "             \
+   "{Interface-Type: Flat}, Instruction-Memory: {Interface-Type: Flat}, "     \
+   "LSQ-L1-Interface: {Access-Latency: 4, Exclusive:False, Load-Bandwidth: "  \
+   "32, Store-Bandwidth: 16, Permitted-Requests-Per-Cycle: 2, "               \
+   "Permitted-Loads-Per-Cycle: 2, Permitted-Stores-Per-Cycle: 1}, Ports: "    \
+   "{'0': {Portname: Port 0, Instruction-Group-Support: [0, 14, 52, 66, 67, " \
+   "70, 71]}}, Reservation-Stations: {'0': {Size: 60, Ports: [0]}}, "         \
+   "Execution-Units: {'0': {Pipelined: true}}}")
 
 /** A helper function to convert the supplied parameters of
  * INSTANTIATE_TEST_SUITE_P into test name. */


### PR DESCRIPTION
A new CoreInstance class which creates the core and its associated memory interfaces. `main.cc` now creates an instance of this class and uses it to generate the SimEng simulation objects.

This change was influenced by the need to remove any dependencies SST had on yaml-cpp due to AppleClang having issues linking them. Through this class, the new SST core wrapper can now use the new CoreINstance class to create all SimEng objects without the need to link against the yaml-ccp external project. 