### PR TITLE
AArch64 Instruction support & minor bug fixes

### DIFF
--- a/configs/a64fx_SME.yaml
+++ b/configs/a64fx_SME.yaml
@@ -1,0 +1,341 @@
+---
+# The following resources where utilised to create the config file and naming schemes:
+# https://github.com/fujitsu/A64FX
+
+Core:
+  Simulation-Mode: outoforder
+  # Clock Frequency is in GHz.
+  Clock-Frequency: 1.8
+  # Timer-Frequency is in MHz.
+  Timer-Frequency: 100
+  Micro-Operations: True
+  Vector-Length: 512
+  Streaming-Vector-Length: 512
+Fetch:
+  Fetch-Block-Size: 32
+  Loop-Buffer-Size: 48
+  Loop-Detection-Threshold: 4
+Process-Image:
+  Heap-Size: 1073741824
+  Stack-Size: 1048576
+Register-Set:
+  GeneralPurpose-Count: 96
+  FloatingPoint/SVE-Count: 128
+  Predicate-Count: 48
+  Conditional-Count: 128
+  MatrixRow-Count: 128
+Pipeline-Widths:
+  Commit: 4
+  FrontEnd: 4
+  LSQ-Completion: 2
+Queue-Sizes:
+  ROB: 128
+  Load: 40
+  Store: 24
+Branch-Predictor:
+  BTB-Tag-Bits: 11
+  Saturating-Count-Bits: 2
+  Global-History-Length: 11
+  RAS-entries: 8
+  Fallback-Static-Predictor: "Always-Taken"
+L1-Data-Memory:
+  Interface-Type: Fixed
+L1-Instruction-Memory:
+  Interface-Type: Flat
+LSQ-L1-Interface:
+  Access-Latency: 5
+  Exclusive: True
+  Load-Bandwidth: 128
+  Store-Bandwidth: 64
+  Permitted-Requests-Per-Cycle: 2
+  Permitted-Loads-Per-Cycle: 2
+  Permitted-Stores-Per-Cycle: 1
+Ports:
+  0:
+    Portname: FLA
+    Instruction-Support:
+    - FP
+    - SVE
+  1:
+    Portname: PR
+    Instruction-Support:
+    - PREDICATE
+  2:
+    Portname: EXA
+    Instruction-Support:
+    - INT_SIMPLE
+    - INT_MUL
+    - STORE_DATA
+  3:
+    Portname: FLB
+    Instruction-Support:
+    - FP_SIMPLE
+    - FP_MUL
+    - SVE_SIMPLE
+    - SVE_MUL
+  4:
+    Portname: EXB
+    Instruction-Support:
+    - INT_SIMPLE
+    - INT_DIV_OR_SQRT
+  5:
+    Portname: EAGA
+    Instruction-Support:
+    - LOAD_INT
+    - LOAD_SCALAR
+    - LOAD_VECTOR
+    - LOAD_SVE    
+    - STORE_INT
+    - STORE_SCALAR
+    - STORE_VECTOR
+    - STORE_SVE
+    - INT_SIMPLE_ARTH_NOSHIFT
+    - INT_SIMPLE_LOGICAL_NOSHIFT
+    - INT_SIMPLE_CMP
+  6:
+    Portname: EAGB
+    Instruction-Support:
+    - LOAD_INT
+    - LOAD_SCALAR
+    - LOAD_VECTOR
+    - LOAD_SVE    
+    - STORE_INT
+    - STORE_SCALAR
+    - STORE_VECTOR
+    - STORE_SVE
+    - INT_SIMPLE_ARTH_NOSHIFT
+    - INT_SIMPLE_LOGICAL_NOSHIFT
+    - INT_SIMPLE_CMP
+  7:
+    Portname: BR
+    Instruction-Support:
+    - BRANCH
+  8:
+    Portname: SME
+    Instruction-Support:
+    - SME
+  9:
+    Portname: SME_LD_STR
+    Instruction-Support:
+    - LOAD_SME
+    - STORE_SME
+Reservation-Stations:
+  0:
+    Size: 20
+    Dispatch-Rate: 2
+    Ports:
+    - FLA
+    - PR
+    - EXA
+  1:
+    Size: 20
+    Dispatch-Rate: 2
+    Ports:
+    - FLB
+    - EXB
+  2:
+    Size: 10
+    Dispatch-Rate: 2
+    Ports:
+    - EAGA
+  3:
+    Size: 10
+    Dispatch-Rate: 2
+    Ports:
+    - EAGB
+  4:
+    Size: 19
+    Dispatch-Rate: 2
+    Ports:
+    - BR
+  5:
+    Size: 20
+    Dispatch-Rate: 2
+    Ports:
+    - SME
+  6:
+    Size: 10
+    Dispatch-Rate: 2
+    Ports:
+    - SME_LD_STR
+Execution-Units:
+  0:
+    Pipelined: True
+    Blocking-Groups:
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  1:
+    Pipelined: True
+    Blocking-Groups: 
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  2:
+    Pipelined: True
+    Blocking-Groups: 
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  3:
+    Pipelined: True
+    Blocking-Groups: 
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  4:
+    Pipelined: True
+    Blocking-Groups: 
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  5:
+    Pipelined: True
+    Blocking-Groups: 
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  6:
+    Pipelined: True
+    Blocking-Groups: 
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  7:
+    Pipelined: True
+    Blocking-Groups: 
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  8:
+    Pipelined: True
+    Blocking-Groups:
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+  9:
+    Pipelined: True
+    Blocking-Groups:
+    - INT_DIV_OR_SQRT
+    - FP_DIV_OR_SQRT
+    - SVE_DIV_OR_SQRT
+Latencies:
+  0:
+    Instruction-Groups: 
+    - INT
+    Execution-Latency: 2
+    Execution-Throughput: 2
+  1:
+    Instruction-Groups: 
+    - INT_SIMPLE_ARTH_NOSHIFT
+    - INT_SIMPLE_LOGICAL_NOSHIFT
+    - INT_SIMPLE_CVT
+    Execution-Latency: 1
+    Execution-Throughput: 1
+  2:
+    Instruction-Groups: 
+    - INT_MUL
+    Execution-Latency: 5
+    Execution-Throughput: 1
+  3:
+    Instruction-Groups: 
+    - INT_DIV_OR_SQRT
+    Execution-Latency: 41
+    Execution-Throughput: 41
+  4:
+    Instruction-Groups: 
+    - SCALAR_SIMPLE
+    - VECTOR_SIMPLE_LOGICAL
+    - SVE_SIMPLE_LOGICAL
+    - VECTOR_SIMPLE_CMP
+    - SVE_SIMPLE_CMP
+    Execution-Latency: 4
+    Execution-Throughput: 1
+  5:
+    Instruction-Groups: 
+    - FP_DIV_OR_SQRT
+    Execution-Latency: 29
+    Execution-Throughput: 29
+  6:
+    Instruction-Groups: 
+    - VECTOR_SIMPLE
+    - SVE_SIMPLE
+    - SCALAR_SIMPLE_CVT
+    - FP_MUL
+    - SVE_MUL
+    - SME
+    Execution-Latency: 9
+    Execution-Throughput: 1
+  7:
+    Instruction-Groups: 
+    - SVE_DIV_OR_SQRT
+    Execution-Latency: 98
+    Execution-Throughput: 98
+  8:
+    Instruction-Groups: 
+    - PREDICATE
+    Execution-Latency: 3
+    Execution-Throughput: 1
+  9:
+    Instruction-Groups: 
+    - LOAD_SCALAR
+    - LOAD_VECTOR
+    - STORE_ADDRESS_SCALAR
+    - STORE_ADDRESS_VECTOR
+    Execution-Latency: 3
+    Execution-Throughput: 1
+  10:
+    Instruction-Groups: 
+    - LOAD_SVE
+    - STORE_ADDRESS_SVE
+    - LOAD_SME
+    - STORE_ADDRESS_SME
+    Execution-Latency: 6
+    Execution-Throughput: 1
+  11:
+    Instruction-Groups:
+    - SME_SIMPLE_LOGICAL
+    - SME_SIMPLE_CMP
+    # Same as SVE
+    Execution-Latency: 4
+    Execution-Throughput: 1
+  12:
+    Instruction-Groups:
+    - SME_SIMPLE
+    - SME_DIV_OR_SQRT
+    - SME_MUL
+    # SME_MUL Used only by outer-product instructions
+    # Same as SVE. No SME DIV or SQRT so classification to this group should be impossible. 
+    # Kept to catch edge cases.
+    Execution-Latency: 9
+    Execution-Throughput: 1
+  13:
+    Instruction-Groups:
+    - LOAD_SME
+    - STORE_ADDRESS_SME
+    # Same as SVE LD/STR
+    Execution-Latency: 6
+    Execution-Throughput: 1
+# CPU-Info mainly used to generate a replica of the special (or system) file directory 
+# structure
+CPU-Info:
+  # Set Generate-Special-Dir to True to generate the special files directory, or to False to not.
+  # (Not generating the special files directory may require the user to copy over files manually)
+  Generate-Special-Dir: True
+  # Core-Count MUST be 1 as multi-core is not supported at this time. (A64FX true value is 48)
+  Core-Count: 1
+  # Socket-Count MUST be 1 as multi-socket simulations are not supported at this time. (A64FX true value is 1)
+  Socket-Count: 1
+  # SMT MUST be 1 as Simultanious-Multi-Threading is not supported at this time. (A64FX true value is 1)
+  SMT: 1
+  # Below are the values needed to generate /proc/cpuinfo
+  BogoMIPS: 200.00
+  Features: fp asimd evtstrm sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm fcma dcpop sve
+  CPU-Implementer: "0x46"
+  CPU-Architecture: 8
+  CPU-Variant: "0x1"
+  CPU-Part: "0x001"
+  CPU-Revision: 0
+  # Package-Count is used to generate 
+  # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
+  Package-Count: 1

--- a/configs/a64fx_SME.yaml
+++ b/configs/a64fx_SME.yaml
@@ -23,7 +23,7 @@ Register-Set:
   FloatingPoint/SVE-Count: 128
   Predicate-Count: 48
   Conditional-Count: 128
-  MatrixRow-Count: 128
+  Matrix-Count: 2
 Pipeline-Widths:
   Commit: 4
   FrontEnd: 4

--- a/docs/sphinx/user/configuring_simeng.rst
+++ b/docs/sphinx/user/configuring_simeng.rst
@@ -90,8 +90,8 @@ Predicate-Count (Optional)
 Conditional-Count
     The number of physical status/flag/conditional-code registers.
 
-MatrixRow-Count
-    The number of physical rows for SME's ``za`` register. SimEng's implementation of the ``za`` matrix register treats each row as a vector register. Having the MatrixRow-Count equal to the Streaming-Vector-Length/8 will yield a single physical ``za`` register. As such, the MatrixRow-Count must be a minimum of Streaming-Vector-Length/8.
+Matrix-Count
+    The number of physical ``za`` SME registers.
 
 Pipeline-widths
 ---------------

--- a/src/include/simeng/ModelConfig.hh
+++ b/src/include/simeng/ModelConfig.hh
@@ -15,23 +15,13 @@
 #include "yaml-cpp/yaml.h"
 
 #define DEFAULT_CONFIG                                                         \
-<<<<<<< HEAD
   ("{Core: {ISA: AArch64, Simulation-Mode: inorderpipelined, "                 \
    "Clock-Frequency: 2.5, Timer-Frequency: 100, Micro-Operations: True, "      \
    "Vector-Length: 512, Streaming-Vector-Length: 512}, Fetch: "                \
    "{Fetch-Block-Size: 32, Loop-Buffer-Size: 64, Loop-Detection-Threshold: "   \
    "4}, Process-Image: {Heap-Size: 10485760, Stack-Size: 1048576}, "           \
    "Register-Set: {GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "   \
-   "Predicate-Count: 17, Conditional-Count: 128, MatrixRow-Count: 128}, "      \
-=======
-  ("{Core: {Simulation-Mode: inorderpipelined, Clock-Frequency: 2.5, "         \
-   "Timer-Frequency: 100, Micro-Operations: True, Vector-Length: 512, "        \
-   "Streaming-Vector-Length: 512}, Fetch: {Fetch-Block-Size: 32, "             \
-   "Loop-Buffer-Size: 64, Loop-Detection-Threshold: 4}, Process-Image: "       \
-   "{Heap-Size: 10485760, Stack-Size: 1048576}, Register-Set: "                \
-   "{GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "                 \
    "Predicate-Count: 17, Conditional-Count: 128, Matrix-Count: 2}, "           \
->>>>>>> 08b51657... Updated how physical matrix register count is defined to make it easier for the user.
    "Pipeline-Widths: {Commit: 4, FrontEnd: 4, LSQ-Completion: 2}, "            \
    "Queue-Sizes: {ROB: 180, Load: 64, Store: 36}, Branch-Predictor: "          \
    "{BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, Global-History-Length: 10, "  \

--- a/src/include/simeng/ModelConfig.hh
+++ b/src/include/simeng/ModelConfig.hh
@@ -15,6 +15,7 @@
 #include "yaml-cpp/yaml.h"
 
 #define DEFAULT_CONFIG                                                         \
+<<<<<<< HEAD
   ("{Core: {ISA: AArch64, Simulation-Mode: inorderpipelined, "                 \
    "Clock-Frequency: 2.5, Timer-Frequency: 100, Micro-Operations: True, "      \
    "Vector-Length: 512, Streaming-Vector-Length: 512}, Fetch: "                \
@@ -22,6 +23,15 @@
    "4}, Process-Image: {Heap-Size: 10485760, Stack-Size: 1048576}, "           \
    "Register-Set: {GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "   \
    "Predicate-Count: 17, Conditional-Count: 128, MatrixRow-Count: 128}, "      \
+=======
+  ("{Core: {Simulation-Mode: inorderpipelined, Clock-Frequency: 2.5, "         \
+   "Timer-Frequency: 100, Micro-Operations: True, Vector-Length: 512, "        \
+   "Streaming-Vector-Length: 512}, Fetch: {Fetch-Block-Size: 32, "             \
+   "Loop-Buffer-Size: 64, Loop-Detection-Threshold: 4}, Process-Image: "       \
+   "{Heap-Size: 10485760, Stack-Size: 1048576}, Register-Set: "                \
+   "{GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "                 \
+   "Predicate-Count: 17, Conditional-Count: 128, Matrix-Count: 2}, "           \
+>>>>>>> 08b51657... Updated how physical matrix register count is defined to make it easier for the user.
    "Pipeline-Widths: {Commit: 4, FrontEnd: 4, LSQ-Completion: 2}, "            \
    "Queue-Sizes: {ROB: 180, Load: 64, Store: 36}, Branch-Predictor: "          \
    "{BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, Global-History-Length: 10, "  \

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -241,9 +241,6 @@ class Instruction : public simeng::Instruction {
               const InstructionMetadata& metadata,
               InstructionException exception);
 
-  /** Copy Constructor. */
-  Instruction(const Instruction& insn);
-
   /** Retrieve the identifier for the first exception that occurred during
    * processing this instruction. */
   virtual InstructionException getException() const;

--- a/src/include/simeng/pipeline/DispatchIssueUnit.hh
+++ b/src/include/simeng/pipeline/DispatchIssueUnit.hh
@@ -128,6 +128,10 @@ class DispatchIssueUnit {
   std::unordered_map<uint16_t, std::unordered_set<std::shared_ptr<Instruction>>>
       flushed_;
 
+  /** Stores the number of instructions dispatched for each reservation station.
+   */
+  std::unique_ptr<uint16_t[]> dispatches_;
+
   /** A reference to the execution port allocator. */
   PortAllocator& portAllocator_;
 

--- a/src/include/simeng/pipeline/DispatchIssueUnit.hh
+++ b/src/include/simeng/pipeline/DispatchIssueUnit.hh
@@ -128,8 +128,8 @@ class DispatchIssueUnit {
   std::unordered_map<uint16_t, std::unordered_set<std::shared_ptr<Instruction>>>
       flushed_;
 
-  /** Stores the number of instructions dispatched for each reservation station.
-   */
+  /** Records the number of instructions dispatched for each reservation station
+   * within a cycle. */
   std::unique_ptr<uint16_t[]> dispatches_;
 
   /** A reference to the execution port allocator. */

--- a/src/include/simeng/pipeline/ReorderBuffer.hh
+++ b/src/include/simeng/pipeline/ReorderBuffer.hh
@@ -23,6 +23,20 @@ struct latestBranch {
   uint64_t commitNumber;
 };
 
+/** Check if the instruction ID is less/greater than a given value used by
+ *  binary_search. */
+struct idCompare {
+  bool operator()(const std::shared_ptr<Instruction>& first,
+                  const uint64_t second) {
+    return first->getInstructionId() < second;
+  }
+
+  bool operator()(const uint64_t first,
+                  const std::shared_ptr<Instruction>& second) {
+    return first < second->getInstructionId();
+  }
+};
+
 /** A Reorder Buffer (ROB) implementation. Contains an in-order queue of
  * in-flight instructions. */
 class ReorderBuffer {

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -247,7 +247,7 @@ void ModelConfig::validate() {
       // Register-Set
       root = "Register-Set";
       subFields = {"GeneralPurpose-Count", "FloatingPoint/SVE-Count",
-                   "Predicate-Count", "Conditional-Count", "MatrixRow-Count"};
+                   "Predicate-Count", "Conditional-Count", "Matrix-Count"};
       nodeChecker<uint16_t>(configFile_[root][subFields[0]], subFields[0],
                             std::make_pair(32, UINT16_MAX),
                             ExpectedValue::UInteger);
@@ -260,12 +260,9 @@ void ModelConfig::validate() {
       nodeChecker<uint16_t>(configFile_[root][subFields[3]], subFields[3],
                             std::make_pair(1, UINT16_MAX),
                             ExpectedValue::UInteger);
-      nodeChecker<uint16_t>(
-          configFile_[root][subFields[4]], subFields[4],
-          std::make_pair(
-              configFile_["Core"]["Streaming-Vector-Length"].as<uint16_t>() / 8,
-              UINT16_MAX),
-          ExpectedValue::UInteger, 128);
+      nodeChecker<uint16_t>(configFile_[root][subFields[4]], subFields[4],
+                            std::make_pair(1, UINT16_MAX),
+                            ExpectedValue::UInteger, 1);
     }
 
     subFields.clear();

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -303,7 +303,13 @@ Architecture::getConfigPhysicalRegisterStructure(YAML::Node config) const {
       {32, config["Register-Set"]["Predicate-Count"].as<uint16_t>()},
       {1, config["Register-Set"]["Conditional-Count"].as<uint16_t>()},
       {8, getNumSystemRegisters()},
-      {256, config["Register-Set"]["MatrixRow-Count"].as<uint16_t>()}};
+      // Matrix-Count multiplied by (SVL/8) as internal representation of
+      // ZA is a block of row-vector-registers. Therefore we need to
+      // convert physical counts from whole-ZA to rows-in-ZA.
+      {256,
+       (uint16_t)(config["Register-Set"]["Matrix-Count"].as<uint16_t>() *
+                  (config["Core"]["Streaming-Vector-Length"].as<uint16_t>() /
+                   8))}};
 }
 
 std::vector<uint16_t> Architecture::getConfigPhysicalRegisterQuantities(
@@ -313,7 +319,12 @@ std::vector<uint16_t> Architecture::getConfigPhysicalRegisterQuantities(
           config["Register-Set"]["Predicate-Count"].as<uint16_t>(),
           config["Register-Set"]["Conditional-Count"].as<uint16_t>(),
           getNumSystemRegisters(),
-          config["Register-Set"]["MatrixRow-Count"].as<uint16_t>()};
+          // Matrix-Count multiplied by (SVL/8) as internal representation of
+          // ZA is a block of row-vector-registers. Therefore we need to
+          // convert physical counts from whole-ZA to rows-in-ZA.
+          (uint16_t)(config["Register-Set"]["Matrix-Count"].as<uint16_t>() *
+                     (config["Core"]["Streaming-Vector-Length"].as<uint16_t>() /
+                      8))};
 }
 /** The SVCR value is stored in Architecture to allow the value to be
  * retrieved within execution pipeline. This prevents adding an implicit

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -297,35 +297,37 @@ void Architecture::updateSystemTimerRegisters(RegisterFileSet* regFile,
 
 std::vector<RegisterFileStructure>
 Architecture::getConfigPhysicalRegisterStructure(YAML::Node config) const {
+  // Matrix-Count multiplied by (SVL/8) as internal representation of
+  // ZA is a block of row-vector-registers. Therefore we need to
+  // convert physical counts from whole-ZA to rows-in-ZA.
+  uint16_t matCount =
+      config["Register-Set"]["Matrix-Count"].as<uint16_t>() *
+      (config["Core"]["Streaming-Vector-Length"].as<uint16_t>() / 8);
   return {
       {8, config["Register-Set"]["GeneralPurpose-Count"].as<uint16_t>()},
       {256, config["Register-Set"]["FloatingPoint/SVE-Count"].as<uint16_t>()},
       {32, config["Register-Set"]["Predicate-Count"].as<uint16_t>()},
       {1, config["Register-Set"]["Conditional-Count"].as<uint16_t>()},
       {8, getNumSystemRegisters()},
-      // Matrix-Count multiplied by (SVL/8) as internal representation of
-      // ZA is a block of row-vector-registers. Therefore we need to
-      // convert physical counts from whole-ZA to rows-in-ZA.
-      {256,
-       (uint16_t)(config["Register-Set"]["Matrix-Count"].as<uint16_t>() *
-                  (config["Core"]["Streaming-Vector-Length"].as<uint16_t>() /
-                   8))}};
+      {256, matCount}};
 }
 
 std::vector<uint16_t> Architecture::getConfigPhysicalRegisterQuantities(
     YAML::Node config) const {
+  // Matrix-Count multiplied by (SVL/8) as internal representation of
+  // ZA is a block of row-vector-registers. Therefore we need to
+  // convert physical counts from whole-ZA to rows-in-ZA.
+  uint16_t matCount =
+      config["Register-Set"]["Matrix-Count"].as<uint16_t>() *
+      (config["Core"]["Streaming-Vector-Length"].as<uint16_t>() / 8);
   return {config["Register-Set"]["GeneralPurpose-Count"].as<uint16_t>(),
           config["Register-Set"]["FloatingPoint/SVE-Count"].as<uint16_t>(),
           config["Register-Set"]["Predicate-Count"].as<uint16_t>(),
           config["Register-Set"]["Conditional-Count"].as<uint16_t>(),
           getNumSystemRegisters(),
-          // Matrix-Count multiplied by (SVL/8) as internal representation of
-          // ZA is a block of row-vector-registers. Therefore we need to
-          // convert physical counts from whole-ZA to rows-in-ZA.
-          (uint16_t)(config["Register-Set"]["Matrix-Count"].as<uint16_t>() *
-                     (config["Core"]["Streaming-Vector-Length"].as<uint16_t>() /
-                      8))};
+          matCount};
 }
+
 /** The SVCR value is stored in Architecture to allow the value to be
  * retrieved within execution pipeline. This prevents adding an implicit
  * operand to every SME instruction; reducing the amount of complexity when

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -598,6 +598,12 @@ bool ExceptionHandler::init() {
         stateChange = {ChangeType::REPLACEMENT, {R0}, {0ull}};
         break;
       }
+      case 235: {  // mbind
+        // mbind is not supported due to all binaries being single threaded.
+        // Always return zero to indicate success
+        stateChange = {ChangeType::REPLACEMENT, {R0}, {0ull}};
+        break;
+      }
       case 261: {  // prlimit64
         // TODO: Functionality temporarily omitted as it is unused within
         // workloads regions of interest and not required for their simulation

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -31,58 +31,6 @@ Instruction::Instruction(const Architecture& architecture,
   exceptionEncountered_ = true;
 }
 
-Instruction::Instruction(const Instruction& insn)
-    : architecture_(insn.architecture_), metadata(insn.metadata) {
-  // Parent class variables
-  exceptionEncountered_ = insn.exceptionEncountered_;
-  instructionAddress_ = insn.instructionAddress_;
-  executed_ = insn.executed_;
-  canCommit_ = insn.canCommit_;
-  dataPending_ = insn.dataPending_;
-  prediction_ = insn.prediction_;
-  branchAddress_ = insn.branchAddress_;
-  branchTaken_ = insn.branchTaken_;
-  branchType_ = insn.branchType_;
-  knownTarget_ = insn.knownTarget_;
-  sequenceId_ = insn.sequenceId_;
-  flushed_ = insn.flushed_;
-  latency_ = insn.latency_;
-  lsqExecutionLatency_ = insn.lsqExecutionLatency_;
-  stallCycles_ = insn.stallCycles_;
-  supportedPorts_ = insn.supportedPorts_;
-  isMicroOp_ = insn.isMicroOp_;
-  isLastMicroOp_ = insn.isLastMicroOp_;
-  instructionId_ = insn.instructionId_;
-  waitingCommit_ = insn.waitingCommit_;
-  microOpIndex_ = insn.microOpIndex_;
-  // Child class variables
-  sourceRegisters = insn.sourceRegisters;
-  sourceRegisterCount = insn.sourceRegisterCount;
-  destinationRegisters = insn.destinationRegisters;
-  destinationRegisterCount = insn.destinationRegisterCount;
-  operands = insn.operands;
-  results = insn.results;
-  exception_ = insn.exception_;
-  operandsPending = insn.operandsPending;
-  isScalarData_ = insn.isScalarData_;
-  isVectorData_ = insn.isVectorData_;
-  isSVEData_ = insn.isSVEData_;
-  isSMEData_ = insn.isSMEData_;
-  isNoShift_ = insn.isNoShift_;
-  isLogical_ = insn.isLogical_;
-  isCompare_ = insn.isCompare_;
-  isConvert_ = insn.isConvert_;
-  isMultiply_ = insn.isMultiply_;
-  isDivideOrSqrt_ = insn.isDivideOrSqrt_;
-  isPredicate_ = insn.isPredicate_;
-  isLoad_ = insn.isLoad_;
-  isStoreAddress_ = insn.isStoreAddress_;
-  isStoreData_ = insn.isStoreData_;
-  isBranch_ = insn.isBranch_;
-  microOpcode_ = insn.microOpcode_;
-  dataSize_ = insn.dataSize_;
-}
-
 InstructionException Instruction::getException() const { return exception_; }
 
 const span<Register> Instruction::getOperandRegisters() const {

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -96,14 +96,14 @@ bool Instruction::isOperandReady(int index) const {
   return static_cast<bool>(operands[index]);
 }
 
-void Instruction::renameSource(uint8_t i, Register renamed) {
+void Instruction::renameSource(uint16_t i, Register renamed) {
   sourceRegisters[i] = renamed;
 }
-void Instruction::renameDestination(uint8_t i, Register renamed) {
+void Instruction::renameDestination(uint16_t i, Register renamed) {
   destinationRegisters[i] = renamed;
 }
 
-void Instruction::supplyOperand(uint8_t i, const RegisterValue& value) {
+void Instruction::supplyOperand(uint16_t i, const RegisterValue& value) {
   assert(!canExecute() &&
          "Attempted to provide an operand to a ready-to-execute instruction");
   assert(value.size() > 0 &&

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -96,14 +96,14 @@ bool Instruction::isOperandReady(int index) const {
   return static_cast<bool>(operands[index]);
 }
 
-void Instruction::renameSource(uint16_t i, Register renamed) {
+void Instruction::renameSource(uint8_t i, Register renamed) {
   sourceRegisters[i] = renamed;
 }
-void Instruction::renameDestination(uint16_t i, Register renamed) {
+void Instruction::renameDestination(uint8_t i, Register renamed) {
   destinationRegisters[i] = renamed;
 }
 
-void Instruction::supplyOperand(uint16_t i, const RegisterValue& value) {
+void Instruction::supplyOperand(uint8_t i, const RegisterValue& value) {
   assert(!canExecute() &&
          "Attempted to provide an operand to a ready-to-execute instruction");
   assert(value.size() > 0 &&

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -1285,6 +1285,8 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
         operands[2].access = CS_AC_READ;
       }
       break;
+    case Opcode::AArch64_ST1Twov4s:
+      [[fallthrough]];
     case Opcode::AArch64_ST1Twov16b:
       // ST1 incorrectly flags read and write
       operands[1].access = CS_AC_READ;

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -1273,6 +1273,18 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       }
       break;
     }
+    case Opcode::AArch64_ST1Fourv2s_POST:
+      [[fallthrough]];
+    case Opcode::AArch64_ST1Fourv4s_POST: {
+      // ST1 four vectors doesn't set access rights correctly
+      operands[0].access = CS_AC_READ;
+      operands[1].access = CS_AC_READ;
+      operands[2].access = CS_AC_READ;
+      operands[3].access = CS_AC_READ;
+      // operands[4] is memory + write-back enabled already
+      if (operandCount == 6) operands[5].access = CS_AC_READ;
+      break;
+    }
     case Opcode::AArch64_ST1i8_POST:
       [[fallthrough]];
     case Opcode::AArch64_ST1i16_POST:

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -1270,13 +1270,24 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         setMemoryAddresses(addresses);
         break;
       }
-      case Opcode::AArch64_ST1Twov16b: {  // st1v {vt.16b, vt2.16b}, [xn]
+      case Opcode::AArch64_ST1Twov16b: {  // st1 {vt.16b, vt2.16b}, [xn]
         const uint64_t base = operands[2].get<uint64_t>();
         std::vector<MemoryAccessTarget> addresses;
         addresses.reserve(32);
 
         for (int i = 0; i < 32; i++) {
           addresses.push_back({base + i, 1});
+        }
+        setMemoryAddresses(std::move(addresses));
+        break;
+      }
+      case Opcode::AArch64_ST1Twov4s: {  // st1 {vt.4s, vt2.4s}, [xn]
+        const uint64_t base = operands[2].get<uint64_t>();
+        std::vector<MemoryAccessTarget> addresses;
+        addresses.reserve(8);
+
+        for (int i = 0; i < 8; i++) {
+          addresses.push_back({base + (i * 4), 4});
         }
         setMemoryAddresses(std::move(addresses));
         break;

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -1270,6 +1270,30 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         setMemoryAddresses(addresses);
         break;
       }
+      case Opcode::AArch64_ST1Fourv2s_POST: {  // st1 {vt.42, vt2.2s, vt3.2s,
+                                               // vt4.2s}, [xn|sp], #imm
+        const uint64_t base = operands[4].get<uint64_t>();
+        std::vector<MemoryAccessTarget> addresses;
+        addresses.reserve(8);
+
+        for (int i = 0; i < 8; i++) {
+          addresses.push_back({base + (i * 4), 4});
+        }
+        setMemoryAddresses(std::move(addresses));
+        break;
+      }
+      case Opcode::AArch64_ST1Fourv4s_POST: {  // st1 {vt.4s, vt2.4s, vt3.4s,
+                                               // vt4.4s}, [xn|sp], #imm
+        const uint64_t base = operands[4].get<uint64_t>();
+        std::vector<MemoryAccessTarget> addresses;
+        addresses.reserve(16);
+
+        for (int i = 0; i < 16; i++) {
+          addresses.push_back({base + (i * 4), 4});
+        }
+        setMemoryAddresses(std::move(addresses));
+        break;
+      }
       case Opcode::AArch64_ST1Twov16b: {  // st1 {vt.16b, vt2.16b}, [xn]
         const uint64_t base = operands[2].get<uint64_t>();
         std::vector<MemoryAccessTarget> addresses;

--- a/src/lib/arch/aarch64/Instruction_decode.cc
+++ b/src/lib/arch/aarch64/Instruction_decode.cc
@@ -467,7 +467,7 @@ void Instruction::decode() {
     }
 
     if (isStoreData_) {
-      // Idnetify store instruction group
+      // Identify store instruction group
       if (ARM64_REG_Z0 <= metadata.operands[0].reg &&
           metadata.operands[0].reg <= ARM64_REG_Z31) {
         isSVEData_ = true;

--- a/src/lib/arch/aarch64/Instruction_decode.cc
+++ b/src/lib/arch/aarch64/Instruction_decode.cc
@@ -206,27 +206,29 @@ void Instruction::decode() {
   for (size_t i = 0; i < metadata.operandCount; i++) {
     const auto& op = metadata.operands[i];
 
+    // Determine the data type the instruction operates on based on the
+    // register operand used
+    if (i == 0) {
+      // Belongs to the predicate group if the detsination register is a
+      // predicate
+      if (op.reg >= ARM64_REG_V0) {
+        isVectorData_ = true;
+      } else if (op.reg >= ARM64_REG_ZAB0 || op.reg == ARM64_REG_ZA) {
+        isSMEData_ = true;
+      } else if (op.reg >= ARM64_REG_Z0) {
+        isSVEData_ = true;
+      } else if (op.reg <= ARM64_REG_S31 && op.reg >= ARM64_REG_Q0) {
+        isScalarData_ = true;
+      } else if (op.reg <= ARM64_REG_P15 && op.reg >= ARM64_REG_P0) {
+        isPredicate_ = true;
+      } else if (op.reg <= ARM64_REG_H31 && op.reg >= ARM64_REG_B0) {
+        isScalarData_ = true;
+      }
+    }
+
     if (op.type == ARM64_OP_REG) {  // Register operand
       if ((op.access & cs_ac_type::CS_AC_WRITE) && op.reg != ARM64_REG_WZR &&
           op.reg != ARM64_REG_XZR) {
-        // Belongs to the predicate group if the destination register is a
-        // predicate
-        // Determine the data type the instruction operates on based on the
-        // register operand used
-        if (op.reg >= ARM64_REG_V0) {
-          isVectorData_ = true;
-        } else if (op.reg >= ARM64_REG_ZAB0 || op.reg == ARM64_REG_ZA) {
-          isSMEData_ = true;
-        } else if (op.reg >= ARM64_REG_Z0) {
-          isSVEData_ = true;
-        } else if (op.reg <= ARM64_REG_S31 && op.reg >= ARM64_REG_Q0) {
-          isScalarData_ = true;
-        } else if (op.reg <= ARM64_REG_P15 && op.reg >= ARM64_REG_P0) {
-          isPredicate_ = true;
-        } else if (op.reg <= ARM64_REG_H31 && op.reg >= ARM64_REG_B0) {
-          isScalarData_ = true;
-        }
-
         if ((op.reg >= ARM64_REG_ZAB0 && op.reg < ARM64_REG_V0) ||
             (op.reg == ARM64_REG_ZA)) {
           // Add all Matrix register rows as destination operands

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -1611,6 +1611,12 @@ void Instruction::execute() {
         results[0] = static_cast<int64_t>(std::trunc(operands[0].get<float>()));
         break;
       }
+      case Opcode::AArch64_FCVTZUv1i64: {  // fcvtzu dd, dn
+        // TODO: Handle NaNs, denorms, and saturation
+        results[0] = {
+            static_cast<uint64_t>(std::trunc(operands[0].get<double>())), 256};
+        break;
+      }
       case Opcode::AArch64_FCVT_ZPmZ_DtoS: {  // fcvt zd.s, pg/m, zn.d
         results[0] =
             sveHelp::sveFcvtPredicated<float, double>(operands, VL_bits);

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -3555,7 +3555,6 @@ void Instruction::execute() {
         // This instruction is always used by SMSTART and SMSTOP aliases.
         const uint64_t svcrBits =
             static_cast<uint64_t>(metadata.operands[0].svcr);
-        const uint8_t imm = metadata.operands[1].imm;
 
         // Changing value of SM or ZA bits in SVCR zeros out vector, predicate,
         // and ZA registers. Raise an exception to do this.
@@ -3871,6 +3870,11 @@ void Instruction::execute() {
       case Opcode::AArch64_SBFMXri: {  // sbfm xd, xn, #immr, #imms
         results[0] =
             bitmanipHelp::bfm_2imms<uint64_t>(operands, metadata, true, true);
+        break;
+      }
+      case Opcode::AArch64_SCVTFSWSri: {  // scvtf sd, wn, #fbits
+        results[0] =
+            floatHelp::scvtf_FixedPoint<float, int32_t>(operands, metadata);
         break;
       }
       case Opcode::AArch64_SCVTFSXDri: {  // scvtf dd, xn, #fbits

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -4238,6 +4238,44 @@ void Instruction::execute() {
         }
         break;
       }
+      case Opcode::AArch64_ST1Fourv2s_POST: {  // st1 {vt.2s, vt2.2s, vt3.2s,
+                                               // vt4.2s}, [xn|sp], <#imm|xm>
+        // STORE
+        const uint32_t* t = operands[0].getAsVector<uint32_t>();
+        const uint32_t* t2 = operands[1].getAsVector<uint32_t>();
+        const uint32_t* t3 = operands[2].getAsVector<uint32_t>();
+        const uint32_t* t4 = operands[3].getAsVector<uint32_t>();
+        for (int i = 0; i < 2; i++) {
+          memoryData[i] = t[i];
+          memoryData[i + 2] = t2[i];
+          memoryData[i + 4] = t3[i];
+          memoryData[i + 6] = t4[i];
+        }
+        // if #imm post-index, value can only be 32
+        const uint64_t postIndex =
+            (metadata.operandCount == 6) ? operands[5].get<uint64_t>() : 32;
+        results[0] = operands[4].get<uint64_t>() + postIndex;
+        break;
+      }
+      case Opcode::AArch64_ST1Fourv4s_POST: {  // st1 {vt.4s, vt2.4s, vt3.4s,
+                                               // vt4.4s}, [xn|sp], <#imm|xm>
+        // STORE
+        const uint32_t* t = operands[0].getAsVector<uint32_t>();
+        const uint32_t* t2 = operands[1].getAsVector<uint32_t>();
+        const uint32_t* t3 = operands[2].getAsVector<uint32_t>();
+        const uint32_t* t4 = operands[3].getAsVector<uint32_t>();
+        for (int i = 0; i < 4; i++) {
+          memoryData[i] = t[i];
+          memoryData[i + 4] = t2[i];
+          memoryData[i + 8] = t3[i];
+          memoryData[i + 12] = t4[i];
+        }
+        // if #imm post-index, value can only be 64
+        const uint64_t postIndex =
+            (metadata.operandCount == 6) ? operands[5].get<uint64_t>() : 64;
+        results[0] = operands[4].get<uint64_t>() + postIndex;
+        break;
+      }
       case Opcode::AArch64_ST1Twov16b: {  // st1 {vt.16b, vt2.16b}, [xn|sp]
         // STORE
         const uint8_t* t = operands[0].getAsVector<uint8_t>();

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -4238,15 +4238,23 @@ void Instruction::execute() {
         }
         break;
       }
-      case Opcode::AArch64_ST1Twov16b: {  // st1v {vt.16b, vt2.16b}, [xn]
+      case Opcode::AArch64_ST1Twov16b: {  // st1 {vt.16b, vt2.16b}, [xn|sp]
         // STORE
         const uint8_t* t = operands[0].getAsVector<uint8_t>();
         const uint8_t* t2 = operands[1].getAsVector<uint8_t>();
         for (int i = 0; i < 16; i++) {
           memoryData[i] = t[i];
-        }
-        for (int i = 0; i < 16; i++) {
           memoryData[i + 16] = t2[i];
+        }
+        break;
+      }
+      case Opcode::AArch64_ST1Twov4s: {  // st1 {vt.4s, vt2.4s}, [xn|sp]
+        // STORE
+        const uint32_t* t = operands[0].getAsVector<uint32_t>();
+        const uint32_t* t2 = operands[1].getAsVector<uint32_t>();
+        for (int i = 0; i < 4; i++) {
+          memoryData[i] = t[i];
+          memoryData[i + 4] = t2[i];
         }
         break;
       }

--- a/src/lib/kernel/LinuxProcess.cc
+++ b/src/lib/kernel/LinuxProcess.cc
@@ -129,7 +129,8 @@ void LinuxProcess::createStack(char** processImage) {
     stringBytes.push_back(0);
   }
   // Environment strings
-  std::vector<std::string> envStrings = {"OMP_NUM_THREADS=1"};
+  std::vector<std::string> envStrings = {
+      "OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1"};
   for (std::string& env : envStrings) {
     for (int i = 0; i < env.size(); i++) {
       stringBytes.push_back(env.c_str()[i]);

--- a/src/lib/kernel/LinuxProcess.cc
+++ b/src/lib/kernel/LinuxProcess.cc
@@ -129,8 +129,7 @@ void LinuxProcess::createStack(char** processImage) {
     stringBytes.push_back(0);
   }
   // Environment strings
-  std::vector<std::string> envStrings = {
-      "OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1"};
+  std::vector<std::string> envStrings = {"OMP_NUM_THREADS=1"};
   for (std::string& env : envStrings) {
     for (int i = 0; i < env.size(); i++) {
       stringBytes.push_back(env.c_str()[i]);

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -140,7 +140,7 @@ void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
                 }
                 // Remove from temporary vector so the confliction can't be
                 // registered again
-                temp_load_addr.erase(itLd);
+                itLd = temp_load_addr.erase(itLd);
               } else {
                 itLd++;
               }

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -154,9 +154,10 @@ void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
     // If addresses remain that had no conflictions, generate those load
     // request(s)
     for (const auto& ld_addr : temp_load_addr) reqAddrQueue.emplace(ld_addr);
+
+    // Register active load
+    requestedLoads_.emplace(insn->getSequenceId(), insn);
   }
-  // Register active load
-  requestedLoads_.emplace(insn->getSequenceId(), insn);
 }
 
 void LoadStoreQueue::supplyStoreData(const std::shared_ptr<Instruction>& insn) {

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
+#include <list>
 
 namespace simeng {
 namespace pipeline {
@@ -104,12 +105,15 @@ void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
     // Create a speculative entry for the load
     requestLoadQueue_[tickCounter_ + insn->getLSQLatency()].push_back(
         {{}, insn});
-    // Store load addresses in vector temporarily so that conflictions are
+    // Store a reference to the reqAddresses queue for easy access
+    auto& reqAddrQueue = requestLoadQueue_[tickCounter_ + insn->getLSQLatency()]
+                             .back()
+                             .reqAddresses;
+    // Store load addresses temporarily so that conflictions are
     // only regsitered once on most recent (program order) store
-    std::vector<simeng::MemoryAccessTarget> temp_load_addr;
-    for (const auto& ld : ld_addresses) {
-      temp_load_addr.push_back(ld);
-    }
+    std::list<simeng::MemoryAccessTarget> temp_load_addr(ld_addresses.begin(),
+                                                         ld_addresses.end());
+
     // Detect reordering conflicts
     if (storeQueue_.size() > 0) {
       uint64_t seqId = insn->getSequenceId();
@@ -134,9 +138,7 @@ void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
                 } else {
                   // To ensure load doesn't match on an earlier store, generate
                   // load request for address
-                  requestLoadQueue_[tickCounter_ + insn->getLSQLatency()]
-                      .back()
-                      .reqAddresses.push(*itLd);
+                  reqAddrQueue.push(*itLd);
                 }
                 // Remove from temporary vector so the confliction can't be
                 // registered again
@@ -151,16 +153,10 @@ void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
     }
     // If addresses remain that had no conflictions, generate those load
     // request(s)
-    if (temp_load_addr.size() > 0) {
-      for (size_t i = 0; i < temp_load_addr.size(); i++) {
-        requestLoadQueue_[tickCounter_ + insn->getLSQLatency()]
-            .back()
-            .reqAddresses.push(temp_load_addr[i]);
-      }
-    }
-    // Register active load
-    requestedLoads_.emplace(insn->getSequenceId(), insn);
+    for (const auto& ld_addr : temp_load_addr) reqAddrQueue.emplace(ld_addr);
   }
+  // Register active load
+  requestedLoads_.emplace(insn->getSequenceId(), insn);
 }
 
 void LoadStoreQueue::supplyStoreData(const std::shared_ptr<Instruction>& insn) {

--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -49,9 +49,10 @@ void ReorderBuffer::commitMicroOps(uint64_t insnId) {
       return;
     }
 
-    std::for_each(first, last, [](std::shared_ptr<Instruction>& insn) {
-      insn->setCommitReady();
-    });
+    while (first != last) {
+      first->get()->setCommitReady();
+      first++;
+    }
   }
 }
 

--- a/sst/SimEngCoreWrapper.cc
+++ b/sst/SimEngCoreWrapper.cc
@@ -86,7 +86,7 @@ void SimEngCoreWrapper::finish() {
   double khz =
       (iterations_ / (static_cast<double>(duration) / 1000.0)) / 1000.0;
   uint64_t retired = core_->getInstructionsRetiredCount();
-  double mips = retired / (static_cast<double>(duration) / 1000.0);
+  double mips = (retired / (static_cast<double>(duration))) / 1000.0;
 
   // Print stats
   std::cout << "\n";

--- a/test/regression/aarch64/AArch64RegressionTest.hh
+++ b/test/regression/aarch64/AArch64RegressionTest.hh
@@ -10,7 +10,7 @@
    "{Fetch-Block-Size: 32, Loop-Buffer-Size: 64, Loop-Detection-Threshold: "  \
    "4}, Process-Image: {Heap-Size: 100000, Stack-Size: 100000}, "             \
    "Register-Set: {GeneralPurpose-Count: 154, FloatingPoint/SVE-Count: 90, "  \
-   "Predicate-Count: 17, Conditional-Count: 128, MatrixRow-Count: 256}, "     \
+   "Predicate-Count: 17, Conditional-Count: 128, Matrix-Count: 2}, "          \
    "Pipeline-Widths: { Commit: 4, FrontEnd: 4, LSQ-Completion: 2}, "          \
    "Queue-Sizes: {ROB: 180, Load: 64, Store: 36}, Branch-Predictor: "         \
    "{BTB-Tag-Bits: 11, Saturating-Count-Bits: 2, Global-History-Length: 10, " \

--- a/test/regression/aarch64/instructions/float.cc
+++ b/test/regression/aarch64/instructions/float.cc
@@ -578,6 +578,29 @@ TEST_P(InstFloat, fcvtzu) {
   EXPECT_EQ((getGeneralRegister<uint64_t>(2)), 0);
   EXPECT_EQ((getGeneralRegister<uint64_t>(3)), 321);
 
+  // Double to implicit_cast<double>(uint64)
+  RUN_AARCH64(R"(
+    # Get heap address
+    mov x0, 0
+    mov x8, 214
+    svc #0
+
+    ldp d0, d1, [x0]
+    ldp d2, d3, [x0, #16]
+    fcvtzu d10, d0
+    fcvtzu d11, d1
+    fcvtzu d12, d2
+    fcvtzu d13, d3
+  )");
+  // Values verified on A64FX via simple assembly test kernel
+  double a = 4.9406564584124654e-324;
+  double b = 0.0;
+  double c = 1.5859507231504014e-321;
+  CHECK_NEON(10, double, {a, 0.0});
+  CHECK_NEON(11, double, {b, 0.0});
+  CHECK_NEON(12, double, {b, 0.0});
+  CHECK_NEON(13, double, {c, 0.0});
+
   float* fheap = reinterpret_cast<float*>(initialHeapData_.data());
   fheap[0] = 1.0;
   fheap[1] = -42.76;

--- a/test/regression/aarch64/instructions/float.cc
+++ b/test/regression/aarch64/instructions/float.cc
@@ -1186,6 +1186,12 @@ TEST_P(InstFloat, scvtf) {
     ldp w3, w4, [x0, #8]
     scvtf d10, w3
     scvtf d11, w4
+
+    # With fixed point
+    mov x5, #5
+    mov x6, #-73
+    scvtf s12, w5, #1
+    scvtf s13, w6, #5
   )");
   CHECK_NEON(0, float, {1.f, 0.f, 0.f, 0.f});
   CHECK_NEON(1, float, {-1.f, 0.f, 0.f, 0.f});
@@ -1199,6 +1205,8 @@ TEST_P(InstFloat, scvtf) {
   CHECK_NEON(9, double, {-1.0, 0.0});
   CHECK_NEON(10, double, {static_cast<double>(INT32_MAX), 0.0});
   CHECK_NEON(11, double, {static_cast<double>(INT32_MIN), 0.0});
+  CHECK_NEON(12, float, {2.5f, 0.0f, 0.0f, 0.0f});
+  CHECK_NEON(13, float, {-2.28125f, 0.f, 0.f, 0.f});
 
   // 64-bit integer
   initialHeapData_.resize(32);

--- a/test/regression/aarch64/instructions/store.cc
+++ b/test/regression/aarch64/instructions/store.cc
@@ -389,6 +389,111 @@ TEST_P(InstStore, st1twov) {
   }
 }
 
+TEST_P(InstStore, st1fourv_post) {
+  // V.2S
+  RUN_AARCH64(R"(
+      movi v0.2s, #1
+      movi v1.2s, #2
+      movi v2.2s, #3
+      movi v3.2s, #4
+
+      sub sp, sp, #64
+      mov x0, sp
+
+      st1 {v0.2s, v1.2s, v2.2s, v3.2s}, [x0], #32
+
+      movi v4.2s, #5
+      movi v5.2s, #6
+      movi v6.2s, #7
+      movi v7.2s, #8
+      mov x1, x0
+      mov x2, #17
+
+      st1 {v4.2s, v5.2s, v6.2s, v7.2s}, [x1], x2
+  )");
+  EXPECT_EQ(getGeneralRegister<uint64_t>(31), process_->getStackPointer() - 64);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(0), process_->getStackPointer() - 32);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(1), process_->getStackPointer() - 15);
+  for (int i = 0; i < 2; i++) {
+    EXPECT_EQ(
+        getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + (i * 4)),
+        (static_cast<uint32_t>(1)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 8 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(2)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 16 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(3)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 24 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(4)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 32 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(5)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 40 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(6)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 48 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(7)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 56 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(8)));
+  }
+
+  // V.4S
+  RUN_AARCH64(R"(
+      movi v0.4s, #1
+      movi v1.4s, #2
+      movi v2.4s, #3
+      movi v3.4s, #4
+
+      sub sp, sp, #128
+      mov x0, sp
+
+      st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [x0], #64
+
+      movi v4.4s, #5
+      movi v5.4s, #6
+      movi v6.4s, #7
+      movi v7.4s, #8
+      mov x1, x0
+      mov x2, #17
+
+      st1 {v4.4s, v5.4s, v6.4s, v7.4s}, [x1], x2
+  )");
+  EXPECT_EQ(getGeneralRegister<uint64_t>(31),
+            process_->getStackPointer() - 128);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(0), process_->getStackPointer() - 64);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(1), process_->getStackPointer() - 47);
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(
+        getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + (i * 4)),
+        (static_cast<uint32_t>(1)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 16 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(2)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 32 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(3)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 48 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(4)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 64 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(5)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 80 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(6)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 96 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(7)));
+    EXPECT_EQ(getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + 112 +
+                                       (i * 4)),
+              (static_cast<uint32_t>(8)));
+  }
+}
+
 TEST_P(InstStore, st2_multi_struct) {
   // V.4S (float)
   RUN_AARCH64(R"(

--- a/test/regression/aarch64/instructions/store.cc
+++ b/test/regression/aarch64/instructions/store.cc
@@ -368,6 +368,25 @@ TEST_P(InstStore, st1twov) {
     EXPECT_EQ(getMemoryValue<uint8_t>(getGeneralRegister<uint64_t>(31) + i),
               (static_cast<uint8_t>(2)));
   }
+
+  // V.4S
+  RUN_AARCH64(R"(
+    movi v0.4s, #1
+    movi v1.4s, #2
+    sub sp, sp, #32
+    st1 {v0.4s, v1.4s}, [sp]
+  )");
+  EXPECT_EQ(getGeneralRegister<uint64_t>(31), process_->getStackPointer() - 32);
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(
+        getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + (i * 4)),
+        (static_cast<uint32_t>(1)));
+  }
+  for (uint64_t i = 4; i < 8; i++) {
+    EXPECT_EQ(
+        getMemoryValue<uint32_t>(getGeneralRegister<uint64_t>(31) + (i * 4)),
+        (static_cast<uint32_t>(2)));
+  }
 }
 
 TEST_P(InstStore, st2_multi_struct) {


### PR DESCRIPTION
As well as some AArch64 instruction support, the following fixes are implemented : 

- Added example SME core (A64FX with in-core SME support)
- Fixes MIPS calculation in CoreWrapper.cc
- Fixed store instruction group allocation logic for non-SVE instructions
- Corrected SME instruction group allocation in
- Reassign LdAddr iterator after erasing element in LSQ load conflict logic (originally in PR #272)
- Moved optinisations of PR #274 into this PR :
   - Refactored the `ReorderBuffer::commitMicroOps` method by using binary search to find the list of uops with the same instruction id. This improves the complexity from O(n) to O(logn)
   - Changed the `DispatchIssueUnit::tick` method to use a dynamic array instead of initializing a vector for each method call. This eliminates ~ 14m memory allocations for stream-triad.
   - Replaced `std::vector` to `std::list` in `LoadStoreQueue::startLoad` as it provides O(1) deletion compared to O(n) (worst-case).
- Removed the explicit copy constructor from the AArch64 Instruction class
- Changed `MatrixRow-Count` config option to `Matrix-Count` 
   - Makes it easier for the user to understand how many physcial ZA registers they are defining
   - Hides the internal ZA implementation, again making it easier for users to understand and use