### PR TITLE
Inorder core fix

### DIFF
--- a/.jenkins/build_test_run.sh
+++ b/.jenkins/build_test_run.sh
@@ -53,7 +53,7 @@ run () {
     cat run
     echo ""
     compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "3145731" "retired instructions"
-    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "3145737" "simulated cycles"
+    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "3145739" "simulated cycles"
     echo ""
 
     ./bin/simeng "$SIMENG_TOP"/configs/tx2.yaml > run

--- a/configs/DEMO_RISCV.yaml
+++ b/configs/DEMO_RISCV.yaml
@@ -7,6 +7,7 @@ Core:
   ISA: rv64
   Simulation-Mode: outoforder
   Clock-Frequency: 2.5
+  Timer-Frequency: 200
   Fetch-Block-Size: 32
 Fetch:
   Fetch-Block-Size: 32

--- a/src/include/simeng/Config.hh
+++ b/src/include/simeng/Config.hh
@@ -34,12 +34,12 @@ class Config {
    "Instruction-Group-Support: [67]}, '5': {Portname: Port 3, "                \
    "Instruction-Group-Support: [70]}}, Reservation-Stations: {'0': {Size: "    \
    "60, Dispatch-Rate: 4, Ports: [0, 1, 2, 3, 4, 5]}}, Execution-Units: "      \
-   "{'0': {Pipelined: true}, '1': {Pipelined: true}, '2': {Pipelined: "        \
-   "true},'3': {Pipelined:true}, '4': {Pipelined: true}, '5': {Pipelined: "    \
-   "true}}, CPU-Info: {Generate-Special-Dir: false, Core-Count: 1, "           \
-   "Socket-Count: 1, SMT: 1, BogoMIPS: 200.00, Features: fp asimd evtstrm "    \
-   "atomics cpuid, CPU-Implementer: 0x0, CPU-Architecture: 0, CPU-Variant: "   \
-   "0x0, CPU-Part: 0x0, CPU-Revision: 0, Package-Count: 1}}")
+   "{'0': {Pipelined: true}, '1': {Pipelined: true}, '2': {Pipelined: true}, " \
+   "'3': {Pipelined: true}, '4': {Pipelined: true}, '5': {Pipelined: true}}, " \
+   "CPU-Info: {Generate-Special-Dir: false, Core-Count: 1, Socket-Count: 1, "  \
+   "SMT: 1, BogoMIPS: 200.00, Features: fp asimd evtstrm atomics cpuid, "      \
+   "CPU-Implementer: 0x0, CPU-Architecture: 0, CPU-Variant: 0x0, CPU-Part: "   \
+   "0x0, CPU-Revision: 0, Package-Count: 1}}")
 
   /** Constructor of a Config object. */
   Config() { config_ = YAML::Load(DEFAULT_CONFIG); }

--- a/src/include/simeng/models/inorder/Core.hh
+++ b/src/include/simeng/models/inorder/Core.hh
@@ -86,12 +86,6 @@ class Core : public simeng::Core {
   /** Handle an exception raised during the cycle. */
   bool handleException();
 
-  /** Handle execution of a load instruction. */
-  void handleLoad(const std::shared_ptr<Instruction>& insn);
-
-  /** Store data supplied by an instruction to memory. */
-  void storeData(const std::shared_ptr<Instruction>& insn);
-
   /** A function to carry out logic associated with the retirement of a
    * instruction post writeback. */
   void retireInstruction(const std::shared_ptr<Instruction>& insn);

--- a/src/include/simeng/models/inorder/Core.hh
+++ b/src/include/simeng/models/inorder/Core.hh
@@ -183,8 +183,9 @@ class Core : public simeng::Core {
    * issued from based on a defined algorithm. */
   pipeline::PortAllocator& portAllocator_;
 
-  /** A queue of store address uops that have been retired that future store
-   * data uops can use to commit the load in the core's load/store queue unit.
+  /** A queue of store address uops that have been retired. Future store
+   * data uops can use this queue to commit its associated store macro-op in the
+   * core's load/store queue unit.
    */
   std::queue<std::shared_ptr<Instruction>> completedStoreAddrUops_ = {};
 

--- a/src/include/simeng/models/outoforder/Core.hh
+++ b/src/include/simeng/models/outoforder/Core.hh
@@ -54,6 +54,9 @@ class Core : public simeng::Core {
   const ArchitecturalRegisterFileSet& getArchitecturalRegisterFileSet()
       const override;
 
+  /** A function to carry out post-writeback micro-op commit logic. */
+  void microOpWriteback(const std::shared_ptr<Instruction>& insn);
+
   /** Send a syscall to the simulated Operating System's syscall handler. */
   void sendSyscall(OS::SyscallInfo syscallInfo) const override;
 

--- a/src/include/simeng/pipeline/BlockingIssueUnit.hh
+++ b/src/include/simeng/pipeline/BlockingIssueUnit.hh
@@ -10,6 +10,7 @@
 #include "simeng/Config.hh"
 #include "simeng/Instruction.hh"
 #include "simeng/pipeline/InOrderStager.hh"
+#include "simeng/pipeline/LoadStoreQueue.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
 #include "simeng/pipeline/PortAllocator.hh"
 
@@ -27,7 +28,9 @@ class BlockingIssueUnit {
   BlockingIssueUnit(
       PipelineBuffer<std::shared_ptr<Instruction>>& input,
       std::vector<PipelineBuffer<std::shared_ptr<Instruction>>>& issuePorts,
-      PortAllocator& portAllocator, std::function<void(uint64_t)> recordIssue,
+      PortAllocator& portAllocator,
+      std::function<void(const std::shared_ptr<Instruction>&)> recordIssue,
+      LoadStoreQueue& lsq,
       std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
       const RegisterFileSet& registerFileSet,
       const std::vector<uint16_t>& physicalRegisterStructure);
@@ -87,7 +90,10 @@ class BlockingIssueUnit {
 
   /** A function to record the issue of an instruction to enable the tracking of
    * in program-order instruction execution and writeback. */
-  std::function<void(uint64_t)> recordIssue_;
+  std::function<void(const std::shared_ptr<Instruction>&)> recordIssue_;
+
+  /** A reference to the loadt/store queue. */
+  LoadStoreQueue& lsq_;
 
   /** A function handle called upon exception generation. */
   std::function<void(const std::shared_ptr<Instruction>&)> raiseException_;

--- a/src/include/simeng/pipeline/BlockingIssueUnit.hh
+++ b/src/include/simeng/pipeline/BlockingIssueUnit.hh
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <deque>
+#include <initializer_list>
+#include <queue>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "simeng/Config.hh"
+#include "simeng/Instruction.hh"
+#include "simeng/pipeline/InOrderStager.hh"
+#include "simeng/pipeline/PipelineBuffer.hh"
+#include "simeng/pipeline/PortAllocator.hh"
+
+namespace simeng {
+namespace pipeline {
+
+/** An issue unit for an inorder pipelined processor. Reads instruction operands
+ * and performs scoreboarding. Issues instructions to the execution units once
+ * ready in program-order. */
+class BlockingIssueUnit {
+ public:
+  /** Construct an issue unit with references to input/output buffers,
+   * the register file, the port allocator, the and a description of the number
+   * of physical registers the scoreboard needs to reflect. */
+  BlockingIssueUnit(
+      PipelineBuffer<std::shared_ptr<Instruction>>& input,
+      std::vector<PipelineBuffer<std::shared_ptr<Instruction>>>& issuePorts,
+      PortAllocator& portAllocator, std::function<void(uint64_t)> recordIssue,
+      std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
+      const RegisterFileSet& registerFileSet,
+      const std::vector<uint16_t>& physicalRegisterStructure);
+
+  /** Ticks the issue unit. Reads available input operands for
+   * instructions and sets scoreboard flags for destination registers. If the
+   * resources required by an instruction aren't available, the unit and its
+   * input buffer are stalled until its ready to be issued. */
+  void tick();
+
+  /** Forwards operands to the instruction at the front of the issue queue and
+   * issues it if ready to execute. */
+  void forwardOperands(const span<Register>& destinations,
+                       const span<RegisterValue>& values);
+
+  /** Set the scoreboard entry for the provided register as ready. */
+  void setRegisterReady(Register reg);
+
+  /** Flush the scoreboard entries which have been set by instructions older
+   * than the sequence id provided. Also clear any register source dependency
+   * and clear the issue queue. */
+  void flush(uint64_t afterSeqId);
+
+  /** Flush the scoreboard entries, clear any register source dependency
+   * and clear the issue queue. */
+  void flush();
+
+  /** Retrieve the number of cycles no instructions were issued due to an empty
+   * issue queue. */
+  uint64_t getFrontendStalls() const;
+
+  /** Retrieve the number of cycles no instructions were issued due to
+   * dependencies or a lack of available ports. */
+  uint64_t getBackendStalls() const;
+
+  /** Retrieve the number of times an instruction was unable to issue due to a
+   * busy port. */
+  uint64_t getPortBusyStalls() const;
+
+ private:
+  /** A buffer of instructions to issue and read operands for. */
+  PipelineBuffer<std::shared_ptr<Instruction>>& input_;
+
+  /** Ports to the execution units, for writing ready instructions to. */
+  std::vector<PipelineBuffer<std::shared_ptr<Instruction>>>& issuePorts_;
+
+  /** A queue of instructions, in program-order, which are ready to be issued.
+   */
+  std::deque<std::shared_ptr<Instruction>> issueQueue_;
+
+  /** A reference to the execution port allocator. */
+  PortAllocator& portAllocator_;
+
+  /** The register availability scoreboard. An unsigned integer is used to set
+   * the instruction which made a register unavailable. */
+  std::vector<std::vector<std::pair<bool, uint64_t>>> scoreboard_;
+
+  /** A function to record the issue of an instruction to enable the tracking of
+   * in program-order instruction execution and writeback. */
+  std::function<void(uint64_t)> recordIssue_;
+
+  /** A function handle called upon exception generation. */
+  std::function<void(const std::shared_ptr<Instruction>&)> raiseException_;
+
+  /** A reference to the physical register file set. */
+  const RegisterFileSet& registerFileSet_;
+
+  /** Whether the supply of a source operand is dependent on a currently
+   * executing instruction. */
+  bool dependent_ = false;
+
+  /** A pair representing a register dependency. The first entry in the pair is
+   * the register depended on, and the second is the operand index, within the
+   * dependent instruction, the dependency is associated with. */
+  std::pair<Register, uint16_t> dependency_;
+
+  /** The number of cycles no instructions were issued due to an empty issue
+   * queue. */
+  uint64_t frontendStalls_ = 0;
+
+  /** The number of cycles no instructions were issued due to dependencies or a
+   * lack of available ports. */
+  uint64_t backendStalls_ = 0;
+
+  /** The number of times an instruction was unable to issue due to a busy port.
+   */
+  uint64_t portBusyStalls_ = 0;
+};
+
+}  // namespace pipeline
+}  // namespace simeng

--- a/src/include/simeng/pipeline/BlockingIssueUnit.hh
+++ b/src/include/simeng/pipeline/BlockingIssueUnit.hh
@@ -23,7 +23,7 @@ namespace pipeline {
 class BlockingIssueUnit {
  public:
   /** Construct an issue unit with references to input/output buffers,
-   * the register file, the port allocator, the and a description of the number
+   * the register file, the port allocator, and a description of the number
    * of physical registers the scoreboard needs to reflect. */
   BlockingIssueUnit(
       PipelineBuffer<std::shared_ptr<Instruction>>& input,
@@ -92,7 +92,7 @@ class BlockingIssueUnit {
    * in program-order instruction execution and writeback. */
   std::function<void(const std::shared_ptr<Instruction>&)> recordIssue_;
 
-  /** A reference to the loadt/store queue. */
+  /** A reference to the load/store queue. */
   LoadStoreQueue& lsq_;
 
   /** A function handle called upon exception generation. */

--- a/src/include/simeng/pipeline/BlockingIssueUnit.hh
+++ b/src/include/simeng/pipeline/BlockingIssueUnit.hh
@@ -50,9 +50,9 @@ class BlockingIssueUnit {
   void setRegisterReady(Register reg);
 
   /** Flush the scoreboard entries which have been set by instructions older
-   * than the sequence id provided. Also clear any register source dependency
+   * than the instruction id provided. Also clear any register source dependency
    * and clear the issue queue. */
-  void flush(uint64_t afterSeqId);
+  void flush(uint64_t afterInsnId);
 
   /** Flush the scoreboard entries, clear any register source dependency
    * and clear the issue queue. */

--- a/src/include/simeng/pipeline/BlockingIssueUnit.hh
+++ b/src/include/simeng/pipeline/BlockingIssueUnit.hh
@@ -105,10 +105,10 @@ class BlockingIssueUnit {
    * executing instruction. */
   bool dependent_ = false;
 
-  /** A pair representing a register dependency. The first entry in the pair is
-   * the register depended on, and the second is the operand index, within the
-   * dependent instruction, the dependency is associated with. */
-  std::pair<Register, uint16_t> dependency_;
+  /** A vector of pairs representing a register dependencies. The first entry in
+   * the pair is the register depended on, and the second is the operand index,
+   * within the dependent instruction, the dependency is associated with. */
+  std::vector<std::pair<Register, uint16_t>> dependency_;
 
   /** The number of cycles no instructions were issued due to an empty issue
    * queue. */

--- a/src/include/simeng/pipeline/BlockingIssueUnit.hh
+++ b/src/include/simeng/pipeline/BlockingIssueUnit.hh
@@ -108,7 +108,7 @@ class BlockingIssueUnit {
   /** A vector of pairs representing a register dependencies. The first entry in
    * the pair is the register depended on, and the second is the operand index,
    * within the dependent instruction, the dependency is associated with. */
-  std::vector<std::pair<Register, uint16_t>> dependency_;
+  std::vector<std::pair<Register, uint16_t>> dependencies_;
 
   /** The number of cycles no instructions were issued due to an empty issue
    * queue. */

--- a/src/include/simeng/pipeline/ExecuteUnit.hh
+++ b/src/include/simeng/pipeline/ExecuteUnit.hh
@@ -48,6 +48,10 @@ class ExecuteUnit {
    * discovered misprediction. */
   uint64_t getFlushAddress() const;
 
+  /** Retrieve the instruction ID associated with the most recently discovered
+   * misprediction. */
+  uint64_t getFlushInsnId() const;
+
   /** Retrieve the sequence ID associated with the most recently discovered
    * misprediction. */
   uint64_t getFlushSeqId() const;
@@ -126,9 +130,13 @@ class ExecuteUnit {
    */
   uint64_t pc_;
 
+  /** The instruction ID of the youngest instruction that should remain after
+   * the current flush. */
+  uint64_t flushAfterInsnId_;
+
   /** The sequence ID of the youngest instruction that should remain after the
    * current flush. */
-  uint64_t flushAfter_;
+  uint64_t flushAfterSeqId_;
 
   /** The number of times this unit has been ticked. */
   uint64_t tickCounter_ = 0;

--- a/src/include/simeng/pipeline/ExecuteUnit.hh
+++ b/src/include/simeng/pipeline/ExecuteUnit.hh
@@ -52,17 +52,9 @@ class ExecuteUnit {
    * misprediction. */
   uint64_t getFlushInsnId() const;
 
-  /** Retrieve the sequence ID associated with the most recently discovered
-   * misprediction. */
-  uint64_t getFlushSeqId() const;
-
   /** Purge flushed instructions from the internal pipeline and clear any active
    * stall, if applicable. */
   void purgeFlushed();
-
-  /** Flush the EU pipeline of any instructions whose sequenceId is greater the
-   * passed ID. */
-  void seqIdFlush(uint64_t afterSeqId);
 
   /** Flushed EU pipeline of any instructions. */
   void flush();
@@ -137,10 +129,6 @@ class ExecuteUnit {
   /** The instruction ID of the youngest instruction that should remain after
    * the current flush. */
   uint64_t flushAfterInsnId_;
-
-  /** The sequence ID of the youngest instruction that should remain after the
-   * current flush. */
-  uint64_t flushAfterSeqId_;
 
   /** The number of times this unit has been ticked. */
   uint64_t tickCounter_ = 0;

--- a/src/include/simeng/pipeline/ExecuteUnit.hh
+++ b/src/include/simeng/pipeline/ExecuteUnit.hh
@@ -60,12 +60,16 @@ class ExecuteUnit {
    * stall, if applicable. */
   void purgeFlushed();
 
-  /** Query whether the execution unit is empty and not currently processing any
-   * instructions. */
-  bool isEmpty();
+  /** Flush the EU pipeline of any instructions whose sequenceId is greater the
+   * passed ID. */
+  void seqIdFlush(uint64_t afterSeqId);
 
   /** Flushed EU pipeline of any instructions. */
   void flush();
+
+  /** Query whether the execution unit is empty and not currently processing any
+   * instructions. */
+  bool isEmpty();
 
   /** Retrieve the number of branch instructions that have been executed. */
   uint64_t getBranchExecutedCount() const;

--- a/src/include/simeng/pipeline/InOrderStager.hh
+++ b/src/include/simeng/pipeline/InOrderStager.hh
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <unordered_map>
+
+#include "simeng/Instruction.hh"
+#include "simeng/pipeline/LoadStoreQueue.hh"
+#include "simeng/pipeline/RegisterAliasTable.hh"
+
+namespace simeng {
+namespace pipeline {
+
+/** A pipeline unit concerned with the tracking of issued instructions in
+ * program-order. This tracking is used to facilitate the staging of
+ * instructions at the writeback stage. Such staging is the delay of an
+ * instruction's writeback to ensure that it is carried out in program-order.
+ * Subsequently, the updates to the architectural state held within simulation
+ * is updated in-order. */
+class InOrderStager {
+ public:
+  /** The constructor of the unit. */
+  InOrderStager();
+
+  /** A function to record the issuing of instructions by a passed unique
+   * sequence ID. */
+  void recordIssue(uint64_t seqId);
+
+  /** A function to query whether an instruction can writeback based on its
+   * unique sequence ID being the youngest in program-order recorded by the
+   * unit. */
+  bool canWriteback(uint64_t seqId) const;
+
+  /** A function to supply the next instruction sequence ID which can be
+   * retired. */
+  uint64_t getNextId() const;
+
+  /** A function to record and release an instruction sequence ID from the unit
+   * due to its retirement from the pipeline. */
+  void recordRetired(uint64_t seqId);
+
+  /** A function to remove IDs from the issueOrderBuffer_ which are older than
+   * the passed ID the pipeline is being flushed from. */
+  void flush(uint64_t afterSeqId);
+
+  /** A function to clear the issueOrderBuffer_ due to a pipeline flush. */
+  void flush();
+
+  /** A function to query whether there are any entries in the
+   * issueOrderBuffer_. */
+  bool isEmpty() const;
+
+ private:
+  /** A queue to hold all in–flight issued instructions in a program-order. */
+  std::deque<uint64_t> issueOrderQueue_;
+};
+
+}  // namespace pipeline
+}  // namespace simeng

--- a/src/include/simeng/pipeline/InOrderStager.hh
+++ b/src/include/simeng/pipeline/InOrderStager.hh
@@ -22,9 +22,8 @@ class InOrderStager {
   /** The constructor of the unit. */
   InOrderStager();
 
-  /** A function to record the issuing of instructions by a passed unique
-   * sequence ID. */
-  void recordIssue(uint64_t seqId);
+  /** A function to record the issuing of instructions. */
+  void recordIssue(const std::shared_ptr<Instruction>& insn);
 
   /** A function to query whether an instruction can writeback based on its
    * unique sequence ID being the youngest in program-order recorded by the
@@ -52,7 +51,7 @@ class InOrderStager {
 
  private:
   /** A queue to hold all in–flight issued instructions in a program-order. */
-  std::deque<uint64_t> issueOrderQueue_;
+  std::deque<std::shared_ptr<Instruction>> issueOrderQueue_;
 };
 
 }  // namespace pipeline

--- a/src/include/simeng/pipeline/InOrderStager.hh
+++ b/src/include/simeng/pipeline/InOrderStager.hh
@@ -32,7 +32,7 @@ class InOrderStager {
 
   /** A function to supply the next instruction sequence ID which can be
    * retired. */
-  uint64_t getNextId() const;
+  uint64_t getNextSeqID() const;
 
   /** A function to record and release an instruction sequence ID from the unit
    * due to its retirement from the pipeline. */
@@ -40,7 +40,7 @@ class InOrderStager {
 
   /** A function to remove IDs from the issueOrderBuffer_ which are older than
    * the passed ID the pipeline is being flushed from. */
-  void flush(uint64_t afterSeqId);
+  void flush(uint64_t afterInsnId);
 
   /** A function to clear the issueOrderBuffer_ due to a pipeline flush. */
   void flush();

--- a/src/include/simeng/pipeline/LoadStoreQueue.hh
+++ b/src/include/simeng/pipeline/LoadStoreQueue.hh
@@ -17,7 +17,7 @@ namespace pipeline {
 enum accessType { LOAD = 0, STORE };
 
 /** The order in which instructions can exit this unit. */
-enum completionOrder { INORDER = 0, OUTOFORDER };
+enum class CompletionOrder { INORDER = 0, OUTOFORDER };
 
 /** A requestQueue_ entry. */
 struct requestEntry {
@@ -38,7 +38,7 @@ class LoadStoreQueue {
       unsigned int maxCombinedSpace, std::shared_ptr<memory::MMU> mmu,
       span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
       std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
-      completionOrder completionOrder = completionOrder::OUTOFORDER,
+      CompletionOrder completionOrder = CompletionOrder::OUTOFORDER,
       bool exclusive = false, uint16_t loadBandwidth = UINT16_MAX,
       uint16_t storeBandwidth = UINT16_MAX,
       uint16_t permittedRequests = UINT16_MAX,
@@ -53,7 +53,7 @@ class LoadStoreQueue {
       std::shared_ptr<memory::MMU> mmu,
       span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
       std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
-      completionOrder completionOrder = completionOrder::OUTOFORDER,
+      CompletionOrder completionOrder = CompletionOrder::OUTOFORDER,
       bool exclusive = false, uint16_t loadBandwidth = UINT16_MAX,
       uint16_t storeBandwidth = UINT16_MAX,
       uint16_t permittedRequests = UINT16_MAX,
@@ -181,7 +181,7 @@ class LoadStoreQueue {
   std::queue<std::shared_ptr<Instruction>> completedLoads_;
 
   /** The order in which instructions can be passed to the completion slots. */
-  completionOrder completionOrder_;
+  CompletionOrder completionOrder_;
 
   /** Whether the LSQ can only process loads xor stores within a cycle. */
   bool exclusive_;

--- a/src/include/simeng/pipeline/LoadStoreQueue.hh
+++ b/src/include/simeng/pipeline/LoadStoreQueue.hh
@@ -16,9 +16,8 @@ namespace pipeline {
 /** The memory access types which are processed. */
 enum accessType { LOAD = 0, STORE };
 
-/** The instruction attributes that are used to schedule their memory accesses.
- */
-enum scheduleBy { LATENCY = 0, ID };
+/** The order in which instructions can exit this unit. */
+enum completionOrder { INORDER = 0, OUTOFORDER };
 
 /** A requestQueue_ entry. */
 struct requestEntry {
@@ -39,8 +38,9 @@ class LoadStoreQueue {
       unsigned int maxCombinedSpace, std::shared_ptr<memory::MMU> mmu,
       span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
       std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
-      scheduleBy scheduleCriteria = scheduleBy::LATENCY, bool exclusive = false,
-      uint16_t loadBandwidth = UINT16_MAX, uint16_t storeBandwidth = UINT16_MAX,
+      completionOrder completionOrder = completionOrder::OUTOFORDER,
+      bool exclusive = false, uint16_t loadBandwidth = UINT16_MAX,
+      uint16_t storeBandwidth = UINT16_MAX,
       uint16_t permittedRequests = UINT16_MAX,
       uint16_t permittedLoads = UINT16_MAX,
       uint16_t permittedStores = UINT16_MAX);
@@ -53,8 +53,9 @@ class LoadStoreQueue {
       std::shared_ptr<memory::MMU> mmu,
       span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
       std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
-      scheduleBy scheduleCriteria = scheduleBy::LATENCY, bool exclusive = false,
-      uint16_t loadBandwidth = UINT16_MAX, uint16_t storeBandwidth = UINT16_MAX,
+      completionOrder completionOrder = completionOrder::OUTOFORDER,
+      bool exclusive = false, uint16_t loadBandwidth = UINT16_MAX,
+      uint16_t storeBandwidth = UINT16_MAX,
       uint16_t permittedRequests = UINT16_MAX,
       uint16_t permittedLoads = UINT16_MAX,
       uint16_t permittedStores = UINT16_MAX);
@@ -179,8 +180,8 @@ class LoadStoreQueue {
   /** A queue of completed loads ready for writeback. */
   std::queue<std::shared_ptr<Instruction>> completedLoads_;
 
-  /** The criteria by which a scheduler schedules memory access. */
-  scheduleBy scheduleCriteria_;
+  /** The order in which instructions can be passed to the completion slots. */
+  completionOrder completionOrder_;
 
   /** Whether the LSQ can only process loads xor stores within a cycle. */
   bool exclusive_;

--- a/src/include/simeng/pipeline/ReorderBuffer.hh
+++ b/src/include/simeng/pipeline/ReorderBuffer.hh
@@ -58,8 +58,9 @@ class ReorderBuffer {
   /** Commit and remove up to `maxCommitSize` instructions. */
   unsigned int commit(unsigned int maxCommitSize);
 
-  /** Flush all instructions with a sequence ID greater than `afterSeqId`. */
-  void flush(uint64_t afterSeqId);
+  /** Flush all instructions with a instruction ID greater than `afterInsnId`.
+   */
+  void flush(uint64_t afterInsnId);
 
   /** Flush all instructions from ROB. Intended for use during context switch.
    */
@@ -79,9 +80,9 @@ class ReorderBuffer {
    * discovered memory order violation. */
   uint64_t getFlushAddress() const;
 
-  /** Retrieve the sequence ID associated with the most recently discovered
+  /** Retrieve the instruction ID associated with the most recently discovered
    * memory order violation. */
-  uint64_t getFlushSeqId() const;
+  uint64_t getFlushInsnId() const;
 
   /** Get the number of instructions the ROB has committed. */
   uint64_t getInstructionsCommittedCount() const;
@@ -122,8 +123,8 @@ class ReorderBuffer {
    */
   uint64_t pc_;
 
-  /** The sequence ID of the youngest instruction that should remain after the
-   * current flush. */
+  /** The instruction ID of the youngest instruction that should remain after
+   * the current flush. */
   uint64_t flushAfter_;
 
   /** Latest retired branch outcome with a counter. */

--- a/src/include/simeng/pipeline/WritebackUnit.hh
+++ b/src/include/simeng/pipeline/WritebackUnit.hh
@@ -14,10 +14,13 @@ class WritebackUnit {
  public:
   /** Constructs a writeback unit with references to an input buffer and
    * register file to write to. */
-  WritebackUnit(std::vector<PipelineBuffer<std::shared_ptr<Instruction>>>&
-                    completionSlots,
-                RegisterFileSet& registerFileSet,
-                std::function<void(uint64_t insnId)> flagMicroOpCommits);
+  WritebackUnit(
+      std::vector<PipelineBuffer<std::shared_ptr<Instruction>>>&
+          completionSlots,
+      RegisterFileSet& registerFileSet,
+      std::function<void(Register reg)> setRegisterReady,
+      std::function<bool(uint64_t seqId)> canWriteback,
+      std::function<void(const std::shared_ptr<Instruction>&)> postWriteback);
 
   /** Tick the writeback unit to perform its operation for this cycle. */
   void tick();
@@ -35,9 +38,17 @@ class WritebackUnit {
   /** The register file set to write results into. */
   RegisterFileSet& registerFileSet_;
 
-  /** A function handle called to determine if uops associated to an instruction
-   * ID can now be committed. */
-  std::function<void(uint64_t insnId)> flagMicroOpCommits_;
+  /** A function handle to mark the destination registers as ready to be read
+   * from by other instructions. */
+  std::function<void(Register reg)> setRegisterReady_;
+
+  /** A function handle to query whether a instruction, identified by its unique
+   * sequence ID, can writeback. */
+  std::function<bool(uint64_t seqId)> canWriteback_;
+
+  /** A function handle to carry out logic, specific to a core/model, after the
+   * general writeback logic has been carried out. */
+  std::function<void(const std::shared_ptr<Instruction>&)> postWriteback_;
 
   /** The number of instructions processed and retired by this stage. */
   uint64_t instructionsWritten_ = 0;

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -31,12 +31,14 @@ set(SIMENG_SOURCES
     models/outoforder/Core.cc
     pipeline/A64FXPortAllocator.cc
     pipeline/BalancedPortAllocator.cc
-    pipeline/M1PortAllocator.cc
+    pipeline/BlockingIssueUnit.cc
     pipeline/DecodeUnit.cc
     pipeline/DispatchIssueUnit.cc
     pipeline/ExecuteUnit.cc
     pipeline/FetchUnit.cc
+    pipeline/InOrderStager.cc
     pipeline/LoadStoreQueue.cc
+    pipeline/M1PortAllocator.cc
     pipeline/MappedRegisterFileSet.cc
     pipeline/RegisterAliasTable.cc
     pipeline/RenameUnit.cc

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -54,7 +54,7 @@ void CoreInstance::createCore() {
                                                               handleSyscall_);
   } else if (mode_ == SimulationMode::InOrderPipelined) {
     core_ = std::make_shared<simeng::models::inorder::Core>(
-        *arch_, *predictor_, mmu_, handleSyscall_);
+        *arch_, *predictor_, mmu_, *portAllocator_, handleSyscall_);
   } else if (mode_ == SimulationMode::OutOfOrder) {
     core_ = std::make_shared<simeng::models::outoforder::Core>(
         *arch_, *predictor_, mmu_, *portAllocator_, handleSyscall_);

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -97,9 +97,9 @@ Architecture::Architecture() : microDecoder_(std::make_unique<MicroDecoder>()) {
     }
   }
 
-  // ports entries in the groupExecutionInfo_ entries only apply for models
-  // using the outoforder core archetype
-  if (config["Core"]["Simulation-Mode"].as<std::string>() == "outoforder") {
+  // Ports entries in the groupExecutionInfo_ entries only apply for
+  // non-emulation core archetypes
+  if (config["Core"]["Simulation-Mode"].as<std::string>() != "emulation") {
     // Create mapping between instructions groups and the ports that support
     // them
     for (size_t i = 0; i < config["Ports"].size(); i++) {

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -77,9 +77,9 @@ Architecture::Architecture() {
     }
   }
 
-  // ports entries in the groupExecutionInfo_ entries only apply for models
-  // using the outoforder core archetype
-  if (config["Core"]["Simulation-Mode"].as<std::string>() == "outoforder") {
+  // Ports entries in the groupExecutionInfo_ entries only apply for
+  // non-emulation core archetypes
+  if (config["Core"]["Simulation-Mode"].as<std::string>() != "emulation") {
     // Create mapping between instructions groups and the ports that support
     // them
     for (size_t i = 0; i < config["Ports"].size(); i++) {

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -27,11 +27,12 @@ Core::Core(const arch::Architecture& isa, BranchPredictor& branchPredictor,
       loadStoreQueue_(
           config["Queue-Sizes"]["Load"].as<unsigned int>(),
           config["Queue-Sizes"]["Store"].as<unsigned int>(), mmu_,
-          {completionSlots_.data() + config["Execution-Units"].size(), 1},
+          {completionSlots_.data() + config["Execution-Units"].size(),
+           config["Pipeline-Widths"]["LSQ-Completion"].as<unsigned int>()},
           [this](auto regs, auto values) {
             issueUnit_.forwardOperands(regs, values);
           },
-          simeng::pipeline::scheduleBy::ID,
+          simeng::pipeline::completionOrder::INORDER,
           config["LSQ-Memory-Interface"]["Exclusive"].as<bool>(),
           config["LSQ-Memory-Interface"]["Load-Bandwidth"].as<uint16_t>(),
           config["LSQ-Memory-Interface"]["Store-Bandwidth"].as<uint16_t>(),

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -32,14 +32,14 @@ Core::Core(const arch::Architecture& isa, BranchPredictor& branchPredictor,
             issueUnit_.forwardOperands(regs, values);
           },
           simeng::pipeline::scheduleBy::ID,
-          config["LSQ-L1-Interface"]["Exclusive"].as<bool>(),
-          config["LSQ-L1-Interface"]["Load-Bandwidth"].as<uint16_t>(),
-          config["LSQ-L1-Interface"]["Store-Bandwidth"].as<uint16_t>(),
-          config["LSQ-L1-Interface"]["Permitted-Requests-Per-Cycle"]
+          config["LSQ-Memory-Interface"]["Exclusive"].as<bool>(),
+          config["LSQ-Memory-Interface"]["Load-Bandwidth"].as<uint16_t>(),
+          config["LSQ-Memory-Interface"]["Store-Bandwidth"].as<uint16_t>(),
+          config["LSQ-Memory-Interface"]["Permitted-Requests-Per-Cycle"]
               .as<uint16_t>(),
-          config["LSQ-L1-Interface"]["Permitted-Loads-Per-Cycle"]
+          config["LSQ-Memory-Interface"]["Permitted-Loads-Per-Cycle"]
               .as<uint16_t>(),
-          config["LSQ-L1-Interface"]["Permitted-Stores-Per-Cycle"]
+          config["LSQ-Memory-Interface"]["Permitted-Stores-Per-Cycle"]
               .as<uint16_t>()),
       fetchUnit_(fetchToDecodeBuffer_, mmu_,
                  config["Fetch"]["Fetch-Block-Size"].as<uint16_t>(), isa,

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -405,7 +405,8 @@ void Core::retireInstruction(const std::shared_ptr<Instruction>& insn) {
                 insn->getInstructionId() &&
             completedStoreAddrUops_.front()->getMicroOpIndex() ==
                 insn->getMicroOpIndex()) &&
-           "Attempted to complete a store macro-op out of program order");
+           "[SimEng:Core] Attempted to complete a store macro-op out of "
+           "program order");
     loadStoreQueue_.commitStore(completedStoreAddrUops_.front());
     completedStoreAddrUops_.pop();
   }

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -9,31 +9,73 @@ namespace simeng {
 namespace models {
 namespace inorder {
 
-// TODO: Replace with config options
-const unsigned int blockSize = 16;
-
 Core::Core(const arch::Architecture& isa, BranchPredictor& branchPredictor,
            std::shared_ptr<memory::MMU> mmu,
-           arch::sendSyscallToHandler handleSyscall)
+           pipeline::PortAllocator& portAllocator,
+           arch::sendSyscallToHandler handleSyscall, YAML::Node& config)
     : mmu_(mmu),
       isa_(isa),
       registerFileSet_(isa.getRegisterFileStructures()),
       architecturalRegisterFileSet_(registerFileSet_),
       fetchToDecodeBuffer_(1, {}),
-      decodeToExecuteBuffer_(1, nullptr),
-      completionSlots_(1, {1, nullptr}),
-      fetchUnit_(fetchToDecodeBuffer_, mmu_, blockSize, isa, branchPredictor),
-      decodeUnit_(fetchToDecodeBuffer_, decodeToExecuteBuffer_,
-                  branchPredictor),
-      executeUnit_(
-          decodeToExecuteBuffer_, completionSlots_[0],
-          [this](auto regs, auto values) { forwardOperands(regs, values); },
-          [this](auto instruction) { handleLoad(instruction); },
-          [this](auto instruction) { storeData(instruction); },
-          [this](auto instruction) { raiseException(instruction); },
-          branchPredictor, false),
-      writebackUnit_(completionSlots_, registerFileSet_, [](auto insnId) {}),
+      decodeToIssueBuffer_(1, nullptr),
+      issuePorts_(config["Execution-Units"].size(), {1, nullptr}),
+      completionSlots_(
+          config["Execution-Units"].size() +
+              config["Pipeline-Widths"]["LSQ-Completion"].as<unsigned int>(),
+          {1, nullptr}),
+      loadStoreQueue_(
+          config["Queue-Sizes"]["Load"].as<unsigned int>(),
+          config["Queue-Sizes"]["Store"].as<unsigned int>(), mmu_,
+          {completionSlots_.data() + config["Execution-Units"].size(), 1},
+          [this](auto regs, auto values) {
+            issueUnit_.forwardOperands(regs, values);
+          },
+          simeng::pipeline::scheduleBy::ID,
+          config["LSQ-L1-Interface"]["Exclusive"].as<bool>(),
+          config["LSQ-L1-Interface"]["Load-Bandwidth"].as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Store-Bandwidth"].as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Permitted-Requests-Per-Cycle"]
+              .as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Permitted-Loads-Per-Cycle"]
+              .as<uint16_t>(),
+          config["LSQ-L1-Interface"]["Permitted-Stores-Per-Cycle"]
+              .as<uint16_t>()),
+      fetchUnit_(fetchToDecodeBuffer_, mmu_,
+                 config["Fetch"]["Fetch-Block-Size"].as<uint16_t>(), isa,
+                 branchPredictor),
+      decodeUnit_(fetchToDecodeBuffer_, decodeToIssueBuffer_, branchPredictor),
+      staging_(),
+      issueUnit_(
+          decodeToIssueBuffer_, issuePorts_, portAllocator,
+          [this](auto seqId) { staging_.recordIssue(seqId); },
+          [this](auto insn) { raiseException(insn); }, registerFileSet_,
+          isa.getConfigPhysicalRegisterQuantities()),
+      writebackUnit_(
+          completionSlots_, registerFileSet_,
+          [this](auto reg) { issueUnit_.setRegisterReady(reg); },
+          [this](auto seqId) { return staging_.canWriteback(seqId); },
+          [this](auto insn) { retireInstruction(insn); }),
+      portAllocator_(portAllocator),
       handleSyscall_(handleSyscall) {
+  for (size_t i = 0; i < config["Execution-Units"].size(); i++) {
+    // Create vector of blocking groups
+    std::vector<uint16_t> blockingGroups = {};
+    if (config["Execution-Units"][i]["Blocking-Groups"].IsDefined()) {
+      for (YAML::Node gp : config["Execution-Units"][i]["Blocking-Groups"]) {
+        blockingGroups.push_back(gp.as<uint16_t>());
+      }
+    }
+    executionUnits_.emplace_back(
+        issuePorts_[i], completionSlots_[i],
+        [this](auto regs, auto values) {
+          issueUnit_.forwardOperands(regs, values);
+        },
+        [this](auto insn) { handleLoad(insn); },
+        [this](auto insn) { storeData(insn); },
+        [this](auto insn) { raiseException(insn); }, branchPredictor,
+        config["Execution-Units"][i]["Pipelined"].as<bool>(), blockingGroups);
+  }
   // Create exception handler based on chosen architecture
   exceptionHandlerFactory(Config::get()["Core"]["ISA"].as<std::string>());
 }
@@ -49,14 +91,17 @@ void Core::tick() {
     case CoreStatus::switching: {
       // Ensure the pipeline is empty and there's no active exception before
       // context switching.
-      if (fetchToDecodeBuffer_.isEmpty() && decodeToExecuteBuffer_.isEmpty() &&
-          executeUnit_.isEmpty() && completionSlots_[0].isEmpty() &&
+      if (fetchToDecodeBuffer_.isEmpty() && decodeToIssueBuffer_.isEmpty() &&
+          staging_.isEmpty() && !mmu_->hasPendingRequests() &&
           (exceptionGenerated_ == false)) {
         // Flush pipeline
         fetchUnit_.flushLoopBuffer();
         decodeUnit_.purgeFlushed();
-        executeUnit_.flush();
-        previousAddresses_ = std::queue<memory::MemoryAccessTarget>();
+        issueUnit_.flush();
+        staging_.flush();
+        for (auto& eu : executionUnits_) {
+          eu.flush();
+        }
         status_ = CoreStatus::idle;
         return;
       }
@@ -71,10 +116,13 @@ void Core::tick() {
   // Increase tick count for current process execution
   procTicks_++;
 
-  if (exceptionGenerated_) {
+  if (exceptionRegistered_) {
     processException();
     return;
   }
+
+  // Tick port allocator's internal functionality at start of cycle
+  portAllocator_.tick();
 
   // Writeback must be ticked at start of cycle, to ensure decode reads the
   // correct values
@@ -83,41 +131,70 @@ void Core::tick() {
   // Tick units
   fetchUnit_.tick();
   decodeUnit_.tick();
-  executeUnit_.tick();
-
-  // Wipe any data read responses, as they will have been handled by this point
-  // TODO THIS WONT WORK
-  mmu_->clearCompletedReads();
-
-  // Read pending registers for ready-to-execute uop; must happen after execute
-  // to allow operand forwarding to take place first
-  readRegisters();
+  issueUnit_.tick();
+  for (auto& eu : executionUnits_) {
+    eu.tick();
+  }
+  loadStoreQueue_.tick();
 
   // Tick buffers
-  // Each unit must have wiped the entries at the head of the buffer after use,
-  // as these will now loop around and become the tail.
+  // Each unit must have wiped the entries at the head of the buffer after
+  // use, as these will now loop around and become the tail.
   fetchToDecodeBuffer_.tick();
-  decodeToExecuteBuffer_.tick();
-  // Only ever 1 completion slot
-  completionSlots_[0].tick();
+  decodeToIssueBuffer_.tick();
+  for (auto& buffer : issuePorts_) {
+    buffer.tick();
+  }
+  for (auto& buffer : completionSlots_) {
+    buffer.tick();
+  }
 
-  if (exceptionGenerated_) {
-    handleException();
+  if (exceptionGenerated_ && handleException()) {
     fetchUnit_.requestFromPC();
     return;
   }
 
+  flushIfNeeded();
+  fetchUnit_.requestFromPC();
+}
+
+void Core::flushIfNeeded() {
   // Check for flush
-  if (executeUnit_.shouldFlush()) {
+  bool euFlush = false;
+  uint64_t targetAddress = 0;
+  uint64_t lowestSeqId = 0;
+  for (const auto& eu : executionUnits_) {
+    if (eu.shouldFlush() && (!euFlush || eu.getFlushSeqId() < lowestSeqId)) {
+      euFlush = true;
+      lowestSeqId = eu.getFlushSeqId();
+      targetAddress = eu.getFlushAddress();
+    }
+  }
+  if (euFlush) {
     // Flush was requested at execute stage
-    // Update PC and wipe younger buffers (Fetch/Decode, Decode/Execute)
-    auto targetAddress = executeUnit_.getFlushAddress();
+    // Update PC and wipe pipeline buffers
 
     fetchUnit_.flushLoopBuffer();
     fetchUnit_.updatePC(targetAddress);
     fetchToDecodeBuffer_.fill({});
-    decodeToExecuteBuffer_.fill(nullptr);
+    decodeToIssueBuffer_.fill(nullptr);
     decodeUnit_.purgeFlushed();
+    issueUnit_.flush(lowestSeqId);
+    staging_.flush(lowestSeqId);
+    for (auto& port : issuePorts_) {
+      port.fill(nullptr);
+    }
+    // Given instructions can flow out-of-order during execution due to
+    // differing latencies, the completion slots need to be cleared
+    // conditionally based on the sequence IDs
+    for (auto& slot : completionSlots_) {
+      if (slot.getHeadSlots()[0] != nullptr &&
+          slot.getHeadSlots()[0]->getSequenceId() > lowestSeqId)
+        slot.getHeadSlots()[0] = nullptr;
+      if (slot.getTailSlots()[0] != nullptr &&
+          slot.getTailSlots()[0]->getSequenceId() > lowestSeqId)
+        slot.getTailSlots()[0] = nullptr;
+    }
 
     flushes_++;
   } else if (decodeUnit_.shouldFlush()) {
@@ -131,8 +208,6 @@ void Core::tick() {
 
     flushes_++;
   }
-
-  fetchUnit_.requestFromPC();
 }
 
 CoreStatus Core::getStatus() { return status_; }
@@ -166,11 +241,21 @@ std::map<std::string, std::string> Core::getStats() const {
   std::ostringstream ipcStr;
   ipcStr << std::setprecision(2) << ipc;
 
+  auto branchStalls = fetchUnit_.getBranchStalls();
+
+  auto earlyFlushes = decodeUnit_.getEarlyFlushes();
+
+  auto frontendStalls = issueUnit_.getFrontendStalls();
+  auto backendStalls = issueUnit_.getBackendStalls();
+  auto portBusyStalls = issueUnit_.getPortBusyStalls();
+
   // Sum up the branch stats reported across the execution units.
   uint64_t totalBranchesExecuted = 0;
   uint64_t totalBranchMispredicts = 0;
-  totalBranchesExecuted += executeUnit_.getBranchExecutedCount();
-  totalBranchMispredicts += executeUnit_.getBranchMispredictedCount();
+  for (auto& eu : executionUnits_) {
+    totalBranchesExecuted += eu.getBranchExecutedCount();
+    totalBranchMispredicts += eu.getBranchMispredictedCount();
+  }
   auto branchMissRate = 100.0f * static_cast<float>(totalBranchMispredicts) /
                         static_cast<float>(totalBranchesExecuted);
   std::ostringstream branchMissRateStr;
@@ -180,6 +265,13 @@ std::map<std::string, std::string> Core::getStats() const {
           {"retired", std::to_string(retired)},
           {"ipc", ipcStr.str()},
           {"flushes", std::to_string(flushes_)},
+          {"fetch.branchStalls", std::to_string(branchStalls)},
+          {"decode.earlyFlushes", std::to_string(earlyFlushes)},
+          {"branch.executed", std::to_string(totalBranchesExecuted)},
+          {"branch.mispredict", std::to_string(totalBranchMispredicts)},
+          {"issue.frontendStalls", std::to_string(frontendStalls)},
+          {"issue.backendStalls", std::to_string(backendStalls)},
+          {"issue.portBusyStalls", std::to_string(portBusyStalls)},
           {"branch.executed", std::to_string(totalBranchesExecuted)},
           {"branch.mispredict", std::to_string(totalBranchMispredicts)},
           {"branch.missrate", branchMissRateStr.str()},
@@ -187,26 +279,52 @@ std::map<std::string, std::string> Core::getStats() const {
           {"context.switches", std::to_string(contextSwitches_)}};
 }
 
-void Core::raiseException(const std::shared_ptr<Instruction>& instruction) {
+void Core::raiseException(const std::shared_ptr<Instruction>& insn) {
+  // If an exception has already been generated by the pipeline, only replace
+  // the exceptionGeneratingInstruction_ if the passed instruction is younger
+  if (exceptionGenerated_) {
+    if (exceptionGeneratingInstruction_->getSequenceId() <
+        insn->getSequenceId()) {
+      return;
+    }
+  }
   exceptionGenerated_ = true;
-  exceptionGeneratingInstruction_ = instruction;
+  exceptionGeneratingInstruction_ = insn;
 }
 
-void Core::handleException() {
+bool Core::handleException() {
+  // Only handle the generated exception if the associated instruction is the
+  // next one to be written back
+  if (exceptionGeneratingInstruction_->getSequenceId() > staging_.getNextId())
+    return false;
+
   exceptionHandler_->registerException(exceptionGeneratingInstruction_);
+  exceptionRegistered_ = true;
   processException();
 
   // Flush pipeline
+  fetchUnit_.flushLoopBuffer();
   fetchToDecodeBuffer_.fill({});
-  decodeToExecuteBuffer_.fill(nullptr);
+  decodeToIssueBuffer_.fill(nullptr);
   decodeUnit_.purgeFlushed();
-  completionSlots_[0].fill(nullptr);
+  issueUnit_.flush();
+  staging_.flush();
+  for (auto& eu : executionUnits_) {
+    eu.flush();
+  }
+  for (auto& buffer : issuePorts_) {
+    buffer.fill(nullptr);
+  }
+  for (auto& buffer : completionSlots_) {
+    buffer.fill(nullptr);
+  }
+  return true;
 }
 
 void Core::processException() {
-  assert(exceptionGenerated_ != false &&
-         "[SimEng:Core] Attempted to process an exception handler that wasn't "
-         "active");
+  assert(exceptionRegistered_ != false &&
+         "[SimEng:Core] Attempted to process an exception which wasn't "
+         "registered with the handler");
   if (mmu_->hasPendingRequests()) {
     // Must wait for all memory requests to complete before processing the
     // exception
@@ -225,13 +343,9 @@ void Core::processException() {
     status_ = CoreStatus::halted;
     std::cout << "[SimEng:Core] Halting due to fatal exception" << std::endl;
   } else {
-    fetchUnit_.flushLoopBuffer();
     fetchUnit_.updatePC(result.instructionAddress);
     applyStateChange(result.stateChange);
     if (result.idleAfterSyscall) {
-      // Ensure pipeline is flushed
-      executeUnit_.flush();
-      previousAddresses_ = std::queue<memory::MemoryAccessTarget>();
       // Update core status
       status_ = CoreStatus::idle;
       contextSwitches_++;
@@ -239,92 +353,54 @@ void Core::processException() {
   }
 
   exceptionGenerated_ = false;
+  exceptionRegistered_ = false;
 }
 
-void Core::loadData(const std::shared_ptr<Instruction>& instruction) {
-  const auto& addresses = instruction->getGeneratedAddresses();
-  for (const auto& target : addresses) {
-    mmu_->requestRead(target, instruction->getSequenceId());
-  }
-
-  // NOTE: This model only supports zero-cycle data memory models, and will not
-  // work unless data requests are handled synchronously.
-  for (const auto& response : mmu_->getCompletedReads()) {
-    instruction->supplyData(response.target.vaddr, response.data);
-  }
-
-  assert(instruction->hasAllData() &&
-         "[SimEng:Core] Load instruction failed to obtain all data this cycle");
-
-  instruction->execute();
-
-  if (instruction->isStoreData()) {
-    storeData(instruction);
-  }
+void Core::handleLoad(const std::shared_ptr<Instruction>& insn) {
+  // Add the load instruction to the LSQ's load queue and start the load
+  loadStoreQueue_.addLoad(insn);
+  loadStoreQueue_.startLoad(insn);
 }
 
-void Core::storeData(const std::shared_ptr<Instruction>& instruction) {
-  if (instruction->isStoreAddress()) {
-    auto addresses = instruction->getGeneratedAddresses();
-    for (auto const& target : addresses) {
-      previousAddresses_.push(target);
-    }
+void Core::storeData(const std::shared_ptr<Instruction>& insn) {
+  // If the passed store instruction is/contains a store address uop, add thr
+  // store to the LSQ's store queue
+  if (insn->isStoreAddress()) {
+    loadStoreQueue_.addStore(insn);
   }
-  if (instruction->isStoreData()) {
-    const auto data = instruction->getData();
-    for (size_t i = 0; i < data.size(); i++) {
-      mmu_->requestWrite(previousAddresses_.front(), data[i], 0);
-      previousAddresses_.pop();
-    }
-  }
+  // Supply the data to be stored to the recently added store address uop
+  // within the LSQ (a check for whether the passed instruction is/contains a
+  // store data uop is done within the supplyStoreData call)
+  loadStoreQueue_.supplyStoreData(insn);
 }
 
-void Core::forwardOperands(const span<Register>& registers,
-                           const span<RegisterValue>& values) {
-  assert(registers.size() == values.size() &&
-         "[SimEng:Core] Mismatched register and value vector sizes");
-
-  const auto& uop = decodeToExecuteBuffer_.getTailSlots()[0];
-  if (uop == nullptr) {
+void Core::retireInstruction(const std::shared_ptr<Instruction>& insn) {
+  // Raise an exception if the recently written back instruction has generated
+  // one
+  if (insn->exceptionEncountered()) {
+    raiseException(insn);
+    staging_.recordRetired(insn->getSequenceId());
     return;
   }
-
-  auto sourceRegisters = uop->getOperandRegisters();
-  for (size_t i = 0; i < registers.size(); i++) {
-    // Check each forwarded register vs source operands and supply for each
-    // match
-    for (size_t operand = 0; operand < sourceRegisters.size(); operand++) {
-      const auto& sourceReg = sourceRegisters[operand];
-      if (uop->canExecute()) {
-        return;
-      }
-      if (sourceReg == registers[i] && !uop->isOperandReady(operand)) {
-        // Supply the operand
-        uop->supplyOperand(operand, values[i]);
-      }
-    }
-  }
-}
-
-void Core::readRegisters() {
-  if (decodeToExecuteBuffer_.isStalled()) {
-    return;
+  // Carry out any memory based logic
+  // Commit the load within the LSQ
+  if (insn->isLoad()) loadStoreQueue_.commitLoad(insn);
+  // Add the store address uop to the completedStoreAddrUops_ queue to keep an
+  // in program-order list of store address uops
+  if (insn->isStoreAddress()) completedStoreAddrUops_.push(insn);
+  // Commit the store address uop within the LSQ associated with the passed
+  // store data uop
+  if (insn->isStoreData()) {
+    assert((completedStoreAddrUops_.front()->getInstructionId() ==
+                insn->getInstructionId() &&
+            completedStoreAddrUops_.front()->getMicroOpIndex() ==
+                insn->getMicroOpIndex()) &&
+           "Attempted to complete a store macro-op out of program order");
+    loadStoreQueue_.commitStore(completedStoreAddrUops_.front());
+    completedStoreAddrUops_.pop();
   }
 
-  const auto& uop = decodeToExecuteBuffer_.getTailSlots()[0];
-  if (uop == nullptr) {
-    return;
-  }
-
-  // Register read
-  // Identify missing registers and supply values
-  const auto& sourceRegisters = uop->getOperandRegisters();
-  for (size_t i = 0; i < sourceRegisters.size(); i++) {
-    const auto& reg = sourceRegisters[i];
-    if (!uop->isOperandReady(i)) {
-      uop->supplyOperand(i, registerFileSet_.get(reg));
-    }
-  }
+  staging_.recordRetired(insn->getSequenceId());
 }
 
 void Core::applyStateChange(const OS::ProcessStateChange& change) {
@@ -365,19 +441,6 @@ void Core::applyStateChange(const OS::ProcessStateChange& change) {
     mmu_->requestWrite(change.memoryAddresses[i], change.memoryAddressValues[i],
                        0);
   }
-}
-
-void Core::handleLoad(const std::shared_ptr<Instruction>& instruction) {
-  loadData(instruction);
-  if (instruction->exceptionEncountered()) {
-    raiseException(instruction);
-    return;
-  }
-
-  forwardOperands(instruction->getDestinationRegisters(),
-                  instruction->getResults());
-  // Manually add the instruction to the writeback input buffer
-  completionSlots_[0].getTailSlots()[0] = instruction;
 }
 
 void Core::schedule(simeng::OS::cpuContext newContext) {

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -32,7 +32,7 @@ Core::Core(const arch::Architecture& isa, BranchPredictor& branchPredictor,
           [this](auto regs, auto values) {
             issueUnit_.forwardOperands(regs, values);
           },
-          simeng::pipeline::completionOrder::INORDER,
+          simeng::pipeline::CompletionOrder::INORDER,
           config["LSQ-Memory-Interface"]["Exclusive"].as<bool>(),
           config["LSQ-Memory-Interface"]["Load-Bandwidth"].as<uint16_t>(),
           config["LSQ-Memory-Interface"]["Store-Bandwidth"].as<uint16_t>(),

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -177,12 +177,15 @@ void Core::flushIfNeeded() {
     fetchUnit_.flushLoopBuffer();
     fetchUnit_.updatePC(targetAddress);
     fetchToDecodeBuffer_.fill({});
-    decodeToIssueBuffer_.fill(nullptr);
     decodeUnit_.purgeFlushed();
+    decodeToIssueBuffer_.fill(nullptr);
     issueUnit_.flush(lowestSeqId);
-    staging_.flush(lowestSeqId);
     for (auto& port : issuePorts_) {
       port.fill(nullptr);
+    }
+    staging_.flush(lowestSeqId);
+    for (auto& eu : executionUnits_) {
+      eu.seqIdFlush(lowestSeqId);
     }
     // Given instructions can flow out-of-order during execution due to
     // differing latencies, the completion slots need to be cleared

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -44,7 +44,7 @@ Core::Core(const arch::Architecture& isa, BranchPredictor& branchPredictor,
           [this](auto regs, auto values) {
             dispatchIssueUnit_.forwardOperands(regs, values);
           },
-          simeng::pipeline::scheduleBy::LATENCY,
+          simeng::pipeline::completionOrder::OUTOFORDER,
           config["LSQ-Memory-Interface"]["Exclusive"].as<bool>(),
           config["LSQ-Memory-Interface"]["Load-Bandwidth"].as<uint16_t>(),
           config["LSQ-Memory-Interface"]["Store-Bandwidth"].as<uint16_t>(),

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -44,7 +44,7 @@ Core::Core(const arch::Architecture& isa, BranchPredictor& branchPredictor,
           [this](auto regs, auto values) {
             dispatchIssueUnit_.forwardOperands(regs, values);
           },
-          simeng::pipeline::completionOrder::OUTOFORDER,
+          simeng::pipeline::CompletionOrder::OUTOFORDER,
           config["LSQ-Memory-Interface"]["Exclusive"].as<bool>(),
           config["LSQ-Memory-Interface"]["Load-Bandwidth"].as<uint16_t>(),
           config["LSQ-Memory-Interface"]["Store-Bandwidth"].as<uint16_t>(),

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -280,6 +280,7 @@ void Core::handleException() {
   // This must happen prior to handling the exception to ensure the commit
   // state is up-to-date with the register mapping table
   reorderBuffer_.flush(exceptionGeneratingInstruction_->getInstructionId());
+  fetchUnit_.flushLoopBuffer();
   decodeUnit_.purgeFlushed();
   dispatchIssueUnit_.purgeFlushed();
   loadStoreQueue_.purgeFlushed();
@@ -313,7 +314,6 @@ void Core::processException() {
     status_ = CoreStatus::halted;
     std::cout << "[SimEng:Core] Halting due to fatal exception" << std::endl;
   } else {
-    fetchUnit_.flushLoopBuffer();
     fetchUnit_.updatePC(result.instructionAddress);
     applyStateChange(result.stateChange);
     if (result.idleAfterSyscall) {

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -45,10 +45,10 @@ Core::Core(const arch::Architecture& isa, BranchPredictor& branchPredictor,
             dispatchIssueUnit_.forwardOperands(regs, values);
           },
           simeng::pipeline::scheduleBy::LATENCY,
-          config["LSQ-L1-Interface"]["Exclusive"].as<bool>(),
-          config["LSQ-L1-Interface"]["Load-Bandwidth"].as<uint16_t>(),
-          config["LSQ-L1-Interface"]["Store-Bandwidth"].as<uint16_t>(),
-          config["LSQ-L1-Interface"]["Permitted-Requests-Per-Cycle"]
+          config["LSQ-Memory-Interface"]["Exclusive"].as<bool>(),
+          config["LSQ-Memory-Interface"]["Load-Bandwidth"].as<uint16_t>(),
+          config["LSQ-Memory-Interface"]["Store-Bandwidth"].as<uint16_t>(),
+          config["LSQ-Memory-Interface"]["Permitted-Requests-Per-Cycle"]
               .as<uint16_t>(),
           config["LSQ-Memory-Interface"]["Permitted-Loads-Per-Cycle"]
               .as<uint16_t>(),

--- a/src/lib/pipeline/BlockingIssueUnit.cc
+++ b/src/lib/pipeline/BlockingIssueUnit.cc
@@ -154,7 +154,7 @@ void BlockingIssueUnit::tick() {
 void BlockingIssueUnit::forwardOperands(const span<Register>& registers,
                                         const span<RegisterValue>& values) {
   assert(registers.size() == values.size() &&
-         "Mismatched register and value vector sizes");
+         "[SimEng:BlockingIssue] Mismatched register and value vector sizes");
 
   for (size_t i = 0; i < registers.size(); i++) {
     const auto& reg = registers[i];
@@ -164,7 +164,8 @@ void BlockingIssueUnit::forwardOperands(const span<Register>& registers,
       auto& uop = issueQueue_.front();
       uop->supplyOperand(dependency_.second, values[i]);
       assert(uop->getSequenceId() == issueQueue_.front()->getSequenceId() &&
-             "Tried to early issue uop not at front of queue");
+             "[SimEng:BlockingIssue] Tried to early issue uop not at front of "
+             "queue");
       // If the uop is now ready to execute, identify whether it can be issued
       // to avoid pipeline bubbles
       if (issueQueue_.front()->canExecute()) {

--- a/src/lib/pipeline/BlockingIssueUnit.cc
+++ b/src/lib/pipeline/BlockingIssueUnit.cc
@@ -23,7 +23,6 @@ BlockingIssueUnit::BlockingIssueUnit(
       lsq_(lsq),
       raiseException_(raiseException),
       registerFileSet_(registerFileSet) {
-  YAML::Node& config = Config::get();
   // Initialise scoreboard
   for (size_t type = 0; type < physicalRegisterStructure.size(); type++) {
     scoreboard_[type].assign(physicalRegisterStructure[type], {true, -1});

--- a/src/lib/pipeline/BlockingIssueUnit.cc
+++ b/src/lib/pipeline/BlockingIssueUnit.cc
@@ -1,0 +1,252 @@
+#include "simeng/pipeline/BlockingIssueUnit.hh"
+
+#include <algorithm>
+#include <iostream>
+
+namespace simeng {
+namespace pipeline {
+
+BlockingIssueUnit::BlockingIssueUnit(
+    PipelineBuffer<std::shared_ptr<Instruction>>& input,
+    std::vector<PipelineBuffer<std::shared_ptr<Instruction>>>& issuePorts,
+    PortAllocator& portAllocator, std::function<void(uint64_t)> recordIssue,
+    std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
+    const RegisterFileSet& registerFileSet,
+    const std::vector<uint16_t>& physicalRegisterStructure)
+    : input_(input),
+      issuePorts_(issuePorts),
+      portAllocator_(portAllocator),
+      scoreboard_(physicalRegisterStructure.size()),
+      recordIssue_(recordIssue),
+      raiseException_(raiseException),
+      registerFileSet_(registerFileSet) {
+  YAML::Node& config = Config::get();
+  // Initialise scoreboard
+  for (size_t type = 0; type < physicalRegisterStructure.size(); type++) {
+    scoreboard_[type].assign(physicalRegisterStructure[type], {true, -1});
+  }
+}
+
+void BlockingIssueUnit::tick() {
+  input_.stall(false);
+
+  int issued = 0;
+
+  // Iterate over the input buffer and add uops to the issue queue
+  for (size_t slot = 0; slot < input_.getWidth(); slot++) {
+    auto& uop = input_.getHeadSlots()[slot];
+    if (uop == nullptr) {
+      continue;
+    }
+
+    // If the size of the input queue is greater than the number of ports, stall
+    // input to avoid over supply to the issue unit
+    if (issueQueue_.size() < issuePorts_.size()) {
+      issueQueue_.push_back(std::move(uop));
+      input_.getHeadSlots()[slot] = nullptr;
+    } else {
+      input_.stall(true);
+    }
+  }
+
+  while (issueQueue_.size()) {
+    auto& uop = issueQueue_.front();
+    bool ready = true;
+
+    // If a instruction has an exception to raise, record its issue but omit
+    // from sending to an exceution unit as it would be unsafe
+    if (uop->exceptionEncountered()) {
+      recordIssue_(uop->getSequenceId());
+      raiseException_(uop);
+      issueQueue_.pop_front();
+      continue;
+    }
+
+    // Register read
+    // Identify remaining missing registers and supply values
+    auto& sourceRegisters = uop->getOperandRegisters();
+    for (uint16_t i = 0; i < sourceRegisters.size(); i++) {
+      const auto& reg = sourceRegisters[i];
+
+      if (!uop->isOperandReady(i)) {
+        // The operand hasn't already been supplied
+        if (scoreboard_[reg.type][reg.tag].first) {
+          // The scoreboard says it's ready; read and supply the register value
+          uop->supplyOperand(i, registerFileSet_.get(reg));
+        } else {
+          // This register isn't ready yet. Stall the unit until the scoreboard
+          // bit is released
+          input_.stall(true);
+          ready = false;
+          dependent_ = true;
+          dependency_ = {reg, i};
+          break;
+        }
+      }
+    }
+
+    // Check if all destination registers are ready in the scoreboard to enfore
+    // WAW dependencies
+    auto& destinationRegisters = uop->getDestinationRegisters();
+    for (const auto& reg : destinationRegisters) {
+      if (!scoreboard_[reg.type][reg.tag].first) {
+        input_.stall(true);
+        ready = false;
+        break;
+      }
+    }
+
+    // Allocate issue port to uop
+    uint16_t port = portAllocator_.allocate(uop->getSupportedPorts());
+
+    // If the issue port has already been issued to this cycle, break and
+    // continue issue next cycle
+    if (issuePorts_[port].getTailSlots()[0] != nullptr) {
+      input_.stall(true);
+      portBusyStalls_++;
+      ready = false;
+    }
+
+    if (!ready) {
+      // Deallocate port if uop is not ready to issue
+      portAllocator_.deallocate(port);
+      break;
+    }
+
+    // Clear any dependencies for this uop
+    dependent_ = false;
+    dependency_ = {};
+
+    // Set scoreboard for all destination registers as not ready
+    for (const auto& reg : destinationRegisters) {
+      scoreboard_[reg.type][reg.tag] = {false, uop->getSequenceId()};
+    }
+
+    // Record that this uop has been issue and send to an execution unit through
+    // allocated port
+    recordIssue_(uop->getSequenceId());
+    issuePorts_[port].getTailSlots()[0] = std::move(uop);
+    portAllocator_.issued(port);
+
+    issueQueue_.pop_front();
+    issued++;
+  }
+
+  // Record reasoning for zero issuing this cycle
+  if (issued == 0) {
+    if (input_.isStalled())
+      backendStalls_++;
+    else
+      frontendStalls_++;
+  }
+}
+
+void BlockingIssueUnit::forwardOperands(const span<Register>& registers,
+                                        const span<RegisterValue>& values) {
+  assert(registers.size() == values.size() &&
+         "Mismatched register and value vector sizes");
+
+  for (size_t i = 0; i < registers.size(); i++) {
+    const auto& reg = registers[i];
+    // If the forwarded register is one depended on, supply value to uop at
+    // front of issue queue
+    if (dependent_ && reg == dependency_.first) {
+      auto& uop = issueQueue_.front();
+      uop->supplyOperand(dependency_.second, values[i]);
+      assert(uop->getSequenceId() == issueQueue_.front()->getSequenceId() &&
+             "Tried to early issue uop not at front of queue");
+      // If the uop is now ready to execute, identify whether it can be issued
+      // to avoid pipeline bubbles
+      if (issueQueue_.front()->canExecute()) {
+        bool ready = true;
+
+        // Allocate issue port to uop
+        uint16_t port = portAllocator_.allocate(uop->getSupportedPorts());
+
+        // Query whether port is free
+        if (issuePorts_[port].getTailSlots()[0] == nullptr) {
+          auto& destinationRegisters = uop->getDestinationRegisters();
+          // Query whether the destination registers are ready
+          for (const auto& reg : destinationRegisters) {
+            if (!scoreboard_[reg.type][reg.tag].first) {
+              ready = false;
+              break;
+            }
+          }
+        } else {
+          ready = false;
+        }
+
+        // Issue the uop if all required resources are available, else
+        // deallocate the port
+        if (ready) {
+          auto& destinationRegisters = uop->getDestinationRegisters();
+          for (const auto& reg : destinationRegisters) {
+            scoreboard_[reg.type][reg.tag] = {false, uop->getSequenceId()};
+          }
+
+          recordIssue_(uop->getSequenceId());
+          issuePorts_[port].getTailSlots()[0] = std::move(uop);
+          portAllocator_.issued(port);
+
+          issueQueue_.pop_front();
+          input_.stall(false);
+        } else {
+          portAllocator_.deallocate(port);
+        }
+      }
+
+      dependent_ = false;
+      dependency_ = {};
+      break;
+    }
+  }
+}
+
+void BlockingIssueUnit::setRegisterReady(Register reg) {
+  scoreboard_[reg.type][reg.tag] = {true, -1};
+}
+
+uint64_t BlockingIssueUnit::getFrontendStalls() const {
+  return frontendStalls_;
+}
+uint64_t BlockingIssueUnit::getBackendStalls() const { return backendStalls_; }
+uint64_t BlockingIssueUnit::getPortBusyStalls() const {
+  return portBusyStalls_;
+}
+
+void BlockingIssueUnit::flush(uint64_t afterSeqId) {
+  // Set scoreboard entries as ready if they were set as unready by a newer
+  // instruction than the sequence ID passed
+  for (size_t i = 0; i < scoreboard_.size(); i++) {
+    for (size_t j = 0; j < scoreboard_[i].size(); j++) {
+      if (scoreboard_[i][j].second > afterSeqId) {
+        scoreboard_[i][j] = {true, -1};
+      }
+    }
+  }
+
+  // Clear any dependency and the issue queue as the assocaited instructions are
+  // guaranteed to be newer in the program-order
+  dependent_ = false;
+  dependency_ = {};
+  issueQueue_.clear();
+}
+
+void BlockingIssueUnit::flush() {
+  // Set all registers as ready in the scoreboard
+  for (size_t i = 0; i < scoreboard_.size(); i++) {
+    for (size_t j = 0; j < scoreboard_[i].size(); j++) {
+      scoreboard_[i][j] = {true, -1};
+    }
+  }
+
+  // Clear any dependency and the issue queue as the assocaited instructions are
+  // guaranteed to be newer in the program-order
+  dependent_ = false;
+  dependency_ = {};
+  issueQueue_.clear();
+}
+
+}  // namespace pipeline
+}  // namespace simeng

--- a/src/lib/pipeline/BlockingIssueUnit.cc
+++ b/src/lib/pipeline/BlockingIssueUnit.cc
@@ -121,7 +121,7 @@ void BlockingIssueUnit::tick() {
 
     // Set scoreboard for all destination registers as not ready
     for (const auto& reg : destinationRegisters) {
-      scoreboard_[reg.type][reg.tag] = {false, uop->getSequenceId()};
+      scoreboard_[reg.type][reg.tag] = {false, uop->getInstructionId()};
     }
 
     // Record that this uop has been issue and send to an execution unit through
@@ -193,7 +193,7 @@ void BlockingIssueUnit::forwardOperands(const span<Register>& registers,
         if (ready) {
           auto& destinationRegisters = uop->getDestinationRegisters();
           for (const auto& reg : destinationRegisters) {
-            scoreboard_[reg.type][reg.tag] = {false, uop->getSequenceId()};
+            scoreboard_[reg.type][reg.tag] = {false, uop->getInstructionId()};
           }
 
           recordIssue_(uop);
@@ -234,12 +234,12 @@ uint64_t BlockingIssueUnit::getPortBusyStalls() const {
   return portBusyStalls_;
 }
 
-void BlockingIssueUnit::flush(uint64_t afterSeqId) {
+void BlockingIssueUnit::flush(uint64_t afterInsnId) {
   // Set scoreboard entries as ready if they were set as unready by a newer
-  // instruction than the sequence ID passed
+  // instruction than the instruction ID passed
   for (size_t i = 0; i < scoreboard_.size(); i++) {
     for (size_t j = 0; j < scoreboard_[i].size(); j++) {
-      if (scoreboard_[i][j].second > afterSeqId) {
+      if (scoreboard_[i][j].second > afterInsnId) {
         scoreboard_[i][j] = {true, -1};
       }
     }

--- a/src/lib/pipeline/BlockingIssueUnit.cc
+++ b/src/lib/pipeline/BlockingIssueUnit.cc
@@ -120,8 +120,8 @@ void BlockingIssueUnit::tick() {
       scoreboard_[reg.type][reg.tag] = {false, uop->getInstructionId()};
     }
 
-    // Record that this uop has been issue and send to an execution unit through
-    // allocated port
+    // Record that this uop has been issued and send to an execution unit
+    // through allocated port
     recordIssue_(uop);
 
     if (uop->isLoad()) {

--- a/src/lib/pipeline/DispatchIssueUnit.cc
+++ b/src/lib/pipeline/DispatchIssueUnit.cc
@@ -178,8 +178,6 @@ void DispatchIssueUnit::forwardOperands(const span<Register>& registers,
 
   for (size_t i = 0; i < registers.size(); i++) {
     const auto& reg = registers[i];
-    // Flag scoreboard as ready now result is available
-    scoreboard_[reg.type][reg.tag] = true;
 
     // Supply the value to all dependent uops
     auto& dependents = dependencyMatrix_[reg.type][reg.tag];

--- a/src/lib/pipeline/ExecuteUnit.cc
+++ b/src/lib/pipeline/ExecuteUnit.cc
@@ -223,6 +223,56 @@ void ExecuteUnit::purgeFlushed() {
   }
 }
 
+void ExecuteUnit::seqIdFlush(uint64_t afterSeqId) {
+  if (pipeline_.size() == 0) {
+    return;
+  }
+
+  // If the newest instruction has been flushed, clear any stalls.
+  if (pipeline_.back().insn->getSequenceId() > afterSeqId) {
+    stallUntil_ = tickCounter_;
+  }
+
+  // Iterate over the pipeline and remove flushed instructions
+  while (!pipeline_.empty()) {
+    if (pipeline_.back().insn->getSequenceId() <= afterSeqId) {
+      break;
+    }
+    pipeline_.pop_back();
+  }
+
+  // If first blocking in-flight instruction is flushed, ensure another
+  // non-flushed stalled instruction takes it place in the pipeline if
+  // available.
+  bool replace = false;
+  if (operationsStalled_.size() > 0 &&
+      operationsStalled_.front()->getSequenceId() > afterSeqId) {
+    replace = true;
+  }
+  auto itStall = operationsStalled_.begin();
+  while (itStall != operationsStalled_.end()) {
+    auto& entry = *itStall;
+    if (entry->getSequenceId() > afterSeqId) {
+      itStall = operationsStalled_.erase(itStall);
+    } else {
+      itStall++;
+    }
+  }
+
+  if (replace && operationsStalled_.size() > 0) {
+    // Add uop to pipeline
+    auto& uop = operationsStalled_.front();
+    pipeline_.push_back({nullptr, tickCounter_ + uop->getLatency() - 1});
+    pipeline_.back().insn = std::move(uop);
+    operationsStalled_.front() = pipeline_.back().insn;
+  }
+}
+
+void ExecuteUnit::flush() {
+  pipeline_.clear();
+  operationsStalled_.clear();
+}
+
 uint64_t ExecuteUnit::getBranchExecutedCount() const {
   return branchesExecuted_;
 }
@@ -234,11 +284,6 @@ bool ExecuteUnit::isEmpty() {
   // Execution unit is considered empty if no instructions are present in the
   // pipeline_ and operationsStalled_ queues
   return !(pipeline_.size() != 0 || operationsStalled_.size() != 0);
-}
-
-void ExecuteUnit::flush() {
-  pipeline_.clear();
-  operationsStalled_.clear();
 }
 
 uint64_t ExecuteUnit::getCycles() const { return cycles_; }

--- a/src/lib/pipeline/InOrderStager.cc
+++ b/src/lib/pipeline/InOrderStager.cc
@@ -23,7 +23,7 @@ bool InOrderStager::canWriteback(uint64_t seqId) const {
   return false;
 }
 
-uint64_t InOrderStager::getNextId() const {
+uint64_t InOrderStager::getNextSeqID() const {
   // Return the next sequence ID that can undergo writeback logic, return -1 if
   // none exist
   if (issueOrderQueue_.size()) return issueOrderQueue_.front()->getSequenceId();
@@ -37,11 +37,11 @@ void InOrderStager::recordRetired(uint64_t seqId) {
   issueOrderQueue_.pop_front();
 }
 
-void InOrderStager::flush(uint64_t afterSeqId) {
+void InOrderStager::flush(uint64_t afterInsnId) {
   // Iterate backwards from the tail of the queue to find and remove entires
   // newer than `afterInsnId`
   while (!issueOrderQueue_.empty()) {
-    if (issueOrderQueue_.back()->getSequenceId() <= afterSeqId) {
+    if (issueOrderQueue_.back()->getInstructionId() <= afterInsnId) {
       break;
     }
     issueOrderQueue_.back()->setFlushed();

--- a/src/lib/pipeline/InOrderStager.cc
+++ b/src/lib/pipeline/InOrderStager.cc
@@ -1,0 +1,57 @@
+#include "simeng/pipeline/InOrderStager.hh"
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+namespace simeng {
+namespace pipeline {
+
+InOrderStager::InOrderStager() {}
+
+void InOrderStager::recordIssue(uint64_t seqId) {
+  // Add sequence id to buffer
+  issueOrderQueue_.push_back(seqId);
+}
+
+bool InOrderStager::canWriteback(uint64_t seqId) const {
+  // The associated instruction is considered to be ready for writeback if its
+  // sequence ID is at the front of the tracking queue
+  if (issueOrderQueue_.size() && issueOrderQueue_.front() == seqId) return true;
+  return false;
+}
+
+uint64_t InOrderStager::getNextId() const {
+  // Return the next sequence ID that can undergo writeback logic, return -1 if
+  // none exist
+  if (issueOrderQueue_.size()) return issueOrderQueue_.front();
+  return -1;
+}
+
+void InOrderStager::recordRetired(uint64_t seqId) {
+  assert(issueOrderQueue_.front() == seqId &&
+         "Tried to record a retirement out of program order");
+  // Remove sequence ID from the tracking queue
+  issueOrderQueue_.pop_front();
+}
+
+void InOrderStager::flush(uint64_t afterSeqId) {
+  // Iterate backwards from the tail of the queue to find and remove entires
+  // newer than `afterInsnId`
+  while (!issueOrderQueue_.empty()) {
+    if (issueOrderQueue_.back() <= afterSeqId) {
+      break;
+    }
+    issueOrderQueue_.pop_back();
+  }
+}
+
+void InOrderStager::flush() {
+  // Clear tracking queue in response to pipeline flush
+  issueOrderQueue_.clear();
+}
+
+bool InOrderStager::isEmpty() const { return issueOrderQueue_.empty(); }
+
+}  // namespace pipeline
+}  // namespace simeng

--- a/src/lib/pipeline/InOrderStager.cc
+++ b/src/lib/pipeline/InOrderStager.cc
@@ -9,27 +9,29 @@ namespace pipeline {
 
 InOrderStager::InOrderStager() {}
 
-void InOrderStager::recordIssue(uint64_t seqId) {
-  // Add sequence id to buffer
-  issueOrderQueue_.push_back(seqId);
+void InOrderStager::recordIssue(const std::shared_ptr<Instruction>& insn) {
+  // Add instruction to buffer
+  issueOrderQueue_.push_back(insn);
 }
 
 bool InOrderStager::canWriteback(uint64_t seqId) const {
   // The associated instruction is considered to be ready for writeback if its
   // sequence ID is at the front of the tracking queue
-  if (issueOrderQueue_.size() && issueOrderQueue_.front() == seqId) return true;
+  if (issueOrderQueue_.size() &&
+      issueOrderQueue_.front()->getSequenceId() == seqId)
+    return true;
   return false;
 }
 
 uint64_t InOrderStager::getNextId() const {
   // Return the next sequence ID that can undergo writeback logic, return -1 if
   // none exist
-  if (issueOrderQueue_.size()) return issueOrderQueue_.front();
+  if (issueOrderQueue_.size()) return issueOrderQueue_.front()->getSequenceId();
   return -1;
 }
 
 void InOrderStager::recordRetired(uint64_t seqId) {
-  assert(issueOrderQueue_.front() == seqId &&
+  assert(issueOrderQueue_.front()->getSequenceId() == seqId &&
          "Tried to record a retirement out of program order");
   // Remove sequence ID from the tracking queue
   issueOrderQueue_.pop_front();
@@ -39,16 +41,20 @@ void InOrderStager::flush(uint64_t afterSeqId) {
   // Iterate backwards from the tail of the queue to find and remove entires
   // newer than `afterInsnId`
   while (!issueOrderQueue_.empty()) {
-    if (issueOrderQueue_.back() <= afterSeqId) {
+    if (issueOrderQueue_.back()->getSequenceId() <= afterSeqId) {
       break;
     }
+    issueOrderQueue_.back()->setFlushed();
     issueOrderQueue_.pop_back();
   }
 }
 
 void InOrderStager::flush() {
   // Clear tracking queue in response to pipeline flush
-  issueOrderQueue_.clear();
+  while (!issueOrderQueue_.empty()) {
+    issueOrderQueue_.front()->setFlushed();
+    issueOrderQueue_.pop_front();
+  }
 }
 
 bool InOrderStager::isEmpty() const { return issueOrderQueue_.empty(); }

--- a/src/lib/pipeline/InOrderStager.cc
+++ b/src/lib/pipeline/InOrderStager.cc
@@ -32,7 +32,8 @@ uint64_t InOrderStager::getNextSeqID() const {
 
 void InOrderStager::recordRetired(uint64_t seqId) {
   assert(issueOrderQueue_.front()->getSequenceId() == seqId &&
-         "Tried to record a retirement out of program order");
+         "[SimEng:InOrderStager] Tried to record a retirement out of program "
+         "order");
   // Remove sequence ID from the tracking queue
   issueOrderQueue_.pop_front();
 }

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -21,7 +21,7 @@ LoadStoreQueue::LoadStoreQueue(
     unsigned int maxCombinedSpace, std::shared_ptr<memory::MMU> mmu,
     span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
     std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
-    completionOrder completionOrder, bool exclusive, uint16_t loadBandwidth,
+    CompletionOrder completionOrder, bool exclusive, uint16_t loadBandwidth,
     uint16_t storeBandwidth, uint16_t permittedRequests,
     uint16_t permittedLoads, uint16_t permittedStores)
     : completionSlots_(completionSlots),
@@ -42,7 +42,7 @@ LoadStoreQueue::LoadStoreQueue(
     std::shared_ptr<memory::MMU> mmu,
     span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
     std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
-    completionOrder completionOrder, bool exclusive, uint16_t loadBandwidth,
+    CompletionOrder completionOrder, bool exclusive, uint16_t loadBandwidth,
     uint16_t storeBandwidth, uint16_t permittedRequests,
     uint16_t permittedLoads, uint16_t permittedStores)
     : completionSlots_(completionSlots),
@@ -107,7 +107,7 @@ void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
   } else {
     // If the completion order is inorder, reserve an entry in completedLoads_
     // now
-    if (completionOrder_ == completionOrder::INORDER)
+    if (completionOrder_ == CompletionOrder::INORDER)
       completedLoads_.push(insn);
 
     // Create a speculative entry for the load
@@ -266,7 +266,7 @@ bool LoadStoreQueue::commitStore(const std::shared_ptr<Instruction>& insn) {
               supplyStoreData(load);
             }
             // If the completion order is OoO, add entry to completedLoads_
-            if (completionOrder_ == completionOrder::OUTOFORDER)
+            if (completionOrder_ == CompletionOrder::OUTOFORDER)
               completedLoads_.push(load);
           }
         }
@@ -522,7 +522,7 @@ void LoadStoreQueue::tick() {
         supplyStoreData(load);
       }
       // If the completion order is OoO, add entry to completedLoads_
-      if (completionOrder_ == completionOrder::OUTOFORDER)
+      if (completionOrder_ == CompletionOrder::OUTOFORDER)
         completedLoads_.push(load);
     }
   }

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -100,13 +100,16 @@ void LoadStoreQueue::addStore(const std::shared_ptr<Instruction>& insn) {
 
 void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
   const auto& ld_addresses = insn->getGeneratedAddresses();
-  // If the completion order is inorder, reserve an entry in completedLoads_ now
-  if (completionOrder_ == completionOrder::INORDER) completedLoads_.push(insn);
-
   if (ld_addresses.size() == 0) {
     // Early execution if not addresses need to be accessed
     insn->execute();
+    completedLoads_.push(insn);
   } else {
+    // If the completion order is inorder, reserve an entry in completedLoads_
+    // now
+    if (completionOrder_ == completionOrder::INORDER)
+      completedLoads_.push(insn);
+
     // Create a speculative entry for the load
     requestLoadQueue_[tickCounter_ + insn->getLSQLatency()].push_back(
         {{}, insn});

--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -154,12 +154,12 @@ unsigned int ReorderBuffer::commit(unsigned int maxCommitSize) {
   return n;
 }
 
-void ReorderBuffer::flush(uint64_t afterSeqId) {
+void ReorderBuffer::flush(uint64_t afterInsnId) {
   // Iterate backwards from the tail of the queue to find and remove ops newer
-  // than `afterSeqId`
+  // than `afterInsnId`
   while (!buffer_.empty()) {
     auto& uop = buffer_.back();
-    if (uop->getInstructionId() <= afterSeqId) {
+    if (uop->getInstructionId() <= afterInsnId) {
       break;
     }
 
@@ -199,7 +199,7 @@ unsigned int ReorderBuffer::getFreeSpace() const {
 
 bool ReorderBuffer::shouldFlush() const { return shouldFlush_; }
 uint64_t ReorderBuffer::getFlushAddress() const { return pc_; }
-uint64_t ReorderBuffer::getFlushSeqId() const { return flushAfter_; }
+uint64_t ReorderBuffer::getFlushInsnId() const { return flushAfter_; }
 
 uint64_t ReorderBuffer::getInstructionsCommittedCount() const {
   return instructionsCommitted_;

--- a/src/lib/pipeline/WritebackUnit.cc
+++ b/src/lib/pipeline/WritebackUnit.cc
@@ -21,6 +21,8 @@ void WritebackUnit::tick() {
   for (size_t slot = 0; slot < completionSlots_.size(); slot++) {
     auto& uop = completionSlots_[slot].getHeadSlots()[0];
 
+    completionSlots_[slot].stall(false);
+
     if (uop == nullptr) {
       continue;
     }
@@ -30,7 +32,6 @@ void WritebackUnit::tick() {
       completionSlots_[slot].stall(true);
       continue;
     }
-    completionSlots_[slot].stall(false);
 
     auto& results = uop->getResults();
     auto& destinations = uop->getDestinationRegisters();

--- a/test/regression/RegressionTest.cc
+++ b/test/regression/RegressionTest.cc
@@ -83,7 +83,8 @@ void RegressionTest::run(const char* source, const char* triple,
       break;
     case INORDER:
       core_ = std::make_shared<simeng::models::inorder::Core>(
-          *architecture_, predictor, mmu, OS.getSyscallReceiver());
+          *architecture_, predictor, mmu, *portAllocator,
+          OS.getSyscallReceiver());
       break;
     case OUTOFORDER:
       core_ = std::make_shared<simeng::models::outoforder::Core>(

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_SOURCES
     pipeline/DecodeUnitTest.cc
     pipeline/ExecuteUnitTest.cc
     pipeline/FetchUnitTest.cc
+    pipeline/InOrderStagerTest.cc
     pipeline/LoadStoreQueueTest.cc
     pipeline/PipelineBufferTest.cc
     pipeline/RegisterAliasTableTest.cc

--- a/test/unit/MockInstruction.hh
+++ b/test/unit/MockInstruction.hh
@@ -54,6 +54,8 @@ class MockInstruction : public Instruction {
 
   void setLatency(uint16_t cycles) { latency_ = cycles; }
 
+  void setLSQLatency(uint16_t cycles) { lsqExecutionLatency_ = cycles; }
+
   void setStallCycles(uint16_t cycles) { stallCycles_ = cycles; }
 };
 

--- a/test/unit/pipeline/BlockingIssueTest.cc
+++ b/test/unit/pipeline/BlockingIssueTest.cc
@@ -1,0 +1,234 @@
+#include <memory>
+
+#include "../MockInstruction.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "simeng/Instruction.hh"
+#include "simeng/pipeline/BalancedPortAllocator.hh"
+#include "simeng/pipeline/BlockingIssueUnit.hh"
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Property;
+using ::testing::Return;
+
+namespace simeng {
+namespace pipeline {
+
+const uint8_t MAX_LOADS = 32;
+const uint8_t MAX_STORES = 32;
+
+class PipelineBlockingIssueTest : public testing::Test {
+ public:
+  PipelineBlockingIssueTest()
+      : input(2, nullptr),
+        output({{1, nullptr}, {1, nullptr}}),
+        registerFileSet({{8, 32}}),
+        physicalRegisterStructure({32}),
+        blockingIssueUnit(
+            input, output, *portAllocator, [](auto insn) {}, lsq,
+            [](auto insn) {}, registerFileSet, physicalRegisterStructure),
+        uop(new MockInstruction),
+        uopPtr(uop),
+        uop2(new MockInstruction),
+        uopPtr2(uop2),
+        supportedPorts({0, 1}) {
+    ON_CALL(*uop, getSupportedPorts())
+        .WillByDefault(Invoke([this]() -> const std::vector<uint16_t>& {
+          return supportedPorts;
+        }));
+    ON_CALL(*uop2, getSupportedPorts())
+        .WillByDefault(Invoke([this]() -> const std::vector<uint16_t>& {
+          return supportedPorts;
+        }));
+  }
+
+ protected:
+  PipelineBuffer<std::shared_ptr<Instruction>> input;
+  std::vector<PipelineBuffer<std::shared_ptr<Instruction>>> output;
+  std::vector<std::vector<uint16_t>> portArrangement = {{0}, {1}};
+  std::unique_ptr<PortAllocator> portAllocator =
+      std::make_unique<BalancedPortAllocator>(portArrangement);
+
+  VAddrTranslator fn = [](uint64_t vaddr, uint64_t pid) -> uint64_t {
+    return vaddr;
+  };
+  std::shared_ptr<memory::MMU> mmu = std::make_shared<memory::MMU>(fn);
+  std::vector<pipeline::PipelineBuffer<std::shared_ptr<Instruction>>>
+      completionSlots = {{1, nullptr}};
+  LoadStoreQueue lsq =
+      LoadStoreQueue(MAX_LOADS, MAX_STORES, mmu,
+                     {completionSlots.data(), completionSlots.size()},
+                     [this](auto regs, auto values) {
+                       blockingIssueUnit.forwardOperands(regs, values);
+                     });
+
+  const RegisterFileSet registerFileSet;
+  const std::vector<uint16_t> physicalRegisterStructure;
+
+  BlockingIssueUnit blockingIssueUnit;
+
+  MockInstruction* uop;
+  std::shared_ptr<Instruction> uopPtr;
+  MockInstruction* uop2;
+  std::shared_ptr<Instruction> uopPtr2;
+
+  const std::vector<uint16_t> supportedPorts;
+};
+
+// Tests that the blockingIssue unit output remains empty when an empty uop
+// is present
+TEST_F(PipelineBlockingIssueTest, TickEmpty) {
+  blockingIssueUnit.tick();
+
+  EXPECT_EQ(output[0].getTailSlots()[0], nullptr);
+}
+
+// Tests that the blockingIssue unit output is correctly populated when supplied
+// with two uops
+TEST_F(PipelineBlockingIssueTest, Tick) {
+  input.getHeadSlots()[0] = {uopPtr};
+  input.getHeadSlots()[1] = {uopPtr2};
+
+  std::vector<Register> uopSrcOps = {{0, 0}};
+  const span<Register> uopSrcSpan(uopSrcOps.data(), uopSrcOps.size());
+  std::vector<Register> uop2SrcOps = {{0, 1}};
+  const span<Register> uop2SrcSpan(uop2SrcOps.data(), uop2SrcOps.size());
+
+  EXPECT_CALL(*uop, getOperandRegisters()).WillRepeatedly(Return(uopSrcSpan));
+  EXPECT_CALL(*uop2, getOperandRegisters()).WillRepeatedly(Return(uop2SrcSpan));
+
+  EXPECT_CALL(*uop, isOperandReady(_)).WillRepeatedly(Return(true));
+  EXPECT_CALL(*uop2, isOperandReady(_)).WillRepeatedly(Return(true));
+
+  blockingIssueUnit.tick();
+  output[0].tick();
+  blockingIssueUnit.tick();
+  EXPECT_EQ(input.getHeadSlots()[0].get(), nullptr);
+  EXPECT_EQ(input.getHeadSlots()[1].get(), nullptr);
+  EXPECT_EQ(output[0].getHeadSlots()[0].get(), uop);
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), uop2);
+}
+
+// Tests that the blockingIssue unit output is correctly populated when supplied
+// with two uops with a RAW dependency
+TEST_F(PipelineBlockingIssueTest, TickWithRAW) {
+  input.getHeadSlots()[0] = {uopPtr};
+  input.getHeadSlots()[1] = {uopPtr2};
+
+  // Setup operands to create a RAW dependency
+  std::vector<Register> uopDestOps = {{0, 0}};
+  const span<Register> uopDestSpan(uopDestOps.data(), uopDestOps.size());
+  std::vector<Register> uop2SrcOps = {{0, 0}, {0, 1}, {0, 2}};
+  const span<Register> uop2SrcSpan(uop2SrcOps.data(), uop2SrcOps.size());
+  std::vector<Register> otherSrcOps = {{0, 4}, {0, 5}, {0, 6}};
+  const span<Register> otherSrcSpan(otherSrcOps.data(), otherSrcOps.size());
+
+  EXPECT_CALL(*uop, getDestinationRegisters())
+      .WillRepeatedly(Return(uopDestSpan));
+  EXPECT_CALL(*uop2, getOperandRegisters()).WillRepeatedly(Return(uop2SrcSpan));
+
+  EXPECT_CALL(*uop, isOperandReady(_)).WillRepeatedly(Return(true));
+  EXPECT_CALL(*uop2, isOperandReady(0)).WillRepeatedly(Return(false));
+  EXPECT_CALL(*uop2, isOperandReady(1)).WillRepeatedly(Return(true));
+  EXPECT_CALL(*uop2, isOperandReady(2)).WillRepeatedly(Return(true));
+
+  blockingIssueUnit.tick();
+  output[0].tick();
+  blockingIssueUnit.tick();
+  EXPECT_EQ(input.getHeadSlots()[0].get(), nullptr);
+  EXPECT_EQ(input.getHeadSlots()[1].get(), nullptr);
+  EXPECT_EQ(output[0].getHeadSlots()[0].get(), uop);
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), nullptr);
+  EXPECT_CALL(*uop2, canExecute()).Times(1).WillOnce(Return(true));
+
+  // Resolve RAW
+  std::vector<RegisterValue> vals1 = {{1, 8}};
+  const span<RegisterValue> val1Span(vals1.data(), vals1.size());
+  std::vector<RegisterValue> vals3 = {{1, 8}, {2, 8}, {3, 8}};
+  const span<RegisterValue> val3Span(vals3.data(), vals3.size());
+
+  blockingIssueUnit.forwardOperands(otherSrcSpan, val3Span);
+  blockingIssueUnit.tick();
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), nullptr);
+
+  blockingIssueUnit.forwardOperands(uopDestSpan, val1Span);
+  blockingIssueUnit.tick();
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), uop2);
+}
+
+// Tests that the blockingIssue unit output is correctly populated when supplied
+// with two uops with a WAW dependency
+TEST_F(PipelineBlockingIssueTest, TickWithWAW) {
+  input.getHeadSlots()[0] = {uopPtr};
+  input.getHeadSlots()[1] = {uopPtr2};
+
+  // Setup operands to create a WAW dependency
+  std::vector<Register> uopDestOps = {{0, 0}, {0, 1}, {0, 2}};
+  const span<Register> uopDestSpan(uopDestOps.data(), uopDestOps.size());
+  std::vector<Register> uop2DestOps = {{0, 1}};
+  const span<Register> uop2DestSpan(uop2DestOps.data(), uop2DestOps.size());
+
+  EXPECT_CALL(*uop, getDestinationRegisters())
+      .WillRepeatedly(Return(uopDestSpan));
+  EXPECT_CALL(*uop2, getDestinationRegisters())
+      .WillRepeatedly(Return(uop2DestSpan));
+
+  blockingIssueUnit.tick();
+  output[0].tick();
+  blockingIssueUnit.tick();
+  EXPECT_EQ(input.getHeadSlots()[0].get(), nullptr);
+  EXPECT_EQ(input.getHeadSlots()[1].get(), nullptr);
+  EXPECT_EQ(output[0].getHeadSlots()[0].get(), uop);
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), nullptr);
+  blockingIssueUnit.tick();
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), nullptr);
+
+  // Resolve WAW
+  blockingIssueUnit.setRegisterReady({0, 1});
+  blockingIssueUnit.tick();
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), uop2);
+}
+
+// Tests that the blockingIssue unit flushing is correct
+TEST_F(PipelineBlockingIssueTest, FlushAfterId) {
+  uop->setInstructionId(1);
+  uop2->setInstructionId(2);
+
+  input.getHeadSlots()[0] = {uopPtr};
+  input.getHeadSlots()[1] = {uopPtr2};
+
+  // Register a RAW and WAW dependency to prevent uop2 exiting the unit
+  std::vector<Register> uopDestOps = {{0, 0}, {0, 1}, {0, 2}};
+  const span<Register> uopDestSpan(uopDestOps.data(), uopDestOps.size());
+  std::vector<Register> uop2DestOps = {{0, 1}};
+  const span<Register> uop2DestSpan(uop2DestOps.data(), uop2DestOps.size());
+  std::vector<Register> uop2SrcOps = {{0, 0}};
+  const span<Register> uop2SrcSpan(uop2SrcOps.data(), uop2SrcOps.size());
+
+  EXPECT_CALL(*uop, getDestinationRegisters())
+      .WillRepeatedly(Return(uopDestSpan));
+  EXPECT_CALL(*uop2, getDestinationRegisters())
+      .WillRepeatedly(Return(uop2DestSpan));
+  EXPECT_CALL(*uop2, getOperandRegisters()).WillRepeatedly(Return(uop2SrcSpan));
+
+  blockingIssueUnit.tick();
+  output[0].tick();
+  blockingIssueUnit.tick();
+  EXPECT_EQ(input.getHeadSlots()[0].get(), nullptr);
+  EXPECT_EQ(input.getHeadSlots()[1].get(), nullptr);
+  EXPECT_EQ(output[0].getHeadSlots()[0].get(), uop);
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), nullptr);
+
+  blockingIssueUnit.flush(0);
+  // After the flush, all dependencies should be wiped and thus uop2 can exit
+  // the unit
+  blockingIssueUnit.tick();
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), nullptr);
+  input.getHeadSlots()[0] = {uopPtr2};
+  blockingIssueUnit.tick();
+  EXPECT_EQ(output[0].getTailSlots()[0].get(), uop2);
+}
+
+}  // namespace pipeline
+}  // namespace simeng

--- a/test/unit/pipeline/InOrderStagerTest.cc
+++ b/test/unit/pipeline/InOrderStagerTest.cc
@@ -1,0 +1,83 @@
+#include <memory>
+
+#include "../MockInstruction.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "simeng/Instruction.hh"
+#include "simeng/pipeline/BalancedPortAllocator.hh"
+#include "simeng/pipeline/BlockingIssueUnit.hh"
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Property;
+using ::testing::Return;
+
+namespace simeng {
+namespace pipeline {
+
+const uint8_t MAX_LOADS = 32;
+const uint8_t MAX_STORES = 32;
+
+class PipelineInOrderStagerTest : public testing::Test {
+ public:
+  PipelineInOrderStagerTest()
+      : inOrderStagerUnit(),
+        uop(new MockInstruction),
+        uopPtr(uop),
+        uop2(new MockInstruction),
+        uopPtr2(uop2) {
+    uop->setInstructionId(1);
+    uop->setSequenceId(1);
+    uop2->setInstructionId(2);
+    uop2->setSequenceId(2);
+    ON_CALL(*uop, getSupportedPorts())
+        .WillByDefault(Invoke([this]() -> const std::vector<uint16_t>& {
+          return supportedPorts;
+        }));
+    ON_CALL(*uop2, getSupportedPorts())
+        .WillByDefault(Invoke([this]() -> const std::vector<uint16_t>& {
+          return supportedPorts;
+        }));
+  }
+
+ protected:
+  InOrderStager inOrderStagerUnit;
+
+  MockInstruction* uop;
+  std::shared_ptr<Instruction> uopPtr;
+  MockInstruction* uop2;
+  std::shared_ptr<Instruction> uopPtr2;
+
+  const std::vector<uint16_t> supportedPorts;
+};
+
+// Tests that the InOrder Stager unit records/tracks issued instructions
+// correctly
+TEST_F(PipelineInOrderStagerTest, RecordIssue) {
+  inOrderStagerUnit.recordIssue(uopPtr);
+  inOrderStagerUnit.recordIssue(uopPtr2);
+
+  EXPECT_EQ(inOrderStagerUnit.getNextSeqID(), 1);
+  EXPECT_EQ(inOrderStagerUnit.canWriteback(uop->getSequenceId()), true);
+  EXPECT_EQ(inOrderStagerUnit.canWriteback(uop2->getSequenceId()), false);
+  inOrderStagerUnit.recordRetired(uop->getSequenceId());
+  EXPECT_EQ(inOrderStagerUnit.getNextSeqID(), 2);
+  EXPECT_EQ(inOrderStagerUnit.canWriteback(uop2->getSequenceId()), true);
+}
+
+// Tests that the InOrder Stager unit records/tracks issued instructions
+// correctly
+TEST_F(PipelineInOrderStagerTest, Flush) {
+  inOrderStagerUnit.recordIssue(uopPtr);
+  inOrderStagerUnit.recordIssue(uopPtr2);
+  inOrderStagerUnit.flush();
+  EXPECT_EQ(inOrderStagerUnit.getNextSeqID(), -1);
+
+  inOrderStagerUnit.recordIssue(uopPtr);
+  inOrderStagerUnit.recordIssue(uopPtr2);
+  inOrderStagerUnit.flush(uop->getInstructionId());
+  EXPECT_EQ(inOrderStagerUnit.getNextSeqID(), uop->getSequenceId());
+}
+
+}  // namespace pipeline
+}  // namespace simeng

--- a/test/unit/pipeline/InOrderStagerTest.cc
+++ b/test/unit/pipeline/InOrderStagerTest.cc
@@ -65,8 +65,7 @@ TEST_F(PipelineInOrderStagerTest, RecordIssue) {
   EXPECT_EQ(inOrderStagerUnit.canWriteback(uop2->getSequenceId()), true);
 }
 
-// Tests that the InOrder Stager unit records/tracks issued instructions
-// correctly
+// Tests that the InOrder Stager unit flush logic is correct
 TEST_F(PipelineInOrderStagerTest, Flush) {
   inOrderStagerUnit.recordIssue(uopPtr);
   inOrderStagerUnit.recordIssue(uopPtr2);

--- a/test/unit/pipeline/LoadStoreQueueTest.cc
+++ b/test/unit/pipeline/LoadStoreQueueTest.cc
@@ -483,7 +483,7 @@ TEST_P(LoadStoreQueueTest, inOrderCompletion) {
       completionSlots(2, {1, nullptr});
   LoadStoreQueue queue = LoadStoreQueue(
       MAX_LOADS, MAX_STORES, mmu, {completionSlots.data(), 2},
-      [](auto registers, auto values) {}, completionOrder::INORDER);
+      [](auto registers, auto values) {}, CompletionOrder::INORDER);
   loadUop->setSequenceId(0);
   loadUop2->setSequenceId(1);
   loadUop->setLSQLatency(3);
@@ -513,7 +513,7 @@ TEST_P(LoadStoreQueueTest, OoOCompletion) {
       completionSlots(1, {1, nullptr});
   LoadStoreQueue queue = LoadStoreQueue(
       MAX_LOADS, MAX_STORES, mmu, {completionSlots.data(), 1},
-      [](auto registers, auto values) {}, completionOrder::OUTOFORDER);
+      [](auto registers, auto values) {}, CompletionOrder::OUTOFORDER);
   loadUop->setSequenceId(0);
   loadUop2->setSequenceId(1);
   loadUop->setLSQLatency(3);

--- a/test/unit/pipeline/WritebackUnitTest.cc
+++ b/test/unit/pipeline/WritebackUnitTest.cc
@@ -22,7 +22,9 @@ class PipelineWritebackUnitTest : public testing::Test {
         registerFileSet({{8, 2}}),
         uop(new MockInstruction),
         uopPtr(uop),
-        writebackUnit(input, registerFileSet, [](auto insnId) {}) {}
+        writebackUnit(
+            input, registerFileSet, [](auto reg) {},
+            [](auto seqId) { return true; }, [](auto uop) {}) {}
 
  protected:
   std::vector<PipelineBuffer<std::shared_ptr<Instruction>>> input;


### PR DESCRIPTION
Within this PR, fixes to the use of the InOrder core have been made to allow for its compatibility with multi-cycle memory accesses and multiple execution units.

Two new pipeline units have been introduced, a blocking issue unit and an inorder stager. The first is similar to the dispatch/issue unit but forces inorder issuing and the latter is similar to the ROB but far more simplified and serves to track the order in which instructions are issued.