### PR TITLE
Post MMU/MemInterface merge cleanup

### DIFF
--- a/src/include/simeng/Port.hh
+++ b/src/include/simeng/Port.hh
@@ -32,9 +32,9 @@ class Port {
 
  public:
   /** Function used to connect a port to a port mediator. */
-  void inline connect(PortMediator<T>* mediator, uint16_t local_id) {
+  void inline connect(PortMediator<T>* mediator, uint16_t id) {
     conn_ = mediator;
-    local_id_ = local_id;
+    id_ = id;
   };
 
   /** Function used to register a callback function called by the recieve
@@ -45,9 +45,9 @@ class Port {
    * port. */
   void inline send(T data) {
     if constexpr (is_unique_ptr<T>::value) {
-      conn_->send(std::move(data), local_id_);
+      conn_->send(std::move(data), id_);
     } else {
-      conn_->send(data, local_id_);
+      conn_->send(data, id_);
     }
   }
 
@@ -60,15 +60,15 @@ class Port {
     }
   }
 
-  uint16_t getLocalId() { return local_id_; }
+  uint16_t getId() { return id_; }
 
   /** Constructor of the Port class. */
   Port() {}
 
  private:
-  /** Id of a port local to a port mediator connection. This is mainly used to
-   * find destination ports for source ports present inside a mediator. */
-  uint16_t local_id_;
+  /** The ID of a port. Used by a mediator connection to locate the destination
+   * port of the corresponding source port. */
+  uint16_t id_;
 
   /** Pointer to a PortMediator class. */
   PortMediator<T>* conn_ = nullptr;
@@ -103,8 +103,8 @@ class PortMediator {
 
   /** Function used to send data from a port to corresponding destination port.
    */
-  void inline send(T data, uint64_t local_port_id) {
-    auto dest = dests_[local_port_id];
+  void inline send(T data, uint64_t port_id) {
+    auto dest = dests_[port_id];
     if constexpr (is_unique_ptr<T>::value) {
       dest->recieve(std::move(data));
     } else {

--- a/src/include/simeng/Port.hh
+++ b/src/include/simeng/Port.hh
@@ -103,8 +103,8 @@ class PortMediator {
 
   /** Function used to send data from a port to corresponding destination port.
    */
-  void inline send(T data, uint64_t port_order) {
-    auto dest = dests_[port_order];
+  void inline send(T data, uint64_t local_port_id) {
+    auto dest = dests_[local_port_id];
     if constexpr (is_unique_ptr<T>::value) {
       dest->recieve(std::move(data));
     } else {

--- a/src/include/simeng/memory/FixedLatencyMemory.hh
+++ b/src/include/simeng/memory/FixedLatencyMemory.hh
@@ -67,10 +67,10 @@ class FixedLatencyMemory : public Mem {
   /** Port used for communication with other classes. */
   std::shared_ptr<Port<std::unique_ptr<MemPacket>>> port_ = nullptr;
 
-  /** This method handles DataPackets of type READ_REQUEST. */
+  /** This method handles MemPackets of type READ_REQUEST. */
   void handleReadRequest(std::unique_ptr<MemPacket>& req);
 
-  /** This method handles DataPackets of type WRITE_REQUEST. */
+  /** This method handles MemPackets of type WRITE_REQUEST. */
   void handleWriteRequest(std::unique_ptr<MemPacket>& req);
 };
 

--- a/src/include/simeng/memory/FixedLatencyMemory.hh
+++ b/src/include/simeng/memory/FixedLatencyMemory.hh
@@ -27,7 +27,7 @@ class FixedLatencyMemory : public Mem {
   virtual ~FixedLatencyMemory() override { delete port_; };
 
   /** This method requests access to memory for both read and write requests. */
-  void requestAccess(std::unique_ptr<MemPacket> pkt) override;
+  void requestAccess(std::unique_ptr<MemPacket>& pkt) override;
 
   /** This method returns the size of memory. */
   size_t getMemorySize() override;

--- a/src/include/simeng/memory/FixedLatencyMemory.hh
+++ b/src/include/simeng/memory/FixedLatencyMemory.hh
@@ -24,7 +24,7 @@ class FixedLatencyMemory : public Mem {
  public:
   FixedLatencyMemory(size_t bytes, uint16_t latency);
 
-  virtual ~FixedLatencyMemory() override { delete port_; };
+  virtual ~FixedLatencyMemory() override{};
 
   /** This method requests access to memory for both read and write requests. */
   void requestAccess(std::unique_ptr<MemPacket>& pkt) override;
@@ -43,7 +43,7 @@ class FixedLatencyMemory : public Mem {
   void handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) override;
 
   /** Function used to initialise a Port used for bidirection communication. */
-  Port<std::unique_ptr<MemPacket>>* initPort() override;
+  std::shared_ptr<Port<std::unique_ptr<MemPacket>>> initPort() override;
 
   /** Method to tick the memory. */
   void tick() override;
@@ -65,7 +65,7 @@ class FixedLatencyMemory : public Mem {
   std::queue<LatencyPacket> reqQueue_;
 
   /** Port used for communication with other classes. */
-  Port<std::unique_ptr<MemPacket>>* port_ = nullptr;
+  std::shared_ptr<Port<std::unique_ptr<MemPacket>>> port_ = nullptr;
 
   /** This method handles DataPackets of type READ_REQUEST. */
   void handleReadRequest(std::unique_ptr<MemPacket>& req);

--- a/src/include/simeng/memory/FixedLatencyMemory.hh
+++ b/src/include/simeng/memory/FixedLatencyMemory.hh
@@ -40,8 +40,7 @@ class FixedLatencyMemory : public Mem {
   std::vector<char> getUntimedData(uint64_t paddr, size_t size) override;
 
   /** This method handles a memory request to an ignored address range. */
-  std::unique_ptr<MemPacket> handleIgnoredRequest(
-      std::unique_ptr<MemPacket> pkt) override;
+  void handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) override;
 
   /** Function used to initialise a Port used for bidirection communication. */
   Port<std::unique_ptr<MemPacket>>* initPort() override;
@@ -69,10 +68,10 @@ class FixedLatencyMemory : public Mem {
   Port<std::unique_ptr<MemPacket>>* port_ = nullptr;
 
   /** This method handles DataPackets of type READ_REQUEST. */
-  std::unique_ptr<MemPacket> handleReadRequest(std::unique_ptr<MemPacket> req);
+  void handleReadRequest(std::unique_ptr<MemPacket>& req);
 
   /** This method handles DataPackets of type WRITE_REQUEST. */
-  std::unique_ptr<MemPacket> handleWriteRequest(std::unique_ptr<MemPacket> req);
+  void handleWriteRequest(std::unique_ptr<MemPacket>& req);
 };
 
 }  // namespace memory

--- a/src/include/simeng/memory/MMU.hh
+++ b/src/include/simeng/memory/MMU.hh
@@ -21,7 +21,7 @@ class MMU {
  public:
   MMU(const uint16_t latency, VAddrTranslator fn);
 
-  ~MMU() { delete port_; }
+  ~MMU() {}
 
   /** Tick the memory model to process the request queue. */
   void tick();
@@ -63,7 +63,7 @@ class MMU {
 
   /** Function used to initialise the Data Port used for bidirection
    * communication. */
-  Port<std::unique_ptr<MemPacket>>* initPort();
+  std::shared_ptr<Port<std::unique_ptr<MemPacket>>> initPort();
 
  private:
   /** The latency all requests are completed after. */
@@ -89,7 +89,7 @@ class MMU {
   VAddrTranslator translate_;
 
   /** Data port used for communication with the memory hierarchy. */
-  Port<std::unique_ptr<MemPacket>>* port_ = nullptr;
+  std::shared_ptr<Port<std::unique_ptr<MemPacket>>> port_ = nullptr;
 
   /** Returns true if unsigned overflow occurs. */
   bool unsignedOverflow(uint64_t a, uint64_t b) const {

--- a/src/include/simeng/memory/Mem.hh
+++ b/src/include/simeng/memory/Mem.hh
@@ -42,7 +42,7 @@ class Mem {
 
   /** This method is initialises a Port for establishing bidirectional
    * communication with other classes. */
-  virtual Port<std::unique_ptr<MemPacket>>* initPort() = 0;
+  virtual std::shared_ptr<Port<std::unique_ptr<MemPacket>>> initPort() = 0;
 
   /** Method to tick the memory. */
   virtual void tick() = 0;

--- a/src/include/simeng/memory/Mem.hh
+++ b/src/include/simeng/memory/Mem.hh
@@ -25,7 +25,7 @@ class Mem {
 
   /** This method requests access to simulation memory for read and write
    * requests. */
-  virtual void requestAccess(std::unique_ptr<MemPacket> pkt) = 0;
+  virtual void requestAccess(std::unique_ptr<MemPacket>& pkt) = 0;
 
   /** This method returns the size of memory. */
   virtual size_t getMemorySize() = 0;

--- a/src/include/simeng/memory/Mem.hh
+++ b/src/include/simeng/memory/Mem.hh
@@ -38,8 +38,7 @@ class Mem {
   virtual std::vector<char> getUntimedData(uint64_t paddr, size_t size) = 0;
 
   /** This method handles a memory request to an ignored address range. */
-  virtual std::unique_ptr<MemPacket> handleIgnoredRequest(
-      std::unique_ptr<MemPacket> pkt) = 0;
+  virtual void handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) = 0;
 
   /** This method is initialises a Port for establishing bidirectional
    * communication with other classes. */

--- a/src/include/simeng/memory/MemPacket.hh
+++ b/src/include/simeng/memory/MemPacket.hh
@@ -80,7 +80,7 @@ class MemPacket {
   inline void setUntimedRead() { metadata_ = metadata_ | UntimedReadMask; }
 
   /** Function to return the data assosciated with a MemPacket. */
-  const std::vector<char>& data() { return data_; }
+  std::vector<char>& payload() { return payload_; }
 
   /** Function used to print the metadata assosciated with a MemPacket. */
   void printMetadata() {
@@ -89,12 +89,15 @@ class MemPacket {
   }
 
   /** Static function used to create a read request. */
-  static std::unique_ptr<MemPacket> createReadRequest(
-      const MemoryAccessTarget& target, uint64_t reqId);
+  static std::unique_ptr<MemPacket> createReadRequest(uint64_t address,
+                                                      uint16_t size,
+                                                      uint64_t reqId);
 
   /** Static function used to create a write request. */
-  static std::unique_ptr<MemPacket> createWriteRequest(
-      const MemoryAccessTarget& target, uint64_t reqId, std::vector<char> data);
+  static std::unique_ptr<MemPacket> createWriteRequest(uint64_t address,
+                                                       uint16_t size,
+                                                       uint64_t reqId,
+                                                       std::vector<char> data);
 
   /** Static function used to create a faulty MemPacket. */
   static std::unique_ptr<MemPacket> createFaultyMemPacket(bool isRead);
@@ -116,19 +119,19 @@ class MemPacket {
    * 6th bit indicates whether a MemPacket is an untimed Read (1) or not (0). */
   uint8_t metadata_ = 0;
 
-  /** Data assosciate with a MemPacket. */
-  std::vector<char> data_;
+  /** Payload assosciate with a MemPacket. */
+  std::vector<char> payload_;
 
   /** Default constructor of a MemPacket. */
   MemPacket() {}
 
   /** Constructor for MemPackets which do not hold any data. */
-  MemPacket(const MemoryAccessTarget& target, MemPacketType type,
+  MemPacket(uint64_t address, uint16_t size, MemPacketType type,
             uint64_t reqId);
 
   /** Constructor for MemPackets which hold any data. */
-  MemPacket(const MemoryAccessTarget& target, MemPacketType type,
-            uint64_t reqId, std::vector<char> data);
+  MemPacket(uint64_t address, uint16_t size, MemPacketType type, uint64_t reqId,
+            std::vector<char> data);
 };
 
 }  // namespace memory

--- a/src/include/simeng/memory/MemPacket.hh
+++ b/src/include/simeng/memory/MemPacket.hh
@@ -89,12 +89,12 @@ class MemPacket {
   }
 
   /** Static function used to create a read request. */
-  static std::unique_ptr<MemPacket> createReadRequest(uint64_t address,
+  static std::unique_ptr<MemPacket> createReadRequest(uint64_t vaddr,
                                                       uint16_t size,
                                                       uint64_t reqId);
 
   /** Static function used to create a write request. */
-  static std::unique_ptr<MemPacket> createWriteRequest(uint64_t address,
+  static std::unique_ptr<MemPacket> createWriteRequest(uint64_t vaddr,
                                                        uint16_t size,
                                                        uint64_t reqId,
                                                        std::vector<char> data);
@@ -103,7 +103,7 @@ class MemPacket {
   static std::unique_ptr<MemPacket> createFaultyMemPacket(bool isRead);
 
   /** Function to change a Read MemPacket into a Response. */
-  void turnIntoReadResponse(std::vector<char> data);
+  void turnIntoReadResponse(std::vector<char> payload);
 
   /** Function to change a Write MemPacket into a Response. */
   void turnIntoWriteResponse();
@@ -126,11 +126,10 @@ class MemPacket {
   MemPacket() {}
 
   /** Constructor for MemPackets which do not hold any data. */
-  MemPacket(uint64_t address, uint16_t size, MemPacketType type,
-            uint64_t reqId);
+  MemPacket(uint64_t vaddr, uint16_t size, MemPacketType type, uint64_t reqId);
 
   /** Constructor for MemPackets which hold any data. */
-  MemPacket(uint64_t address, uint16_t size, MemPacketType type, uint64_t reqId,
+  MemPacket(uint64_t vaddr, uint16_t size, MemPacketType type, uint64_t reqId,
             std::vector<char> data);
 };
 

--- a/src/include/simeng/memory/MemPacket.hh
+++ b/src/include/simeng/memory/MemPacket.hh
@@ -6,6 +6,8 @@
 #include <memory>
 #include <vector>
 
+#include "simeng/memory/MemRequests.hh"
+
 namespace simeng {
 namespace memory {
 
@@ -36,7 +38,7 @@ class MemPacket {
   uint64_t paddr_ = 0;
 
   /** The size of the memory operation to be performed. */
-  uint64_t size_ = 0;
+  uint16_t size_ = 0;
 
   /* Uniquely identifies a memory packet and is set by the MMU. Instruction-read
    * and data-write requests can have an ID of 0. */
@@ -87,15 +89,12 @@ class MemPacket {
   }
 
   /** Static function used to create a read request. */
-  static std::unique_ptr<MemPacket> createReadRequest(uint64_t vaddr,
-                                                      uint64_t size,
-                                                      uint64_t reqId);
+  static std::unique_ptr<MemPacket> createReadRequest(
+      const MemoryAccessTarget& target, uint64_t reqId);
 
   /** Static function used to create a write request. */
-  static std::unique_ptr<MemPacket> createWriteRequest(uint64_t vaddr,
-                                                       uint64_t size,
-                                                       uint64_t reqId,
-                                                       std::vector<char> data);
+  static std::unique_ptr<MemPacket> createWriteRequest(
+      const MemoryAccessTarget& target, uint64_t reqId, std::vector<char> data);
 
   /** Static function used to create a faulty MemPacket. */
   static std::unique_ptr<MemPacket> createFaultyMemPacket(bool isRead);
@@ -124,11 +123,12 @@ class MemPacket {
   MemPacket() {}
 
   /** Constructor for MemPackets which do not hold any data. */
-  MemPacket(uint64_t vaddr, uint64_t size, MemPacketType type, uint64_t reqId);
+  MemPacket(const MemoryAccessTarget& target, MemPacketType type,
+            uint64_t reqId);
 
   /** Constructor for MemPackets which hold any data. */
-  MemPacket(uint64_t vaddr, uint64_t size, MemPacketType type, uint64_t reqId,
-            std::vector<char> data);
+  MemPacket(const MemoryAccessTarget& target, MemPacketType type,
+            uint64_t reqId, std::vector<char> data);
 };
 
 }  // namespace memory

--- a/src/include/simeng/memory/MemRequests.hh
+++ b/src/include/simeng/memory/MemRequests.hh
@@ -10,37 +10,23 @@ namespace memory {
 /** A generic memory access target; describes a region of memory to access. */
 struct MemoryAccessTarget {
   /** The address to access. */
-  uint64_t address = 0;
+  uint64_t vaddr = 0;
   /** The number of bytes to access at `address`. */
-  uint8_t size = 0;
+  uint16_t size = 0;
 
-  uint64_t id = 0;
-
-  MemoryAccessTarget(uint64_t taddr, uint64_t tsize, uint64_t target_id)
-      : id(target_id) {
-    address = taddr;
-    size = tsize;
-  }
-
-  MemoryAccessTarget(uint64_t taddr, uint64_t tsize) : id(++idCtr) {
-    address = taddr;
-    size = tsize;
-  }
-
-  MemoryAccessTarget() : id(++idCtr) {}
+  /** Constructor to create MemoryAccessTarget with addr and size values. */
+  MemoryAccessTarget(uint64_t taddr, uint16_t tsize)
+      : vaddr(taddr), size(tsize) {}
 
   /** Check for equality of two access targets. */
   bool operator==(const MemoryAccessTarget& other) const {
-    return (address == other.address && size == other.size);
+    return (vaddr == other.vaddr && size == other.size);
   };
 
   /** Check for inequality of two access targets. */
   bool operator!=(const MemoryAccessTarget& other) const {
-    return other.id != id;
+    return !(other == *this);
   }
-
- private:
-  static inline uint64_t idCtr = 0;
 };
 
 /** A structure used for the result of memory read operations. */

--- a/src/include/simeng/memory/MemRequests.hh
+++ b/src/include/simeng/memory/MemRequests.hh
@@ -18,6 +18,9 @@ struct MemoryAccessTarget {
   MemoryAccessTarget(uint64_t taddr, uint16_t tsize)
       : vaddr(taddr), size(tsize) {}
 
+  /** Default empty constructor for MemoryAccessTarget. */
+  MemoryAccessTarget() {}
+
   /** Check for equality of two access targets. */
   bool operator==(const MemoryAccessTarget& other) const {
     return (vaddr == other.vaddr && size == other.size);

--- a/src/include/simeng/memory/SimpleMem.hh
+++ b/src/include/simeng/memory/SimpleMem.hh
@@ -16,7 +16,7 @@ class SimpleMem : public Mem {
  public:
   SimpleMem(size_t bytes);
 
-  virtual ~SimpleMem() override { delete port_; }
+  virtual ~SimpleMem() override {}
 
   /** This method requests access to memory for both read and write requests. */
   void requestAccess(std::unique_ptr<MemPacket>& pkt) override;
@@ -34,7 +34,7 @@ class SimpleMem : public Mem {
   void handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) override;
 
   /** Function used to initialise a Port used for bidirection communication. */
-  Port<std::unique_ptr<MemPacket>>* initPort() override;
+  std::shared_ptr<Port<std::unique_ptr<MemPacket>>> initPort() override;
 
   /** Method to tick the memory. */
   void tick() override{};
@@ -53,7 +53,7 @@ class SimpleMem : public Mem {
   void handleWriteRequest(std::unique_ptr<MemPacket>& req);
 
   /** Port used for communication with other classes. */
-  Port<std::unique_ptr<MemPacket>>* port_ = nullptr;
+  std::shared_ptr<Port<std::unique_ptr<MemPacket>>> port_ = nullptr;
 };
 
 }  // namespace memory

--- a/src/include/simeng/memory/SimpleMem.hh
+++ b/src/include/simeng/memory/SimpleMem.hh
@@ -31,8 +31,7 @@ class SimpleMem : public Mem {
   /** This method reads data from memory without incurring any latency. */
   std::vector<char> getUntimedData(uint64_t paddr, size_t size) override;
 
-  std::unique_ptr<MemPacket> handleIgnoredRequest(
-      std::unique_ptr<MemPacket> pkt) override;
+  void handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) override;
 
   /** Function used to initialise a Port used for bidirection communication. */
   Port<std::unique_ptr<MemPacket>>* initPort() override;
@@ -48,10 +47,10 @@ class SimpleMem : public Mem {
   size_t memSize_;
 
   /** This method handles DataPackets of type READ_REQUEST. */
-  std::unique_ptr<MemPacket> handleReadRequest(std::unique_ptr<MemPacket> req);
+  void handleReadRequest(std::unique_ptr<MemPacket>& req);
 
   /** This method handles DataPackets of type WRITE_REQUEST. */
-  std::unique_ptr<MemPacket> handleWriteRequest(std::unique_ptr<MemPacket> req);
+  void handleWriteRequest(std::unique_ptr<MemPacket>& req);
 
   /** Port used for communication with other classes. */
   Port<std::unique_ptr<MemPacket>>* port_ = nullptr;

--- a/src/include/simeng/memory/SimpleMem.hh
+++ b/src/include/simeng/memory/SimpleMem.hh
@@ -19,7 +19,7 @@ class SimpleMem : public Mem {
   virtual ~SimpleMem() override { delete port_; }
 
   /** This method requests access to memory for both read and write requests. */
-  void requestAccess(std::unique_ptr<MemPacket> pkt) override;
+  void requestAccess(std::unique_ptr<MemPacket>& pkt) override;
 
   /** This method returns the size of memory. */
   size_t getMemorySize() override;

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -63,7 +63,7 @@ void Instruction::supplyOperand(uint8_t i, const RegisterValue& value) {
 
 void Instruction::supplyData(uint64_t address, const RegisterValue& data) {
   for (size_t i = 0; i < memoryAddresses.size(); i++) {
-    if (memoryAddresses[i].address == address && !memoryData[i]) {
+    if (memoryAddresses[i].vaddr == address && !memoryData[i]) {
       if (!data) {
         // Raise exception for failed read
         // TODO: Move this logic to caller and distinguish between different

--- a/src/lib/arch/riscv/Instruction.cc
+++ b/src/lib/arch/riscv/Instruction.cc
@@ -68,7 +68,7 @@ void Instruction::supplyOperand(uint8_t i, const RegisterValue& value) {
 
 void Instruction::supplyData(uint64_t address, const RegisterValue& data) {
   for (size_t i = 0; i < memoryAddresses.size(); i++) {
-    if (memoryAddresses[i].address == address && !memoryData[i]) {
+    if (memoryAddresses[i].vaddr == address && !memoryData[i]) {
       if (!data) {
         // Raise exception for failed read
         // TODO: Move this logic to caller and distinguish between different

--- a/src/lib/memory/FixedLatencyMemory.cc
+++ b/src/lib/memory/FixedLatencyMemory.cc
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <memory>
 
+#include "simeng/memory/MemPacket.hh"
+
 namespace simeng {
 namespace memory {
 
@@ -84,8 +86,9 @@ void FixedLatencyMemory::handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) {
   }
 }
 
-Port<std::unique_ptr<MemPacket>>* FixedLatencyMemory::initPort() {
-  port_ = new Port<std::unique_ptr<MemPacket>>();
+std::shared_ptr<Port<std::unique_ptr<MemPacket>>>
+FixedLatencyMemory::initPort() {
+  port_ = std::make_shared<Port<std::unique_ptr<MemPacket>>>();
   auto fn = [this](std::unique_ptr<MemPacket> packet) -> void {
     this->requestAccess(packet);
     return;

--- a/src/lib/memory/FixedLatencyMemory.cc
+++ b/src/lib/memory/FixedLatencyMemory.cc
@@ -15,7 +15,7 @@ FixedLatencyMemory::FixedLatencyMemory(size_t size, uint16_t latency) {
 
 size_t FixedLatencyMemory::getMemorySize() { return memSize_; }
 
-void FixedLatencyMemory::requestAccess(std::unique_ptr<MemPacket> pkt) {
+void FixedLatencyMemory::requestAccess(std::unique_ptr<MemPacket>& pkt) {
   if (pkt->ignore()) {
     handleIgnoredRequest(pkt);
     port_->send(std::move(pkt));
@@ -87,7 +87,7 @@ void FixedLatencyMemory::handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) {
 Port<std::unique_ptr<MemPacket>>* FixedLatencyMemory::initPort() {
   port_ = new Port<std::unique_ptr<MemPacket>>();
   auto fn = [this](std::unique_ptr<MemPacket> packet) -> void {
-    this->requestAccess(std::move(packet));
+    this->requestAccess(packet);
     return;
   };
   port_->registerReceiver(fn);

--- a/src/lib/memory/FixedLatencyMemory.cc
+++ b/src/lib/memory/FixedLatencyMemory.cc
@@ -17,48 +17,53 @@ size_t FixedLatencyMemory::getMemorySize() { return memSize_; }
 
 void FixedLatencyMemory::requestAccess(std::unique_ptr<MemPacket> pkt) {
   if (pkt->ignore()) {
-    port_->send(handleIgnoredRequest(std::move(pkt)));
+    handleIgnoredRequest(pkt);
+    port_->send(std::move(pkt));
+    return;
+  }
+  if (pkt->isUntimedRead()) {
+    pkt->turnIntoReadResponse(getUntimedData(pkt->paddr_, pkt->size_));
+    port_->send(std::move(pkt));
+    return;
   }
   LatencyPacket lpkt = {std::move(pkt), ticks_ + latency_};
   reqQueue_.push(std::move(lpkt));
 }
 
+void FixedLatencyMemory::handleReadRequest(std::unique_ptr<MemPacket>& req) {
+  size_t size = req->size_;
+  uint64_t addr = req->paddr_;
+  req->turnIntoReadResponse(
+      std::vector<char>(memory_.begin() + addr, memory_.begin() + addr + size));
+}
+
+void FixedLatencyMemory::handleWriteRequest(std::unique_ptr<MemPacket>& req) {
+  uint64_t address = req->paddr_;
+  std::copy(req->payload().begin(), req->payload().end(),
+            memory_.begin() + address);
+  req->turnIntoWriteResponse();
+}
+
 void FixedLatencyMemory::tick() {
   while (reqQueue_.front().endLat >= ticks_) {
-    auto req = std::move(reqQueue_.front().req);
-    if (req->isRequest() && req->isRead()) {
-      port_->send(handleReadRequest(std::move(req)));
-    } else if (req->isRequest() && req->isWrite()) {
-      port_->send(handleWriteRequest(std::move(req)));
+    std::unique_ptr<MemPacket>& pkt = reqQueue_.front().req;
+    if (pkt->isRequest() && pkt->isRead()) {
+      handleReadRequest(pkt);
+    } else if (pkt->isRequest() && pkt->isWrite()) {
+      handleWriteRequest(pkt);
     } else {
-      std::cerr << "[SimEng:FixedLatencyMemory] Invalid MemPacket type for "
+      std::cerr << "[SimEng:SimpleMem] Invalid MemPacket type for "
                    "requesting access to memory. Requests to memory should "
                    "either be of "
                    "type READ_REQUEST or WRITE_REQUEST."
                 << std::endl;
-      port_->send(MemPacket::createFaultyMemPacket(req->isRead()));
+      pkt->setFault();
     }
+    port_->send(std::move(pkt));
     reqQueue_.pop();
   }
   ticks_++;
 };
-
-std::unique_ptr<MemPacket> FixedLatencyMemory::handleReadRequest(
-    std::unique_ptr<MemPacket> req) {
-  size_t size = req->size_;
-  uint64_t addr = req->paddr_;
-  std::vector<char> data(memory_.begin() + addr, memory_.begin() + addr + size);
-  req->turnIntoReadResponse(data);
-  return req;
-}
-
-std::unique_ptr<MemPacket> FixedLatencyMemory::handleWriteRequest(
-    std::unique_ptr<MemPacket> req) {
-  uint64_t address = req->paddr_;
-  std::copy(req->data().begin(), req->data().end(), memory_.begin() + address);
-  req->turnIntoWriteResponse();
-  return req;
-}
 
 void FixedLatencyMemory::sendUntimedData(std::vector<char> data, uint64_t addr,
                                          size_t size) {
@@ -71,14 +76,12 @@ std::vector<char> FixedLatencyMemory::getUntimedData(uint64_t paddr,
                            memory_.begin() + paddr + size);
 }
 
-std::unique_ptr<MemPacket> FixedLatencyMemory::handleIgnoredRequest(
-    std::unique_ptr<MemPacket> pkt) {
+void FixedLatencyMemory::handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) {
   if (pkt->isRead()) {
     pkt->turnIntoReadResponse(std::vector<char>(pkt->size_, '\0'));
   } else {
     pkt->turnIntoWriteResponse();
   }
-  return pkt;
 }
 
 Port<std::unique_ptr<MemPacket>>* FixedLatencyMemory::initPort() {

--- a/src/lib/memory/MMU.cc
+++ b/src/lib/memory/MMU.cc
@@ -49,12 +49,12 @@ void MMU::requestWrite(const MemoryAccessTarget& target,
 }
 
 void MMU::requestInstrRead(const MemoryAccessTarget& target,
-                           const uint64_t requestId) {
-  uint64_t paddr = translate_(target.address, tid_);
+                           uint64_t requestId) {
+  uint64_t paddr = translate_(target.vaddr, tid_);
   uint64_t faultCode = simeng::OS::masks::faults::getFaultCode(paddr);
 
-  std::unique_ptr<memory::MemPacket> pkt = memory::MemPacket::createReadRequest(
-      target.address, target.size, requestId);
+  std::unique_ptr<memory::MemPacket> pkt =
+      memory::MemPacket::createReadRequest(target, requestId);
   if (faultCode == simeng::OS::masks::faults::pagetable::DATA_ABORT) {
     port_->recieve(MemPacket::createFaultyMemPacket(true));
     return;
@@ -113,7 +113,7 @@ Port<std::unique_ptr<MemPacket>>* MMU::initPort() {
         completedInstrReads_.push_back(
             // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
             // definition
-            {{packet->vaddr_, static_cast<uint8_t>(packet->size_), packet->id_},
+            {{packet->vaddr_, packet->size_, packet->id_},
              RegisterValue(),
              packet->id_});
         return;
@@ -121,7 +121,7 @@ Port<std::unique_ptr<MemPacket>>* MMU::initPort() {
       completedInstrReads_.push_back(
           // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
           // definition
-          {{packet->vaddr_, static_cast<uint8_t>(packet->size_), packet->id_},
+          {{packet->vaddr_, packet->size_, packet->id_},
            RegisterValue(packet->data().data(), packet->size_),
            packet->id_});
       return;
@@ -133,7 +133,7 @@ Port<std::unique_ptr<MemPacket>>* MMU::initPort() {
         completedReads_.push_back(
             // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
             // definition
-            {{packet->vaddr_, static_cast<uint8_t>(packet->size_), packet->id_},
+            {{packet->vaddr_, packet->size_, packet->id_},
              RegisterValue(),
              packet->id_});
         return;
@@ -141,7 +141,7 @@ Port<std::unique_ptr<MemPacket>>* MMU::initPort() {
       completedReads_.push_back(
           // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
           // definition
-          {{packet->vaddr_, static_cast<uint8_t>(packet->size_), packet->id_},
+          {{packet->vaddr_, packet->size_, packet->id_},
            RegisterValue(packet->data().data(), packet->size_),
            packet->id_});
     }

--- a/src/lib/memory/MMU.cc
+++ b/src/lib/memory/MMU.cc
@@ -97,8 +97,8 @@ void MMU::bufferRequest(std::unique_ptr<MemPacket> request) {
 
 void MMU::setTid(uint64_t tid) { tid_ = tid; }
 
-Port<std::unique_ptr<MemPacket>>* MMU::initPort() {
-  port_ = new Port<std::unique_ptr<MemPacket>>();
+std::shared_ptr<Port<std::unique_ptr<MemPacket>>> MMU::initPort() {
+  port_ = std::make_shared<Port<std::unique_ptr<MemPacket>>>();
   auto fn = [this](std::unique_ptr<MemPacket> packet) -> void {
     if (packet->isUntimedRead()) {
       // Untimed Read only used by instruction requests

--- a/src/lib/memory/MMU.cc
+++ b/src/lib/memory/MMU.cc
@@ -1,5 +1,6 @@
 #include "simeng/memory/MMU.hh"
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 
@@ -27,10 +28,10 @@ void MMU::tick() {
       const char* wdata = request.data.getAsVector<char>();
       std::vector<char> dt(wdata, wdata + target.size);
       bufferRequest(memory::MemPacket::createWriteRequest(
-          target.address, target.size, requestId, dt));
+          target.vaddr, target.size, requestId, dt));
     } else {
       bufferRequest(memory::MemPacket::createReadRequest(
-          target.address, target.size, requestId));
+          target.vaddr, target.size, requestId));
     }
 
     // Remove the request from the queue
@@ -50,21 +51,11 @@ void MMU::requestWrite(const MemoryAccessTarget& target,
 
 void MMU::requestInstrRead(const MemoryAccessTarget& target,
                            uint64_t requestId) {
-  uint64_t paddr = translate_(target.vaddr, tid_);
-  uint64_t faultCode = simeng::OS::masks::faults::getFaultCode(paddr);
-
-  std::unique_ptr<memory::MemPacket> pkt =
-      memory::MemPacket::createReadRequest(target, requestId);
-  if (faultCode == simeng::OS::masks::faults::pagetable::DATA_ABORT) {
-    port_->recieve(MemPacket::createFaultyMemPacket(true));
-    return;
-  } else if (faultCode == simeng::OS::masks::faults::pagetable::IGNORED) {
-    pkt->setIgnored();
-  } else {
-    pkt->paddr_ = paddr;
-    pkt->setUntimedRead();
-  }
-  port_->send(std::move(pkt));
+  std::unique_ptr<memory::MemPacket> insRequest =
+      memory::MemPacket::createReadRequest(target.vaddr, target.size,
+                                           requestId);
+  insRequest->setUntimedRead();
+  bufferRequest(std::move(insRequest));
 }
 
 const span<MemoryReadResult> MMU::getCompletedReads() const {
@@ -93,11 +84,14 @@ void MMU::bufferRequest(std::unique_ptr<MemPacket> request) {
     request->setFault();
     port_->recieve(std::move(request));
     return;
-  } else if (faultCode == simeng::OS::masks::faults::pagetable::IGNORED) {
+  }
+
+  if (faultCode == simeng::OS::masks::faults::pagetable::IGNORED) {
     request->setIgnored();
   } else {
     request->paddr_ = paddr;
   }
+
   port_->send(std::move(request));
 }
 
@@ -111,18 +105,14 @@ Port<std::unique_ptr<MemPacket>>* MMU::initPort() {
       if (packet->isFaulty()) {
         // If faulty, return no data. This signals a data abort.
         completedInstrReads_.push_back(
-            // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
-            // definition
-            {{packet->vaddr_, packet->size_, packet->id_},
-             RegisterValue(),
-             packet->id_});
+            {{packet->vaddr_, packet->size_}, RegisterValue(), packet->id_});
         return;
       }
       completedInstrReads_.push_back(
           // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
           // definition
-          {{packet->vaddr_, packet->size_, packet->id_},
-           RegisterValue(packet->data().data(), packet->size_),
+          {{packet->vaddr_, packet->size_},
+           RegisterValue(packet->payload().data(), packet->size_),
            packet->id_});
       return;
     }
@@ -133,16 +123,14 @@ Port<std::unique_ptr<MemPacket>>* MMU::initPort() {
         completedReads_.push_back(
             // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
             // definition
-            {{packet->vaddr_, packet->size_, packet->id_},
-             RegisterValue(),
-             packet->id_});
+            {{packet->vaddr_, packet->size_}, RegisterValue(), packet->id_});
         return;
       }
       completedReads_.push_back(
           // Risky cast from uint64_t to uint8_t due to MemoryAccessTarget
           // definition
-          {{packet->vaddr_, packet->size_, packet->id_},
-           RegisterValue(packet->data().data(), packet->size_),
+          {{packet->vaddr_, packet->size_},
+           RegisterValue(packet->payload().data(), packet->size_),
            packet->id_});
     }
     // Currently, ignore write responses as none are expected

--- a/src/lib/memory/MemPacket.cc
+++ b/src/lib/memory/MemPacket.cc
@@ -11,8 +11,12 @@ MemPacket::MemPacket(uint64_t vaddr, uint16_t size, MemPacketType type,
     : vaddr_(vaddr), size_(size), id_(reqId), metadata_(type) {}
 
 MemPacket::MemPacket(uint64_t vaddr, uint16_t size, MemPacketType type,
-                     uint64_t reqId, std::vector<char> data)
-    : vaddr_(vaddr), size_(size), id_(reqId), metadata_(type), data_(data) {}
+                     uint64_t reqId, std::vector<char> payload)
+    : vaddr_(vaddr),
+      size_(size),
+      id_(reqId),
+      metadata_(type),
+      payload_(payload) {}
 
 std::unique_ptr<MemPacket> MemPacket::createReadRequest(uint64_t vaddr,
                                                         uint16_t size,
@@ -22,9 +26,9 @@ std::unique_ptr<MemPacket> MemPacket::createReadRequest(uint64_t vaddr,
 }
 
 std::unique_ptr<MemPacket> MemPacket::createWriteRequest(
-    uint64_t vaddr, uint16_t size, uint64_t reqId, std::vector<char> data) {
+    uint64_t vaddr, uint16_t size, uint64_t reqId, std::vector<char> payload) {
   return std::unique_ptr<MemPacket>(
-      new MemPacket(vaddr, size, WRITE_REQUEST, reqId, data));
+      new MemPacket(vaddr, size, WRITE_REQUEST, reqId, payload));
 }
 
 void MemPacket::turnIntoWriteResponse() {
@@ -38,7 +42,7 @@ void MemPacket::turnIntoWriteResponse() {
   metadata_ = metadata_ & 0b01111111;
 }
 
-void MemPacket::turnIntoReadResponse(std::vector<char> data) {
+void MemPacket::turnIntoReadResponse(std::vector<char> payload) {
   if (!isRequest() && !isRead()) {
     std::cerr << "[SimEng:MemPacket] Only MemPackets of type Read Request can "
                  "be changed into Read Response"
@@ -47,14 +51,7 @@ void MemPacket::turnIntoReadResponse(std::vector<char> data) {
   }
   // Turn into response, maintaining other metadata
   metadata_ = metadata_ & 0b01111111;
-  data_ = data;
-}
-
-std::unique_ptr<MemPacket> MemPacket::createFaultyMemPacket(bool isRead) {
-  std::unique_ptr<MemPacket> pkt(new MemPacket());
-  pkt->metadata_ = FaultMask;
-  pkt->metadata_ |= isRead ? READ_RESPONSE : 0;
-  return pkt;
+  payload_ = payload;
 }
 
 }  // namespace memory

--- a/src/lib/memory/MemPacket.cc
+++ b/src/lib/memory/MemPacket.cc
@@ -6,23 +6,23 @@
 namespace simeng {
 namespace memory {
 
-MemPacket::MemPacket(uint64_t vaddr, uint64_t size, MemPacketType type,
+MemPacket::MemPacket(uint64_t vaddr, uint16_t size, MemPacketType type,
                      uint64_t reqId)
     : vaddr_(vaddr), size_(size), id_(reqId), metadata_(type) {}
 
-MemPacket::MemPacket(uint64_t vaddr, uint64_t size, MemPacketType type,
+MemPacket::MemPacket(uint64_t vaddr, uint16_t size, MemPacketType type,
                      uint64_t reqId, std::vector<char> data)
     : vaddr_(vaddr), size_(size), id_(reqId), metadata_(type), data_(data) {}
 
 std::unique_ptr<MemPacket> MemPacket::createReadRequest(uint64_t vaddr,
-                                                        uint64_t size,
+                                                        uint16_t size,
                                                         uint64_t reqId) {
   return std::unique_ptr<MemPacket>(
       new MemPacket(vaddr, size, READ_REQUEST, reqId));
 }
 
 std::unique_ptr<MemPacket> MemPacket::createWriteRequest(
-    uint64_t vaddr, uint64_t size, uint64_t reqId, std::vector<char> data) {
+    uint64_t vaddr, uint16_t size, uint64_t reqId, std::vector<char> data) {
   return std::unique_ptr<MemPacket>(
       new MemPacket(vaddr, size, WRITE_REQUEST, reqId, data));
 }

--- a/src/lib/memory/SimpleMem.cc
+++ b/src/lib/memory/SimpleMem.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <memory>
 
+#include "simeng/memory/MemPacket.hh"
+
 namespace simeng {
 namespace memory {
 
@@ -65,8 +67,8 @@ void SimpleMem::handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) {
   }
 }
 
-Port<std::unique_ptr<MemPacket>>* SimpleMem::initPort() {
-  port_ = new Port<std::unique_ptr<MemPacket>>();
+std::shared_ptr<Port<std::unique_ptr<MemPacket>>> SimpleMem::initPort() {
+  port_ = std::make_shared<Port<std::unique_ptr<MemPacket>>>();
   auto fn = [this](std::unique_ptr<MemPacket> packet) -> void {
     this->requestAccess(packet);
     return;

--- a/src/lib/memory/SimpleMem.cc
+++ b/src/lib/memory/SimpleMem.cc
@@ -13,7 +13,7 @@ SimpleMem::SimpleMem(size_t size) {
 
 size_t SimpleMem::getMemorySize() { return memSize_; }
 
-void SimpleMem::requestAccess(std::unique_ptr<MemPacket> pkt) {
+void SimpleMem::requestAccess(std::unique_ptr<MemPacket>& pkt) {
   if (pkt->ignore()) {
     handleIgnoredRequest(pkt);
   } else if (pkt->isUntimedRead()) {
@@ -68,7 +68,7 @@ void SimpleMem::handleIgnoredRequest(std::unique_ptr<MemPacket>& pkt) {
 Port<std::unique_ptr<MemPacket>>* SimpleMem::initPort() {
   port_ = new Port<std::unique_ptr<MemPacket>>();
   auto fn = [this](std::unique_ptr<MemPacket> packet) -> void {
-    this->requestAccess(std::move(packet));
+    this->requestAccess(packet);
     return;
   };
   port_->registerReceiver(fn);

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -64,7 +64,7 @@ void Core::tick() {
     const auto& completedReads = mmu_->getCompletedReads();
     for (const auto& response : completedReads) {
       assert(pendingReads_ > 0);
-      uop->supplyData(response.target.address, response.data);
+      uop->supplyData(response.target.vaddr, response.data);
       pendingReads_--;
     }
     mmu_->clearCompletedReads();
@@ -86,7 +86,7 @@ void Core::tick() {
     const auto& fetched = mmu_->getCompletedInstrReads();
     size_t fetchIndex;
     for (fetchIndex = 0; fetchIndex < fetched.size(); fetchIndex++) {
-      if (fetched[fetchIndex].target.address == pc_) {
+      if (fetched[fetchIndex].target.vaddr == pc_) {
         break;
       }
     }

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -251,7 +251,7 @@ void Core::loadData(const std::shared_ptr<Instruction>& instruction) {
   // NOTE: This model only supports zero-cycle data memory models, and will not
   // work unless data requests are handled synchronously.
   for (const auto& response : mmu_->getCompletedReads()) {
-    instruction->supplyData(response.target.address, response.data);
+    instruction->supplyData(response.target.vaddr, response.data);
   }
 
   assert(instruction->hasAllData() &&

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -91,7 +91,7 @@ void FetchUnit::tick() {
       // memory which cannot be mapped, a data abort exception is thrown and an
       // empty register value is returned as the read payload. A data null check
       // suffices to catch these data aborts.
-      if (fetched[fetchIndex].target.address == blockAddress &&
+      if (fetched[fetchIndex].target.vaddr == blockAddress &&
           fetched[fetchIndex].data) {
         break;
       }

--- a/test/unit/SimpleMem.cc
+++ b/test/unit/SimpleMem.cc
@@ -45,8 +45,8 @@ TEST(SimpleMemTest, Read) {
   sMem.sendUntimedData(data, addr, dataSize);
   auto req = simeng::memory::MemPacket::createReadRequest(addr, dataSize, 0);
   req->paddr_ = addr;
-  sMem.requestAccess(std::move(req));
-  auto res = respRecv.resp->data();
+  sMem.requestAccess(req);
+  auto res = respRecv.resp->payload();
   for (size_t i = 0; i < dataSize; i++) {
     EXPECT_EQ(res[i], data[i]);
   }
@@ -55,8 +55,8 @@ TEST(SimpleMemTest, Read) {
   dataSize = 2;
   auto req2 = simeng::memory::MemPacket::createReadRequest(addr, dataSize, 1);
   req2->paddr_ = addr;
-  sMem.requestAccess(std::move(req2));
-  auto res2 = respRecv.resp->data();
+  sMem.requestAccess(req2);
+  auto res2 = respRecv.resp->payload();
   EXPECT_EQ(res2[0], '8');
   EXPECT_EQ(res2[1], '9');
 }
@@ -87,7 +87,7 @@ TEST(SimpleMemTest, Write) {
   auto req =
       simeng::memory::MemPacket::createWriteRequest(addr, dataSize, 0, data);
   req->paddr_ = addr;
-  sMem.requestAccess(std::move(req));
+  sMem.requestAccess(req);
   auto mem = sMem.getUntimedData(0, dataSize);
   for (size_t i = 0; i < dataSize; i++) {
     EXPECT_EQ(mem[i], data[i]);
@@ -97,7 +97,7 @@ TEST(SimpleMemTest, Write) {
   auto req2 =
       simeng::memory::MemPacket::createWriteRequest(addr, dataSize, 1, data);
   req2->paddr_ = addr;
-  sMem.requestAccess(std::move(req2));
+  sMem.requestAccess(req2);
   mem = sMem.getUntimedData(addr, dataSize);
   for (size_t i = 0; i < dataSize; i++) {
     EXPECT_EQ(mem[i], data[i]);

--- a/test/unit/SimpleMem.cc
+++ b/test/unit/SimpleMem.cc
@@ -1,5 +1,7 @@
 #include "simeng/memory/SimpleMem.hh"
 
+#include <memory>
+
 #include "gtest/gtest.h"
 
 namespace {
@@ -11,8 +13,10 @@ class testRecv {
 
   /** Function used to initialise the Data Port used for bidirection
    * communication. */
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* initPort() {
-    port_ = new simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>();
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+  initPort() {
+    port_ = std::make_shared<
+        simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>();
     auto fn =
         [this](std::unique_ptr<simeng::memory::MemPacket> packet) -> void {
       this->resp = std::move(packet);
@@ -27,7 +31,8 @@ class testRecv {
 
  private:
   /** Data port used for communication with the memory hierarchy. */
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* port_ = nullptr;
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+      port_ = nullptr;
 };
 
 TEST(SimpleMemTest, Read) {

--- a/test/unit/pipeline/FetchUnitTest.cc
+++ b/test/unit/pipeline/FetchUnitTest.cc
@@ -119,13 +119,13 @@ TEST_F(PipelineFetchUnitTest, FetchUnaligned) {
   // Fetch ocurred on block 0->16, with bytes 14-16 being buffered. Hence, no
   // decode
   EXPECT_EQ(mmu->getCompletedInstrReads().size(), 1);
-  EXPECT_EQ(mmu->getCompletedInstrReads()[0].target.address, 0);
+  EXPECT_EQ(mmu->getCompletedInstrReads()[0].target.vaddr, 0);
   EXPECT_EQ(mmu->getCompletedInstrReads()[0].data.size(), 16);
 
   // Expect a block starting at address 16 to be requested when we fetch again
   fetchUnit.requestFromPC();
   // Ensure that a block starting at address 16, of size 16-bytes, was fetched
-  EXPECT_EQ(mmu->getCompletedInstrReads()[1].target.address, 16);
+  EXPECT_EQ(mmu->getCompletedInstrReads()[1].target.vaddr, 16);
   EXPECT_EQ(mmu->getCompletedInstrReads()[1].data.size(), 16);
 
   // Tick again, expecting that decoding will now resume

--- a/test/unit/pipeline/FetchUnitTest.cc
+++ b/test/unit/pipeline/FetchUnitTest.cc
@@ -57,8 +57,10 @@ class PipelineFetchUnitTest : public testing::Test {
   std::shared_ptr<memory::MMU> mmu;
 
   simeng::PortMediator<std::unique_ptr<simeng::memory::MemPacket>> connection;
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* port1;
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* port2;
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+      port1;
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+      port2;
 
   FetchUnit fetchUnit;
 

--- a/test/unit/pipeline/LoadStoreQueueTest.cc
+++ b/test/unit/pipeline/LoadStoreQueueTest.cc
@@ -142,8 +142,10 @@ class LoadStoreQueueTest : public ::testing::TestWithParam<bool> {
   std::shared_ptr<memory::MMU> mmu;
 
   simeng::PortMediator<std::unique_ptr<simeng::memory::MemPacket>> connection;
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* port1;
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* port2;
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+      port1;
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+      port2;
 };
 
 // Test that a split queue can be constructed correctly

--- a/test/unit/pipeline/ReorderBufferTest.cc
+++ b/test/unit/pipeline/ReorderBufferTest.cc
@@ -58,8 +58,10 @@ class ReorderBufferTest : public testing::Test {
   std::shared_ptr<memory::MMU> mmu;
 
   simeng::PortMediator<std::unique_ptr<simeng::memory::MemPacket>> connection;
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* port1;
-  simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>* port2;
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+      port1;
+  std::shared_ptr<simeng::Port<std::unique_ptr<simeng::memory::MemPacket>>>
+      port2;
 
   RegisterAliasTable rat;
   LoadStoreQueue lsq;


### PR DESCRIPTION
Includes:
- Ports are now shared_ptrs
- Size change of `size` in MemoryAcessTarget
- Variable name change to vaddr in MemoryAccessTarget
- Removed unnecessary moves of unique_ptr to references
- General refactor of functions