### PR TITLE
SST compile fix on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ option(SIMENG_ENABLE_SST_TESTS "Enable testing for SST" OFF)
 # Set CXX flag for Apple Mac so that `binary_function` and `unary_function` types that are used in SST can be recognised. 
 # They were deprecated in C++11 and removed in C++17, and Apple Clang v15 no longer supports these types without the following flag
 if(APPLE)
-  add_compile_options(-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
+  add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
 endif()
 
 if (SIMENG_OPTIMIZE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ option(SIMENG_ENABLE_SST_TESTS "Enable testing for SST" OFF)
 
 # Set CXX flag for Apple Mac so that `binary_function` and `unary_function` types that are used in SST can be recognised. 
 # They were deprecated in C++11 and removed in C++17, and Apple Clang v15 no longer supports these types without the following flag
+# TODO: Remove one SST integration has updated to SST version 13 or later - the use of unary and binary functions are removed in later versions.
 if(APPLE)
   add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ option(SIMENG_ENABLE_SST_TESTS "Enable testing for SST" OFF)
 
 # Set CXX flag for Apple Mac so that `binary_function` and `unary_function` types that are used in SST can be recognised. 
 # They were deprecated in C++11 and removed in C++17, and Apple Clang v15 no longer supports these types without the following flag
-# TODO: Remove one SST integration has updated to SST version 13 or later - the use of unary and binary functions are removed in later versions.
+# TODO: Remove once SST integration has updated to SST version 13 or later - the use of unary and binary functions are removed in later versions.
 if(APPLE)
   add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,12 @@ option(SIMENG_OPTIMIZE "Enable Extra Compiler Optimizatoins" OFF)
 option(SIMENG_ENABLE_SST "Compile SimEng SST Wrapper" OFF)
 option(SIMENG_ENABLE_SST_TESTS "Enable testing for SST" OFF)
 
+# Set CXX flag for Apple Mac so that `binary_function` and `unary_function` types that are used in SST can be recognised. 
+# They were deprecated in C++11 and removed in C++17, and Apple Clang v15 no longer supports these types without the following flag
+if(APPLE)
+  add_compile_options(-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
+endif()
+
 if (SIMENG_OPTIMIZE)
   # Turn on link time optimization for all targets.
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)


### PR DESCRIPTION
On more recent versions of MacOS, and more specifically with more recent versions of Apple Clang, SST is unable to be compiled due to `unary_function` and `binary_function` types being depricated (since c++11) and now removed from Apple Clang v15. There is a compile flag which re-enabled these types and this has been added to `CMakeLists.txt` if the user is on MacOS.

These functions are only used in SST, and in more recent versions (i.e. SST v13) they have been replaced - so this issue may only be short term if SimEng's SST support is updated to version 13+