### PR TITLE
Unaigned PC exception fix

### DIFF
--- a/src/include/simeng/OS/Process.hh
+++ b/src/include/simeng/OS/Process.hh
@@ -40,7 +40,7 @@ struct cpuContext {
   uint64_t pc;
   // SP only used in process construction. Actual value lives in regFile
   uint64_t sp;
-  uint64_t progByteLen;
+  uint64_t dataSectionEnd;
   std::vector<std::vector<RegisterValue>> regFile;
 };
 

--- a/src/lib/OS/Process.cc
+++ b/src/lib/OS/Process.cc
@@ -396,7 +396,7 @@ void Process::initContext(
   context_.TID = TID_;
   context_.pc = entryPoint_;
   context_.sp = stackPtr;
-  context_.progByteLen = getProcessImageSize();
+  context_.dataSectionEnd = getHeapStart();
   // Initialise all registers to 0
   size_t numTypes = regFileStructure.size();
   context_.regFile.reserve(numTypes);

--- a/src/lib/OS/Process.cc
+++ b/src/lib/OS/Process.cc
@@ -396,7 +396,8 @@ void Process::initContext(
   context_.TID = TID_;
   context_.pc = entryPoint_;
   context_.sp = stackPtr;
-  context_.dataSectionEnd = getHeapStart();
+  // Remove padding (equal to PAGE_SIZE) from heapStart to get .data end
+  context_.dataSectionEnd = getHeapStart() - PAGE_SIZE;
   // Initialise all registers to 0
   size_t numTypes = regFileStructure.size();
   context_.regFile.reserve(numTypes);

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -326,7 +326,7 @@ std::map<std::string, std::string> Core::getStats() const {
 
 void Core::schedule(simeng::OS::cpuContext newContext) {
   currentTID_ = newContext.TID;
-  programByteLength_ = newContext.progByteLen;
+  programByteLength_ = newContext.dataSectionEnd;
   pc_ = newContext.pc;
   for (size_t type = 0; type < newContext.regFile.size(); type++) {
     for (size_t tag = 0; tag < newContext.regFile[type].size(); tag++) {
@@ -355,7 +355,7 @@ simeng::OS::cpuContext Core::getCurrentContext() const {
   OS::cpuContext newContext;
   newContext.TID = currentTID_;
   newContext.pc = pc_;
-  // progByteLen will not change in process so do not need to set it
+  // dataSectionEnd will not change in process so do not need to set it
   // Don't need to explicitly save SP as will be in reg file contents
   auto regFileStruc = isa_.getRegisterFileStructures();
   newContext.regFile.resize(regFileStruc.size());

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -383,7 +383,7 @@ void Core::handleLoad(const std::shared_ptr<Instruction>& instruction) {
 
 void Core::schedule(simeng::OS::cpuContext newContext) {
   currentTID_ = newContext.TID;
-  fetchUnit_.setProgramLength(newContext.progByteLen);
+  fetchUnit_.setProgramLength(newContext.dataSectionEnd);
   fetchUnit_.updatePC(newContext.pc);
   for (size_t type = 0; type < newContext.regFile.size(); type++) {
     for (size_t tag = 0; tag < newContext.regFile[type].size(); tag++) {
@@ -420,7 +420,7 @@ simeng::OS::cpuContext Core::getCurrentContext() const {
       exceptionGenerated_
           ? exceptionGeneratingInstruction_->getInstructionAddress() + 4
           : fetchUnit_.getPC();
-  // progByteLen will not change in process so do not need to set it
+  // dataSectionEnd will not change in process so do not need to set it
   // Don't need to explicitly save SP as will be in reg file contents
   auto regFileStruc = isa_.getRegisterFileStructures();
   newContext.regFile.resize(regFileStruc.size());

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -447,7 +447,7 @@ void Core::schedule(simeng::OS::cpuContext newContext) {
                             physicalRegisterQuantities_);
 
   currentTID_ = newContext.TID;
-  fetchUnit_.setProgramLength(newContext.progByteLen);
+  fetchUnit_.setProgramLength(newContext.dataSectionEnd);
   fetchUnit_.updatePC(newContext.pc);
   for (size_t type = 0; type < newContext.regFile.size(); type++) {
     for (size_t tag = 0; tag < newContext.regFile[type].size(); tag++) {
@@ -483,7 +483,7 @@ simeng::OS::cpuContext Core::getCurrentContext() const {
       exceptionGenerated_
           ? exceptionGeneratingInstruction_->getInstructionAddress() + 4
           : fetchUnit_.getPC();
-  // progByteLen will not change in process so do not need to set it
+  // dataSectionEnd will not change in process so do not need to set it
   // Don't need to explicitly save SP as will be in reg file contents
   auto regFileStruc = isa_.getRegisterFileStructures();
   newContext.regFile.resize(regFileStruc.size());

--- a/test/regression/RegressionTest.cc
+++ b/test/regression/RegressionTest.cc
@@ -45,7 +45,7 @@ void RegressionTest::run(const char* source, const char* triple,
   uint64_t procTID = 1;  // Initial process always has TID = 1
   process_ = OS.getProcess(procTID);
   ASSERT_TRUE(process_->isValid());
-  processMemorySize_ = process_->context_.progByteLen;
+  processMemorySize_ = process_->context_.dataSectionEnd;
 
   // Create the architecture
   architecture_ = createArchitecture();

--- a/test/unit/OSTest.cc
+++ b/test/unit/OSTest.cc
@@ -34,7 +34,7 @@ TEST(OSTest, CreateSimOS) {
   // Check CPU context
   // PC is always 0 for processes assembled by SimEng
   EXPECT_EQ(proc->context_.pc, 0);
-  EXPECT_GT(proc->context_.progByteLen, 0);
+  EXPECT_GT(proc->context_.dataSectionEnd, 0);
   EXPECT_GT(proc->context_.sp, 0);
   EXPECT_GT(proc->context_.regFile.size(), 0);
   // Check Initial Process' state


### PR DESCRIPTION
After the updates made for multi-threading-support and memory-overhaul, the programByteLength definition (used by the fetch unit to determine when to not fetch) had changed to the actual length of the process's region rather than the end of the .data section that it had been before.

This meant that any PC value which exceeded the data section (i.e. via speculated fetches on incorrect branch predictions) would be fetched and processed by the decoder, where in some cases when the address branched to was not properly aligned and as such triggered an unaligned PC exception.

To fix this, the context associated to each process now contains `dataSectionEnd`, which is then used by the fetch unit to determine if a PC is valid before sending a request to memory.