### PR TITLE
Enable support for CoreInstance to assemble and execute string instructions via LLVM - SE-145

### DIFF
--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -22,6 +22,10 @@
 #include "simeng/pipeline/BalancedPortAllocator.hh"
 #include "yaml-cpp/yaml.h"
 
+#ifdef SIMENG_ENABLE_TESTS
+
+#endif
+
 // Program used when no executable is provided; counts down from
 // 1024*1024, with an independent `orr` at the start of each branch.
 uint32_t hex_[] = {
@@ -52,6 +56,10 @@ class CoreInstance {
    */
   CoreInstance(std::string configPath, std::string executablePath,
                std::vector<std::string> executableArgs);
+
+#ifdef SIMENG_ENABLE_TESTS
+  CoreInstance(std::string instructions, std::string configPath);
+#endif
 
   ~CoreInstance();
 
@@ -112,6 +120,20 @@ class CoreInstance {
 
   /** Construct the special file directory. */
   void createSpecialFileDirectory();
+
+#ifdef SIMENG_ENABLE_TESTS
+  /** Assemble test source to a flat binary for the given triple. */
+  void assemble(const char* source, const char* triple);
+
+  /** The flat binary produced by assembling the test source. */
+  uint8_t* code_ = nullptr;
+
+  /** The size of the assembled flat binary in bytes. */
+  size_t codeSize_ = 0;
+
+  /** Whether or not the executable binary is created by LLVM in code. */
+  bool constructBinaryByLLVM_ = false;
+#endif
 
   /** The config file describing the modelled core to be created. */
   YAML::Node config_;

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -47,7 +47,16 @@ set_target_properties(libsimeng PROPERTIES OUTPUT_NAME simeng)
 
 target_include_directories(libsimeng PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(libsimeng PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(libsimeng capstone yaml-cpp)
+if(SIMENG_ENABLE_TESTS)
+    # Add LLVM includes
+    target_include_directories(libsimeng PUBLIC ${LLVM_INCLUDE_DIRS})
+
+    # Link to LLVM libraries
+    llvm_map_components_to_libnames(LLVM_LIBS aarch64asmparser object)
+    target_link_libraries(libsimeng capstone yaml-cpp ${LLVM_LIBS})
+else()
+    target_link_libraries(libsimeng capstone yaml-cpp)
+endif()
 
 set_target_properties(libsimeng PROPERTIES VERSION ${SimEng_VERSION})
 set_target_properties(libsimeng PROPERTIES SOVERSION ${SimEng_VERSION_MAJOR})


### PR DESCRIPTION
This PR adds a new constructor to CoreInstance (`CoreInstance::CoreInstance(std::string instructions, std::string configPath)`). This constructor is only available after specifying the flag `-DSIMENG_ENABLE_TESTS=ON`. Calling this constructor with a string of instructions and a config path will assemble the string of instructions via LLVM and construct the process image with the assembled source.  SimEng is then able to execute these assembled instructions. This constructor is not exposed to `main.cc` so this functionality is not accessible through the compiled SimEng executable. 
This feature will mainly be used for testing SST. Instructions supplied via `TEST_GROUP(s)` will be assembled via this constructor and executed.