### PR TITLE
Minibude instruction support for openmp

### DIFF
--- a/configs/DEMO_RISCV.yaml
+++ b/configs/DEMO_RISCV.yaml
@@ -144,4 +144,4 @@ CPU-Info:
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
 Environment-Variables:
-  - "OMP_NUM_THREADS=2"
+  - "OMP_NUM_THREADS=1"

--- a/configs/DEMO_RISCV.yaml
+++ b/configs/DEMO_RISCV.yaml
@@ -143,3 +143,5 @@ CPU-Info:
   # Package-Count is used to generate
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
+Environment-Variables:
+  - "OMP_NUM_THREADS=2"

--- a/configs/a64fx.yaml
+++ b/configs/a64fx.yaml
@@ -273,4 +273,4 @@ CPU-Info:
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
 Environment-Variables:
-  - "OMP_NUM_THREADS=2"
+  - "OMP_NUM_THREADS=1"

--- a/configs/a64fx.yaml
+++ b/configs/a64fx.yaml
@@ -272,3 +272,5 @@ CPU-Info:
   # Package-Count is used to generate
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
+Environment-Variables:
+  - "OMP_NUM_THREADS=2"

--- a/configs/a64fx_SME.yaml
+++ b/configs/a64fx_SME.yaml
@@ -345,4 +345,4 @@ CPU-Info:
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
 Environment-Variables:
-  - "OMP_NUM_THREADS=2"
+  - "OMP_NUM_THREADS=1"

--- a/configs/a64fx_SME.yaml
+++ b/configs/a64fx_SME.yaml
@@ -344,3 +344,5 @@ CPU-Info:
   # Package-Count is used to generate 
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
+Environment-Variables:
+  - "OMP_NUM_THREADS=2"

--- a/configs/m1_firestorm.yaml
+++ b/configs/m1_firestorm.yaml
@@ -322,4 +322,5 @@ CPU-Info:
   # Package-Count is used to generate 
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
-
+Environment-Variables:
+  - "OMP_NUM_THREADS=2"

--- a/configs/m1_firestorm.yaml
+++ b/configs/m1_firestorm.yaml
@@ -323,4 +323,4 @@ CPU-Info:
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
 Environment-Variables:
-  - "OMP_NUM_THREADS=2"
+  - "OMP_NUM_THREADS=1"

--- a/configs/tx2.yaml
+++ b/configs/tx2.yaml
@@ -189,4 +189,4 @@ CPU-Info:
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
 Environment-Variables:
-  - "OMP_NUM_THREADS=2"
+  - "OMP_NUM_THREADS=1"

--- a/configs/tx2.yaml
+++ b/configs/tx2.yaml
@@ -188,3 +188,5 @@ CPU-Info:
   # Package-Count is used to generate 
   # /sys/devices/system/cpu/cpu{0..Core-Count}/topology/{physical_package_id, core_id}
   Package-Count: 1
+Environment-Variables:
+  - "OMP_NUM_THREADS=2"

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -625,9 +625,8 @@ void ModelConfig::validate() {
   root = "Environment-Variables";
   size_t numEnvVars = configFile_[root].size();
   for (size_t i = 0; i < numEnvVars; i++) {
-    char envVarNum[50];
-    snprintf(envVarNum, 50, "Environment-Variable %zu ", i);
-    nodeChecker<std::string>(configFile_[root][i], std::string(envVarNum),
+    std::string envVarNum = "Environment-Variable " + std::to_string(i) + " ";
+    nodeChecker<std::string>(configFile_[root][i], envVarNum,
                              std::vector<std::string>{}, ExpectedValue::String);
   }
 

--- a/src/lib/ModelConfig.cc
+++ b/src/lib/ModelConfig.cc
@@ -621,6 +621,16 @@ void ModelConfig::validate() {
   }
   subFields.clear();
 
+  // Environment-Variables
+  root = "Environment-Variables";
+  size_t numEnvVars = configFile_[root].size();
+  for (size_t i = 0; i < numEnvVars; i++) {
+    char envVarNum[50];
+    snprintf(envVarNum, 50, "Environment-Variable %zu ", i);
+    nodeChecker<std::string>(configFile_[root][i], std::string(envVarNum),
+                             std::vector<std::string>{}, ExpectedValue::String);
+  }
+
   std::string missingStr = missing_.str();
   std::string invalidStr = invalid_.str();
   // Print all missing fields

--- a/src/lib/OS/Process.cc
+++ b/src/lib/OS/Process.cc
@@ -274,10 +274,11 @@ uint64_t Process::createStack(uint64_t stackStart) {
     stringBytes.push_back(0);
   }
   // Environment strings
-  std::vector<std::string> envStrings = {"OMP_NUM_THREADS=1"};
-  for (std::string& env : envStrings) {
-    for (int i = 0; i < env.size(); i++) {
-      stringBytes.push_back(env.c_str()[i]);
+  for (size_t i = 0; i < Config::get()["Environment-Variables"].size(); i++) {
+    std::string envVar =
+        Config::get()["Environment-Variables"][i].as<std::string>();
+    for (int i = 0; i < envVar.size(); i++) {
+      stringBytes.push_back(envVar.c_str()[i]);
     }
     // Null entry to seperate strings
     stringBytes.push_back(0);

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -880,6 +880,10 @@ InstructionMetadata::InstructionMetadata(const cs_insn& insn)
       operands[0].access = CS_AC_WRITE;
       operands[1].access = CS_AC_WRITE;
       break;
+    case Opcode::AArch64_LDADDALW:
+      [[fallthrough]];
+    case Opcode::AArch64_LDADDALX:
+      [[fallthrough]];
     case Opcode::AArch64_LDADDLW:
       [[fallthrough]];
     case Opcode::AArch64_LDADDW:

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -482,6 +482,12 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         setMemoryAddresses({{base, 16}, {base + 16, 16}});
         break;
       }
+      case Opcode::AArch64_LDADDALW: {  // ldaddal ws, wt, [xn|sp]
+        setMemoryAddresses({{operands[1].get<uint32_t>(), 4}});
+      }
+      case Opcode::AArch64_LDADDALX: {  // ldaddal xs, xt, [xn|sp]
+        setMemoryAddresses({{operands[1].get<uint64_t>(), 8}});
+      }
       case Opcode::AArch64_LDADDLW:  // ldaddl ws, wt, [xn]
         [[fallthrough]];
       case Opcode::AArch64_LDADDW: {  // ldadd ws, wt, [xn]

--- a/src/lib/arch/aarch64/Instruction_decode.cc
+++ b/src/lib/arch/aarch64/Instruction_decode.cc
@@ -460,10 +460,16 @@ void Instruction::decode() {
       isLoad_ = true;
     }
 
-    // CASAL* are considered to be both a load and a store
+    // The following are considered to be both a load and a store
     if (metadata.opcode == Opcode::AArch64_CASALW ||
-        metadata.opcode == Opcode::AArch64_CASALX) {
+        metadata.opcode == Opcode::AArch64_CASALX ||
+        metadata.opcode == Opcode::AArch64_LDADDALW ||
+        metadata.opcode == Opcode::AArch64_LDADDALX ||
+        metadata.opcode == Opcode::AArch64_LDADDLW ||
+        metadata.opcode == Opcode::AArch64_LDADDW) {
       isLoad_ = true;
+      isStoreAddress_ = true;
+      isStoreData_ = true;
     }
 
     if (isStoreData_) {

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -548,6 +548,7 @@ void Instruction::execute() {
         break;
       }
       case Opcode::AArch64_CASALW: {  // casal ws, wt, [xn|sp]
+        // TODO: Load and Store must occur atomically
         // LOAD / STORE
         const uint32_t s = operands[0].get<uint32_t>();
         const uint32_t t = operands[1].get<uint32_t>();
@@ -556,6 +557,7 @@ void Instruction::execute() {
         break;
       }
       case Opcode::AArch64_CASALX: {  // casal xs, xt, [xn|sp]
+        // TODO: Load and Store must occur atomically
         // LOAD / STORE
         const uint64_t s = operands[0].get<uint64_t>();
         const uint64_t t = operands[1].get<uint64_t>();
@@ -3018,11 +3020,29 @@ void Instruction::execute() {
         results[3] = {out4, 256};
         break;
       }
+      case Opcode::AArch64_LDADDALW: {  // ldaddal ws, wt, [xn|sp]
+        // TODO: Load and Store must occur atomically
+        // LOAD / STORE
+        results[0] = memoryData[0].zeroExtend(4, 8);
+        memoryData[0] = RegisterValue(
+            memoryData[0].get<uint32_t>() + operands[0].get<uint32_t>(), 4);
+        break;
+      }
+      case Opcode::AArch64_LDADDALX: {  // ldaddal xs, xt, [xn|sp]
+        // TODO: Load and Store must occur atomically
+        // LOAD / STORE
+        results[0] = memoryData[0].get<uint64_t>();
+        memoryData[0] = RegisterValue(
+            memoryData[0].get<uint32_t>() + operands[0].get<uint32_t>(), 4);
+        break;
+      }
       case Opcode::AArch64_LDADDLW:  // ldaddl ws, wt, [xn]
-        // LOAD
+        // TODO: Load and Store must occur atomically
+        // LOAD / STORE
         [[fallthrough]];
       case Opcode::AArch64_LDADDW: {  // ldadd ws, wt, [xn]
-        // LOAD
+        // TODO: Load and Store must occur atomically
+        // LOAD / STORE
         results[0] = memoryData[0].zeroExtend(4, 8);
         memoryData[0] = RegisterValue(
             memoryData[0].get<uint32_t>() + operands[0].get<uint32_t>(), 4);

--- a/test/regression/aarch64/instructions/load.cc
+++ b/test/regression/aarch64/instructions/load.cc
@@ -291,38 +291,115 @@ TEST_P(InstLoad, ldadd) {
     mov w3, #64
     mov w4, #80
     mov w5, #96
-    mov w6, #112
-    mov w7, #128
 
     str w0, [sp], #32
     str w1, [sp], #32
-    str w2, [sp], #32
-    str w3, [sp], #32
 
-    sub sp, sp, #128
-
+    sub sp, sp, #64
+    ldadd w3, w2, [sp]
+    add sp, sp, #32
     ldadd w5, w4, [sp]
-    add sp, sp, #32
-    ldadd w1, w1, [sp]
-    add sp, sp, #32
-    ldaddl w7, w6, [sp]
-    add sp, sp, #32
-    ldaddl w3, w3, [sp]
   )");
 
   EXPECT_EQ(getGeneralRegister<uint32_t>(0), 16);
   EXPECT_EQ(getGeneralRegister<uint32_t>(1), 32);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 48);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 16);
   EXPECT_EQ(getGeneralRegister<uint32_t>(3), 64);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(4), 16);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(4), 32);
   EXPECT_EQ(getGeneralRegister<uint32_t>(5), 96);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(6), 48);
-  EXPECT_EQ(getGeneralRegister<uint32_t>(7), 128);
 
-  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 1024), 112);
-  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 992), 64);
-  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 960), 176);
-  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 928), 128);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 1024), 80);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 992), 128);
+}
+
+TEST_P(InstLoad, ldaddl) {
+  RUN_AARCH64(R"(
+    sub sp, sp, #1024
+    mov w0, #16
+    mov w1, #32
+    mov w2, #48
+    mov w3, #64
+    mov w4, #80
+    mov w5, #96
+
+    str w0, [sp], #32
+    str w1, [sp], #32
+
+    sub sp, sp, #64
+    ldaddl w3, w2, [sp]
+    add sp, sp, #32
+    ldaddl w5, w4, [sp]
+  )");
+
+  EXPECT_EQ(getGeneralRegister<uint32_t>(0), 16);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(1), 32);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 16);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(3), 64);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(4), 32);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(5), 96);
+
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 1024), 80);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 992), 128);
+}
+
+TEST_P(InstLoad, ldaddal) {
+  // 32-bit
+  RUN_AARCH64(R"(
+    sub sp, sp, #1024
+    mov w0, #16
+    mov w1, #32
+    mov w2, #48
+    mov w3, #64
+    mov w4, #80
+    mov w5, #96
+
+    str w0, [sp], #32
+    str w1, [sp], #32
+
+    sub sp, sp, #64
+    ldaddal w3, w2, [sp]
+    add sp, sp, #32
+    ldaddal w5, w4, [sp]
+  )");
+
+  EXPECT_EQ(getGeneralRegister<uint32_t>(0), 16);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(1), 32);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(2), 16);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(3), 64);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(4), 32);
+  EXPECT_EQ(getGeneralRegister<uint32_t>(5), 96);
+
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 1024), 80);
+  EXPECT_EQ(getMemoryValue<uint32_t>(process_->getStackPointer() - 992), 128);
+
+  // 64-bit
+  RUN_AARCH64(R"(
+    sub sp, sp, #1024
+    mov x0, #16
+    mov x1, #32
+    mov x2, #48
+    mov x3, #64
+    mov x4, #80
+    mov x5, #96
+
+    str x0, [sp], #32
+    str x1, [sp], #32
+
+    sub sp, sp, #64
+    ldaddal x3, x2, [sp]
+    add sp, sp, #32
+    ldaddal x5, x4, [sp]
+  )");
+
+  EXPECT_EQ(getGeneralRegister<uint64_t>(0), 16);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(1), 32);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(2), 16);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(3), 64);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(4), 32);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(5), 96);
+
+  EXPECT_EQ(getMemoryValue<uint64_t>(process_->getStackPointer() - 1024), 80);
+  EXPECT_EQ(getMemoryValue<uint64_t>(process_->getStackPointer() - 992), 128);
 }
 
 TEST_P(InstLoad, ldar) {


### PR DESCRIPTION
Along with the ldaddal instruction being added, the user can now input the environment variables they want to use via the YAML config file, rather than in Process.cc