### PR TITLE
Fix NUM_GROUPS warning

### DIFF
--- a/src/include/simeng/arch/aarch64/InstructionGroups.hh
+++ b/src/include/simeng/arch/aarch64/InstructionGroups.hh
@@ -95,7 +95,8 @@ const uint16_t STORE_SME = 85;
 }  // namespace InstructionGroups
 
 /** The number of aarch64 instruction groups. */
-#define NUM_GROUPS 86
+static constexpr uint8_t NUM_GROUPS = 86;
+
 const std::unordered_map<uint16_t, std::vector<uint16_t>> groupInheritance = {
     {InstructionGroups::INT,
      {InstructionGroups::INT_SIMPLE, InstructionGroups::INT_DIV_OR_SQRT,

--- a/src/include/simeng/arch/riscv/InstructionGroups.hh
+++ b/src/include/simeng/arch/riscv/InstructionGroups.hh
@@ -21,7 +21,7 @@ const uint16_t STORE = 11;
 const uint16_t BRANCH = 12;
 }  // namespace InstructionGroups
 
-#define NUM_GROUPS 13
+static constexpr uint8_t NUM_GROUPS = 13;
 
 const std::unordered_map<uint16_t, std::vector<uint16_t>> groupInheritance = {
     {InstructionGroups::INT,


### PR DESCRIPTION
This pull request fixes the warning produced due to the name clash of NUM_GROUPS within riscv/InstructionGroups.hh and aarch64/InstructionGroups.hh. Instead of using #define which is resolved during pre-processing, these are changed to constexpr's which conform to namespaces so don't clash and also allows for type checking.