### PR TITLE
Exit and Exit_Group syscalls

### DIFF
--- a/.jenkins/build_test_run.sh
+++ b/.jenkins/build_test_run.sh
@@ -53,7 +53,7 @@ run () {
     cat run
     echo ""
     compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "3145731" "retired instructions"
-    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "3145738" "simulated cycles"
+    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "3145737" "simulated cycles"
     echo ""
 
     ./bin/simeng "$SIMENG_TOP"/configs/tx2.yaml > run
@@ -61,7 +61,7 @@ run () {
     cat run
     echo ""
     compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "3145732" "retired instructions"
-    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "1048590" "simulated cycles"
+    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "1048589" "simulated cycles"
     echo ""
 }
 

--- a/src/include/simeng/OS/SimOS.hh
+++ b/src/include/simeng/OS/SimOS.hh
@@ -38,7 +38,8 @@ static uint32_t hex_[8] = {
     0x54FFFFC1,  // b.ne -8
                  // .exit:
     0xD2800000,  // mov x0, #0
-    0xD2800BC8,  // mov x8, #94
+    // 0xD2800BC8,  // mov x8, #94
+    0xD2800ba8,  // mov x8, #93
     0xD4000001,  // svc #0
 };
 
@@ -134,10 +135,6 @@ class SimOS {
 
   /** Construct the special file directory. */
   void createSpecialFileDirectory() const;
-
-  /** Change the state of a process or a core.
-   * Used by the terminateThread & terminateThreadGroup functions. */
-  void terminateThreadHelper(std::shared_ptr<Process> proc);
 
   /** The total number of times the SimOS class has been ticked. */
   uint64_t ticks_ = 0;

--- a/src/include/simeng/OS/SimOS.hh
+++ b/src/include/simeng/OS/SimOS.hh
@@ -38,8 +38,7 @@ static uint32_t hex_[8] = {
     0x54FFFFC1,  // b.ne -8
                  // .exit:
     0xD2800000,  // mov x0, #0
-    // 0xD2800BC8,  // mov x8, #94
-    0xD2800ba8,  // mov x8, #93
+    0xD2800BC8,  // mov x8, #94
     0xD4000001,  // svc #0
 };
 

--- a/src/include/simeng/OS/SyscallHandler.hh
+++ b/src/include/simeng/OS/SyscallHandler.hh
@@ -150,6 +150,10 @@ struct SyscallResult {
    * core and it should therefore halt. */
   bool fatal = false;
 
+  /** Indicates whether the recieving core should go into an idle state after
+   * the syscall has concluded and all state changes have been processed. */
+  bool idleAfterSyscall = false;
+
   /** Id of the syscall to aid exception handler processing. */
   uint64_t syscallId = 0;
 
@@ -228,7 +232,8 @@ class SyscallHandler {
   /** Once the syscall is complete, conclude its execution by
    * constructing a SyscallResult and supplying it to the returnSyscall_
    * function. */
-  void concludeSyscall(const ProcessStateChange& change, bool fatal = false);
+  void concludeSyscall(const ProcessStateChange& change, bool fatal = false,
+                       bool idleAftersycall = false);
 
   /** Attempt to read a string of max length `maxLength` from address `address`
    * into the supplied buffer, starting from character `offset`. */

--- a/src/include/simeng/OS/SyscallHandler.hh
+++ b/src/include/simeng/OS/SyscallHandler.hh
@@ -150,7 +150,7 @@ struct SyscallResult {
    * core and it should therefore halt. */
   bool fatal = false;
 
-  /** Indicates whether the recieving core should go into an idle state after
+  /** Indicates whether the receiving core should go into an idle state after
    * the syscall has concluded and all state changes have been processed. */
   bool idleAfterSyscall = false;
 

--- a/src/include/simeng/arch/ExceptionHandler.hh
+++ b/src/include/simeng/arch/ExceptionHandler.hh
@@ -17,6 +17,10 @@ struct ExceptionResult {
    * core and it should therefore halt. */
   bool fatal;
 
+  /** Indicates whether the recieving core should go into an idle state after
+   * the syscall has concluded and all state changes have been processed. */
+  bool idleAfterSyscall = false;
+
   /** The address to resume execution from. */
   uint64_t instructionAddress;
 

--- a/src/include/simeng/arch/ExceptionHandler.hh
+++ b/src/include/simeng/arch/ExceptionHandler.hh
@@ -17,7 +17,7 @@ struct ExceptionResult {
    * core and it should therefore halt. */
   bool fatal;
 
-  /** Indicates whether the recieving core should go into an idle state after
+  /** Indicates whether the receiving core should go into an idle state after
    * the syscall has concluded and all state changes have been processed. */
   bool idleAfterSyscall = false;
 

--- a/src/lib/OS/SimOS.cc
+++ b/src/lib/OS/SimOS.cc
@@ -255,7 +255,7 @@ uint64_t SimOS::createProcess(span<char> instructionBytes) {
   }
 
   processes_[tid]->status_ = procStatus::waiting;
-  waitingProcs_.push(processes_.find(tid)->second);
+  waitingProcs_.push(processes_[tid]);
 
   return tid;
 }

--- a/src/lib/OS/SimOS.cc
+++ b/src/lib/OS/SimOS.cc
@@ -83,7 +83,9 @@ void SimOS::tick() {
    *    b. On a successful interupt, the process that caused it is moved to the
    * scheduledProc queue
    *    c. Only processes in the scheduledProc queue can be scheduled onto a
-   * core
+   * core, unless the scheduledProc queue is empty and a core is idle. In this
+   * case a process from waitingProcs_ can jump ahead and be scheduled onto the
+   * waiting core
    *
    * If not for this process, then a waitingProc could tell more executing cores
    * to context switch given a core is likely to be in a switching state (post
@@ -275,8 +277,16 @@ void SimOS::terminateThread(uint64_t tid) {
     // If process with TID doesn't exist, return early
     return;
   }
-  // Update process or Core status
-  terminateThreadHelper(proc->second);
+  // If clear_chilt_tid is non-zero then write 0 to this address
+  uint64_t addr = proc->second->clearChildTid_;
+  if (addr) {
+    memory_->sendUntimedData({0}, addr, 1);
+    // TODO: When `futex` has been implemented, perform
+    // futex(clear_child_tid, FUTEX_WAKE, 1, NULL, NULL, 0);
+  }
+  // Set status to complete so it can be removed from the relevant queue in
+  // tick()
+  proc->second->status_ = procStatus::completed;
   // Remove from processes_
   processes_.erase(tid);
 }
@@ -285,8 +295,16 @@ void SimOS::terminateThreadGroup(uint64_t tgid) {
   auto proc = processes_.begin();
   while (proc != processes_.end()) {
     if (proc->second->getTGID() == tgid) {
-      // Update process or Core status
-      terminateThreadHelper(proc->second);
+      // If clear_chilt_tid is non-zero then write 0 to this address
+      uint64_t addr = proc->second->clearChildTid_;
+      if (addr) {
+        memory_->sendUntimedData({0}, addr, 1);
+        // TODO: When `futex` has been implemented, perform
+        // futex(clear_child_tid, FUTEX_WAKE, 1, NULL, NULL, 0);
+      }
+      // Set status to complete so it can be removed from the relevant queue in
+      // tick()
+      proc->second->status_ = procStatus::completed;
       proc = processes_.erase(proc);
     } else {
       proc++;
@@ -333,22 +351,6 @@ void SimOS::createSpecialFileDirectory() const {
   SFdir.RemoveExistingSFDir();
   // Create new special files dir
   SFdir.GenerateSFDir();
-}
-
-void SimOS::terminateThreadHelper(std::shared_ptr<Process> proc) {
-  uint64_t tid = proc->getTID();
-  if (proc->status_ == procStatus::executing) {
-    // Set core's status to idle, stopping execution immediately
-    for (auto core : cores_) {
-      if (core->getCurrentTID() == tid) {
-        core->setStatus(CoreStatus::idle);
-        break;
-      }
-    }
-  }
-  // Set status to complete so it can be removed from the relevant queue in
-  // tick()
-  proc->status_ = procStatus::completed;
 }
 
 uint64_t SimOS::getSystemTimer() const {

--- a/src/lib/OS/SyscallHandler.cc
+++ b/src/lib/OS/SyscallHandler.cc
@@ -704,9 +704,9 @@ void SyscallHandler::readBufferThen(uint64_t ptr, uint64_t length,
 }
 
 void SyscallHandler::concludeSyscall(const ProcessStateChange& change,
-                                     bool fatal) {
-  OS_->sendSyscallResult(
-      {fatal, currentInfo_.syscallId, currentInfo_.coreId, change});
+                                     bool fatal, bool idleAftersycall) {
+  OS_->sendSyscallResult({fatal, idleAftersycall, currentInfo_.syscallId,
+                          currentInfo_.coreId, change});
   // Remove syscall from queue and reset handler to default state
   syscallQueue_.pop();
   dataBuffer_ = {};

--- a/src/lib/OS/SyscallHandler.cc
+++ b/src/lib/OS/SyscallHandler.cc
@@ -376,7 +376,7 @@ void SyscallHandler::handleSyscall() {
       // TODO: Flush all open `stdio` streams when supported
       // TODO: Remove files created by `tmpfile` when supported
       OS_->terminateThread(tid);
-      std::cerr << "[SimEng:SyscallHandler] Received exit syscall on Thread "
+      std::cout << "[SimEng:SyscallHandler] Received exit syscall on Thread "
                 << tid << ". Terminating with exit code " << exitCode
                 << std::endl;
       return concludeSyscall({}, false, true);
@@ -389,7 +389,7 @@ void SyscallHandler::handleSyscall() {
       // TODO: Flush all open `stdio` streams when supported
       // TODO: Remove files created by `tmpfile` when supported
       OS_->terminateThreadGroup(tgid);
-      std::cerr << "[SimEng:SyscallHandler] Received exit_group syscall on "
+      std::cout << "[SimEng:SyscallHandler] Received exit_group syscall on "
                    "Thread Group "
                 << tgid << ". Terminating with exit code " << exitCode
                 << std::endl;
@@ -791,12 +791,12 @@ std::string SyscallHandler::getSpecialFile(const std::string filename) {
     if (strncmp(filename.c_str(), prefix, strlen(prefix)) == 0) {
       for (int i = 0; i < supportedSpecialFiles_.size(); i++) {
         if (filename.find(supportedSpecialFiles_[i]) != std::string::npos) {
-          std::cerr << "[SimEng:SyscallHandler] Using Special File: "
+          std::cout << "[SimEng:SyscallHandler] Using Special File: "
                     << filename.c_str() << std::endl;
           return specialFilesDir_ + filename;
         }
       }
-      std::cerr
+      std::cout
           << "[SimEng:SyscallHandler] WARNING: unable to open unsupported "
              "special file: "
           << "'" << filename.c_str() << "'" << std::endl
@@ -1089,7 +1089,7 @@ int64_t SyscallHandler::mmap(uint64_t addr, size_t length, int prot, int flags,
   if (fd > 0) {
     auto entry = process->fdArray_->getFDEntry(fd);
     if (!entry.isValid()) {
-      std::cerr << "[SimEng:SyscallHandler] Invalid virtual file descriptor "
+      std::cout << "[SimEng:SyscallHandler] Invalid virtual file descriptor "
                    "given to mmap"
                 << std::endl;
       return -1;

--- a/src/lib/OS/SyscallHandler.cc
+++ b/src/lib/OS/SyscallHandler.cc
@@ -370,17 +370,30 @@ void SyscallHandler::handleSyscall() {
     }
     case 93: {  // exit
       auto exitCode = currentInfo_.registerArguments[0].get<uint64_t>();
-      std::cout << "[SimEng:SyscallHandler] Received exit syscall: "
-                   "terminating with exit code "
-                << exitCode << std::endl;
-      return concludeSyscall({}, true);
+      uint64_t tid = currentInfo_.threadId;
+      // TODO: When `wait` is supported, return exitCode & 0xFF to parent
+      // TODO: Call all functions registered with `atexit` and `on_exit`
+      // TODO: Flush all open `stdio` streams when supported
+      // TODO: Remove files created by `tmpfile` when supported
+      OS_->terminateThread(tid);
+      std::cerr << "[SimEng:SyscallHandler] Received exit syscall on Thread "
+                << tid << ". Terminating with exit code " << exitCode
+                << std::endl;
+      return concludeSyscall({}, false, true);
     }
     case 94: {  // exit_group
       auto exitCode = currentInfo_.registerArguments[0].get<uint64_t>();
-      std::cout << "[SimEng:SyscallHandler] Received exit_group syscall: "
-                   "terminating with exit code "
-                << exitCode << std::endl;
-      return concludeSyscall({}, true);
+      uint64_t tgid = OS_->getProcess(currentInfo_.threadId)->getTGID();
+      // TODO: When `wait` is supported, return exitCode & 0xFF to parent
+      // TODO: Call all functions registered with `atexit` and `on_exit`
+      // TODO: Flush all open `stdio` streams when supported
+      // TODO: Remove files created by `tmpfile` when supported
+      OS_->terminateThreadGroup(tgid);
+      std::cerr << "[SimEng:SyscallHandler] Received exit_group syscall on "
+                   "Thread Group "
+                << tgid << ". Terminating with exit code " << exitCode
+                << std::endl;
+      return concludeSyscall({}, false, true);
     }
     case 96: {  // set_tid_address
       uint64_t ptr = currentInfo_.registerArguments[0].get<uint64_t>();

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -69,6 +69,7 @@ bool ExceptionHandler::handleException() {
       case 78:     // readlinkat
       case 79:     // newfstatat AKA fstatat
       case 80:     // fstat
+      case 93:     // exit
       case 94:     // exit_group
       case 96:     // set_tid_address
       case 98:     // futex
@@ -98,7 +99,7 @@ bool ExceptionHandler::handleException() {
       case 293: {  // rseq
         core_.sendSyscall({syscallId,
                            core_.getCoreId(),
-                           0,
+                           core_.getCurrentTID(),
                            {registerFileSet.get(R0), registerFileSet.get(R1),
                             registerFileSet.get(R2), registerFileSet.get(R3),
                             registerFileSet.get(R4), registerFileSet.get(R5)},

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -138,7 +138,7 @@ bool ExceptionHandler::handleException() {
         return fatal();
     }
 
-    processSyscallResult({false, 0, 0, stateChange});
+    processSyscallResult({false, false, 0, 0, stateChange});
     return concludeSyscall();
   } else if (exception == InstructionException::StreamingModeUpdate ||
              exception == InstructionException::ZAregisterStatusUpdate ||
@@ -203,7 +203,7 @@ bool ExceptionHandler::handleException() {
 
     simeng::OS::ProcessStateChange stateChange = {
         simeng::OS::ChangeType::REPLACEMENT, regs, regValues};
-    processSyscallResult({false, 0, 0, stateChange});
+    processSyscallResult({false, false, 0, 0, stateChange});
     return concludeSyscall();
   }
 
@@ -252,7 +252,8 @@ bool ExceptionHandler::concludeSyscall() {
   }
 
   uint64_t nextInstructionAddress = instruction_->getInstructionAddress() + 4;
-  result_ = {false, nextInstructionAddress, syscallResult_.stateChange};
+  result_ = {false, syscallResult_.idleAfterSyscall, nextInstructionAddress,
+             syscallResult_.stateChange};
 
   resetState();
   return true;
@@ -336,7 +337,7 @@ void ExceptionHandler::printException() const {
 }
 
 bool ExceptionHandler::fatal() {
-  result_ = {true, 0, {}};
+  result_ = {true, false, 0, {}};
   resetState();
   return true;
 }

--- a/src/lib/arch/riscv/ExceptionHandler.cc
+++ b/src/lib/arch/riscv/ExceptionHandler.cc
@@ -142,7 +142,7 @@ bool ExceptionHandler::handleException() {
         return fatal();
     }
 
-    processSyscallResult({false, 0, 0, stateChange});
+    processSyscallResult({false, false, 0, 0, stateChange});
     return concludeSyscall();
   }
 
@@ -192,7 +192,8 @@ bool ExceptionHandler::concludeSyscall() {
   }
 
   uint64_t nextInstructionAddress = instruction_->getInstructionAddress() + 4;
-  result_ = {false, nextInstructionAddress, syscallResult_.stateChange};
+  result_ = {false, syscallResult_.idleAfterSyscall, nextInstructionAddress,
+             syscallResult_.stateChange};
 
   resetState();
   return true;
@@ -257,7 +258,7 @@ void ExceptionHandler::printException() const {
 }
 
 bool ExceptionHandler::fatal() {
-  result_ = {true, 0, {}};
+  result_ = {true, false, 0, {}};
   resetState();
   return true;
 }

--- a/src/lib/arch/riscv/ExceptionHandler.cc
+++ b/src/lib/arch/riscv/ExceptionHandler.cc
@@ -99,7 +99,7 @@ bool ExceptionHandler::handleException() {
       case 293: {  // rseq
         core_.sendSyscall({syscallId,
                            core_.getCoreId(),
-                           0,
+                           core_.getCurrentTID(),
                            {registerFileSet.get(R0), registerFileSet.get(R1),
                             registerFileSet.get(R2), registerFileSet.get(R3),
                             registerFileSet.get(R4), registerFileSet.get(R5)},

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -245,6 +245,10 @@ void Core::processException() {
   exceptionGenerated_ = false;
 
   microOps_.pop();
+
+  if (result.idleAfterSyscall) {
+    status_ = CoreStatus::idle;
+  }
 }
 
 void Core::applyStateChange(const OS::ProcessStateChange& change) {

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -48,7 +48,7 @@ void Core::tick() {
   procTicks_++;
 
   if (pc_ >= programByteLength_) {
-    status_ = CoreStatus::halted;
+    status_ = CoreStatus::idle;
     return;
   }
 

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -240,15 +240,14 @@ void Core::processException() {
   } else {
     pc_ = result.instructionAddress;
     applyStateChange(result.stateChange);
+    if (result.idleAfterSyscall) {
+      status_ = CoreStatus::idle;
+    }
   }
 
   exceptionGenerated_ = false;
 
   microOps_.pop();
-
-  if (result.idleAfterSyscall) {
-    status_ = CoreStatus::idle;
-  }
 }
 
 void Core::applyStateChange(const OS::ProcessStateChange& change) {

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -245,6 +245,10 @@ void Core::processException() {
   }
 
   exceptionGenerated_ = false;
+
+  if (result.idleAfterSyscall) {
+    status_ = CoreStatus::idle;
+  }
 }
 
 void Core::loadData(const std::shared_ptr<Instruction>& instruction) {

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -136,7 +136,7 @@ void Core::tick() {
 }
 
 CoreStatus Core::getStatus() {
-  // Core is considered to have halted when the fetch unit has halted, there are
+  // Core is considered to be idle when the fetch unit has halted, there are
   // no uops at the head of any buffer, and no exception is currently being
   // handled.
   bool decodePending = fetchToDecodeBuffer_.getHeadSlots()[0].size() > 0;
@@ -145,7 +145,7 @@ CoreStatus Core::getStatus() {
 
   if (fetchUnit_.hasHalted() && !decodePending && !writebackPending &&
       !executePending && exceptionGenerated_ == false) {
-    status_ = CoreStatus::halted;
+    status_ = CoreStatus::idle;
   }
 
   return status_;

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -347,6 +347,10 @@ void Core::processException() {
   }
 
   exceptionGenerated_ = false;
+
+  if (result.idleAfterSyscall) {
+    status_ = CoreStatus::idle;
+  }
 }
 
 void Core::applyStateChange(const OS::ProcessStateChange& change) {

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -252,7 +252,7 @@ void Core::flushIfNeeded() {
 }
 
 CoreStatus Core::getStatus() {
-  // Core is considered to have halted when the fetch unit has halted, there
+  // Core is considered to be idle when the fetch unit has halted, there
   // are no uops at the head of any buffer, and no exception is currently
   // being handled.
   if (fetchUnit_.hasHalted() && !(reorderBuffer_.size() > 0) &&
@@ -275,7 +275,7 @@ CoreStatus Core::getStatus() {
         }
       }
       if (renameSlotEmpty) {
-        status_ = CoreStatus::halted;
+        status_ = CoreStatus::idle;
       }
     }
   }

--- a/test/unit/OSTest.cc
+++ b/test/unit/OSTest.cc
@@ -38,7 +38,7 @@ TEST(OSTest, CreateSimOS) {
   EXPECT_GT(proc->context_.sp, 0);
   EXPECT_GT(proc->context_.regFile.size(), 0);
   // Check Initial Process' state
-  EXPECT_EQ(proc->status_, simeng::OS::procStatus::scheduled);
+  EXPECT_EQ(proc->status_, simeng::OS::procStatus::waiting);
 
   // Check syscallHandler created
   EXPECT_TRUE(OS.getSyscallHandler());


### PR DESCRIPTION
Implemented the `exit` and `exit_group` syscalls, along with a mechanism to allow a syscall to update the core's status to idle, once the process state returned from the syscall has been applied.

Also includes a minor tweak to the scheduling logic, meaning that if `scheduledProcs_` is empty then a process in `waitingProcs_` can jump ahead.

(Will re-target to `multi-thread-support` branch once the `exceptionHandler-refactor` PR has been merged)