### PR TITLE
Correct CSRRW State Change

### DIFF
--- a/src/lib/arch/riscv/ExceptionHandler.cc
+++ b/src/lib/arch/riscv/ExceptionHandler.cc
@@ -649,7 +649,7 @@ bool ExceptionHandler::init() {
     auto operands = instruction_.getSourceOperands();
     auto destinationRegs = instruction_.getDestinationRegisters();
 
-    uint8_t rm = 0b110; // Set to invalid rounding mode
+    uint8_t rm = 0b110;  // Set to invalid rounding mode
     uint64_t result = 0;
 
     ProcessStateChange stateChange;
@@ -659,7 +659,7 @@ bool ExceptionHandler::init() {
           // Update CPP rounding mode but not floating point CSR as currently no
           // implementation
 
-          rm = operands[0].get<uint64_t >() & 0b111; // Take the lower 3 bits
+          rm = operands[0].get<uint64_t>() & 0b111;  // Take the lower 3 bits
 
           switch (operands[0].get<uint64_t>()) {
             case 0:  // RNE, Round to nearest, ties to even
@@ -693,7 +693,8 @@ bool ExceptionHandler::init() {
               // implementation of Zicsr
               break;
           }
-          result = rm << 5; // Shift rounding mode to correct position, frm[5:7]
+          // Shift rounding mode to correct position, frm[5:7]
+          result = rm << 5;
         }
 
         // Only update if registers should be written to

--- a/src/lib/arch/riscv/ExceptionHandler.cc
+++ b/src/lib/arch/riscv/ExceptionHandler.cc
@@ -649,12 +649,17 @@ bool ExceptionHandler::init() {
     auto operands = instruction_.getSourceOperands();
     auto destinationRegs = instruction_.getDestinationRegisters();
 
+    uint8_t rm = 0b110; // Set to invalid rounding mode
+    uint64_t result = 0;
+
     ProcessStateChange stateChange;
     switch (instruction_.getMetadata().opcode) {
       case Opcode::RISCV_CSRRW:  // CSRRW rd,csr,rs1
         if (metadata.operands[1].reg == RISCV_SYSREG_FRM) {
           // Update CPP rounding mode but not floating point CSR as currently no
           // implementation
+
+          rm = operands[0].get<uint64_t >() & 0b111; // Take the lower 3 bits
 
           switch (operands[0].get<uint64_t>()) {
             case 0:  // RNE, Round to nearest, ties to even
@@ -688,10 +693,15 @@ bool ExceptionHandler::init() {
               // implementation of Zicsr
               break;
           }
+          result = rm << 5; // Shift rounding mode to correct position, frm[5:7]
         }
 
-        // Dummy logic to allow progression. Set Rd to 0
-        stateChange = {ChangeType::REPLACEMENT, {destinationRegs[0]}, {0ull}};
+        // Only update if registers should be written to
+        if (destinationRegs.size() > 0) {
+          // Dummy logic to allow progression. Set Rd to 0
+          stateChange = {
+              ChangeType::REPLACEMENT, {destinationRegs[0]}, {result}};
+        }
         break;
       default:
         printException(instruction_);

--- a/src/lib/arch/riscv/Instruction_execute.cc
+++ b/src/lib/arch/riscv/Instruction_execute.cc
@@ -1161,7 +1161,6 @@ void Instruction::execute() {
       const float rs2 = checkNanBox(operands[1]);
 
       // Comments regarding fmaxf similar to RISCV_FMAX_D
-      float res;
       if (rs1 == 0 && rs2 == 0) {
         results[0] = RegisterValue(0xffffffff00000000, 8);
       } else {

--- a/src/lib/arch/riscv/Instruction_execute.cc
+++ b/src/lib/arch/riscv/Instruction_execute.cc
@@ -1149,7 +1149,6 @@ void Instruction::execute() {
       // the sign of zero, although some implementations additionally enforce
       // that if one argument is +0 and the other is -0, then +0 is returned.
       // But RISC-V spec requires this to be the case
-      double res;
       if (rs1 == 0 && rs2 == 0) {
         results[0] = RegisterValue(0x0000000000000000, 8);
       } else {


### PR DESCRIPTION
Closes #359 

This PR fixes issue #359 causing CloverLeaf compiled with GCC 12.2 to produce Inf for all floating point values. At beginning of the program execution `fsflags Ra` is called repeatedly. This is a pseudoinstruction for `csrrw x0, fflags, Ra` which discards the result in the zero register. 

The code in the execution handler blindly updated the first value held in the destination register span without checking if it is valid first which is not the case when the only destination is X0. This caused overwriting of registers incorrectly. A simple check is introduced to fix this.

Also in this PR:

- More accurate dummy value returned for the fsrm instruction
- Removal of unused variables in execute 
