### PR TITLE
Revert commitMicroOps Function

### DIFF
--- a/configs/a64fx_SME.yaml
+++ b/configs/a64fx_SME.yaml
@@ -4,6 +4,7 @@
 
 Core:
   Simulation-Mode: outoforder
+  ISA: AArch64
   # Clock Frequency is in GHz.
   Clock-Frequency: 1.8
   # Timer-Frequency is in MHz.


### PR DESCRIPTION
The commitMicroOps function was changed to try and gain an overall speedup. This had the unintended side effect of causing segfaults when running the simeng benchmarks. The speedup of the new solution was compared to the old and there is no noticeable difference.

To prevent segfaults this function is reverted to it's old implementation. 