### PR TITLE
Added first draft logic and test for the sysinfo syscall

### DIFF
--- a/src/lib/OS/SyscallHandler.cc
+++ b/src/lib/OS/SyscallHandler.cc
@@ -560,6 +560,7 @@ void SyscallHandler::handleSyscall() {
       uint64_t infoPtr = currentInfo_.registerArguments[0].get<uint64_t>();
       stateChange = {ChangeType::REPLACEMENT, {currentInfo_.ret}, {0ull}};
       std::array<uint64_t, 14> sysInfoVals;
+      std::fill(sysInfoVals.begin(), sysInfoVals.end(), 0);
       std::array<uint8_t, 14> sysInfoValsSizes = {8, 8, 8, 8, 8, 8, 8,
                                                   8, 8, 8, 2, 8, 8, 4};
       // Populate those entries within the sysinfo struct which are currently

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -880,14 +880,6 @@ TEST_P(Syscall, sysinfo) {
     svc #0
     mov x20, x0
 
-    mov x1, #10000
-    mov x2, #10
-    mul x1, x1, x2
-
-    .loop:
-    subs x1, x1, #1
-    b.ne .loop
-
     # syscall(addr)
     mov x0, x20
     mov x8, #179

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -901,7 +901,8 @@ TEST_P(Syscall, sysinfo) {
   // Check outputted sysinfo struct
   uint64_t paddr = process_->translate(process_->getHeapStart());
   // The size of the sysinfo struct within SimEng is 102 bytes
-  char reference[102] = {0};
+  std::array<char, 102> reference;
+  std::fill(reference.begin(), reference.end(), 0);
   // Most values in the returned sysinfo struct will be 0, excluding:
   // - totalram = 500000 (0x07A120)
   // - procs = 1 (0x01)
@@ -910,8 +911,8 @@ TEST_P(Syscall, sysinfo) {
   reference[33] = 0xA1;
   reference[34] = 0x07;
   reference[80] = 0x01;
-  auto data = memory_->getUntimedData(paddr, 102);
-  for (int i = 0; i < 102; i++) {
+  auto data = memory_->getUntimedData(paddr, reference.size());
+  for (int i = 0; i < reference.size(); i++) {
     EXPECT_EQ(data[i], reference[i]) << "at index i=" << i << '\n';
   }
 }


### PR DESCRIPTION
In this PR, the `sysinfo` syscall infrastructure has been introduced. Currently, not all values of the returned `sysinfo` struct (generated by the `sysinfo` syscall) are supported so have been set to zero and left for either future developments or within the lifetime of this PR based on actual usage of the syscall. 

Rather than define the `sysinfo` struct in the `SyscallHandler` header and verbosely assign each `sysinfo` struct entry  to then be added to the statechange one by one, the struct is represented as an array of `uint64_t` values. This allowed for less duplicate code and a smaller code footprint within the `sysinfo` case body. A somewhat detailed comment has been written to explain the mapping/use of this array.