### PR TITLE
Unaligned pc exception fix 2

### DIFF
--- a/src/include/simeng/OS/Process.hh
+++ b/src/include/simeng/OS/Process.hh
@@ -40,7 +40,7 @@ struct cpuContext {
   uint64_t pc;
   // SP only used in process construction. Actual value lives in regFile
   uint64_t sp;
-  uint64_t dataSectionEnd;
+  uint64_t progByteLen;
   std::vector<std::vector<RegisterValue>> regFile;
 };
 

--- a/src/lib/OS/Process.cc
+++ b/src/lib/OS/Process.cc
@@ -396,8 +396,7 @@ void Process::initContext(
   context_.TID = TID_;
   context_.pc = entryPoint_;
   context_.sp = stackPtr;
-  // Remove padding (equal to PAGE_SIZE) from heapStart to get .data end
-  context_.dataSectionEnd = getHeapStart() - PAGE_SIZE;
+  context_.progByteLen = getProcessImageSize();
   // Initialise all registers to 0
   size_t numTypes = regFileStructure.size();
   context_.regFile.reserve(numTypes);

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -158,6 +158,8 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
     uop = std::make_shared<Instruction>(*this, metadataCache.front(),
                                         InstructionException::MisalignedPC);
     uop->setInstructionAddress(instructionAddress);
+    uop->setSequenceId(instrSeqIdCtr_++);
+    uop->setInstructionId(insnIdCtr_++);
     // Return non-zero value to avoid fatal error
     return 1;
   }
@@ -206,7 +208,7 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
 
   // Set instruction address and branch prediction for each micro-op generated
   for (int i = 0; i < num_ops; i++) {
-    output[i]->setSequenceId(++instrSeqIdCtr_);
+    output[i]->setSequenceId(instrSeqIdCtr_++);
     output[i]->setInstructionId(insnIdCtr_);
     output[i]->setInstructionAddress(instructionAddress);
   }

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -138,6 +138,8 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
     uop = std::make_shared<Instruction>(*this, metadataCache.front(),
                                         InstructionException::MisalignedPC);
     uop->setInstructionAddress(instructionAddress);
+    uop->setSequenceId(instrSeqIdCtr_++);
+    uop->setInstructionId(insnIdCtr_++);
     // Return non-zero value to avoid fatal error
     return 1;
   }
@@ -186,8 +188,8 @@ uint8_t Architecture::predecode(const void* ptr, uint8_t bytesAvailable,
   uop = std::make_shared<Instruction>(iter->second);
 
   uop->setInstructionAddress(instructionAddress);
-  uop->setSequenceId(++instrSeqIdCtr_);
-  uop->setInstructionId(++insnIdCtr_);
+  uop->setSequenceId(instrSeqIdCtr_++);
+  uop->setInstructionId(insnIdCtr_++);
 
   return 4;
 }

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -326,7 +326,7 @@ std::map<std::string, std::string> Core::getStats() const {
 
 void Core::schedule(simeng::OS::cpuContext newContext) {
   currentTID_ = newContext.TID;
-  programByteLength_ = newContext.dataSectionEnd;
+  programByteLength_ = newContext.progByteLen;
   pc_ = newContext.pc;
   for (size_t type = 0; type < newContext.regFile.size(); type++) {
     for (size_t tag = 0; tag < newContext.regFile[type].size(); tag++) {
@@ -355,7 +355,7 @@ simeng::OS::cpuContext Core::getCurrentContext() const {
   OS::cpuContext newContext;
   newContext.TID = currentTID_;
   newContext.pc = pc_;
-  // dataSectionEnd will not change in process so do not need to set it
+  // progByteLen will not change in process so do not need to set it
   // Don't need to explicitly save SP as will be in reg file contents
   auto regFileStruc = isa_.getRegisterFileStructures();
   newContext.regFile.resize(regFileStruc.size());

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -383,7 +383,7 @@ void Core::handleLoad(const std::shared_ptr<Instruction>& instruction) {
 
 void Core::schedule(simeng::OS::cpuContext newContext) {
   currentTID_ = newContext.TID;
-  fetchUnit_.setProgramLength(newContext.dataSectionEnd);
+  fetchUnit_.setProgramLength(newContext.progByteLen);
   fetchUnit_.updatePC(newContext.pc);
   for (size_t type = 0; type < newContext.regFile.size(); type++) {
     for (size_t tag = 0; tag < newContext.regFile[type].size(); tag++) {
@@ -420,7 +420,7 @@ simeng::OS::cpuContext Core::getCurrentContext() const {
       exceptionGenerated_
           ? exceptionGeneratingInstruction_->getInstructionAddress() + 4
           : fetchUnit_.getPC();
-  // dataSectionEnd will not change in process so do not need to set it
+  // progByteLen will not change in process so do not need to set it
   // Don't need to explicitly save SP as will be in reg file contents
   auto regFileStruc = isa_.getRegisterFileStructures();
   newContext.regFile.resize(regFileStruc.size());

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -447,7 +447,7 @@ void Core::schedule(simeng::OS::cpuContext newContext) {
                             physicalRegisterQuantities_);
 
   currentTID_ = newContext.TID;
-  fetchUnit_.setProgramLength(newContext.dataSectionEnd);
+  fetchUnit_.setProgramLength(newContext.progByteLen);
   fetchUnit_.updatePC(newContext.pc);
   for (size_t type = 0; type < newContext.regFile.size(); type++) {
     for (size_t tag = 0; tag < newContext.regFile[type].size(); tag++) {
@@ -483,7 +483,7 @@ simeng::OS::cpuContext Core::getCurrentContext() const {
       exceptionGenerated_
           ? exceptionGeneratingInstruction_->getInstructionAddress() + 4
           : fetchUnit_.getPC();
-  // dataSectionEnd will not change in process so do not need to set it
+  // progByteLen will not change in process so do not need to set it
   // Don't need to explicitly save SP as will be in reg file contents
   auto regFileStruc = isa_.getRegisterFileStructures();
   newContext.regFile.resize(regFileStruc.size());

--- a/test/regression/RegressionTest.cc
+++ b/test/regression/RegressionTest.cc
@@ -45,7 +45,7 @@ void RegressionTest::run(const char* source, const char* triple,
   uint64_t procTID = 1;  // Initial process always has TID = 1
   process_ = OS.getProcess(procTID);
   ASSERT_TRUE(process_->isValid());
-  processMemorySize_ = process_->context_.dataSectionEnd;
+  processMemorySize_ = process_->context_.progByteLen;
 
   // Create the architecture
   architecture_ = createArchitecture();

--- a/test/unit/OSTest.cc
+++ b/test/unit/OSTest.cc
@@ -34,7 +34,7 @@ TEST(OSTest, CreateSimOS) {
   // Check CPU context
   // PC is always 0 for processes assembled by SimEng
   EXPECT_EQ(proc->context_.pc, 0);
-  EXPECT_GT(proc->context_.dataSectionEnd, 0);
+  EXPECT_GT(proc->context_.progByteLen, 0);
   EXPECT_GT(proc->context_.sp, 0);
   EXPECT_GT(proc->context_.regFile.size(), 0);
   // Check Initial Process' state


### PR DESCRIPTION
This PR reverts PR #315 as this was a) not an actual full fix of the issue, and b) the functionality that it replaced is better suited to support dynamic linking.

Also contained in this PR is the fix for unaligned PC exceptions, caused by decoded instructions not being allocated a sequenceID or instructionID meaning it was never flushed from the ROB (expected for all unaligned PC exceptions given they should only occur through incorrect speculation).