### PR TITLE
Memory interface type check

### DIFF
--- a/src/lib/config/ModelConfig.cc
+++ b/src/lib/config/ModelConfig.cc
@@ -886,6 +886,29 @@ void ModelConfig::postValidation() {
   // Record any unlinked port names
   for (const auto& prt : portnames)
     invalid_ << "\t- " << prt << " has no associated reservation station\n";
+
+  // Ensure the L1-[Data|Instruction]-Memory:Interface-Type restrictions are
+  // enforced
+  // Currently, only outoforder core types can use non-Flat L1-Data-Memory
+  // interfaces
+  if (configTree_["Core"]["Simulation-Mode"].as<std::string>() !=
+      "outoforder") {
+    std::string l1dType =
+        configTree_["L1-Data-Memory"]["Interface-Type"].as<std::string>();
+    if (l1dType != "Flat")
+      invalid_
+          << "\t- Only a 'Flat' L1-Data-Memory Interface-Type may be used "
+             "for a non-outoforder Simulation-Mode. Interface-Type used is "
+          << l1dType << "\n";
+  }
+
+  // Currently, only a Flat L1-Instruction-Memory:Interface-Type is supported
+  std::string l1iType =
+      configTree_["L1-Instruction-Memory"]["Interface-Type"].as<std::string>();
+  if (l1iType != "Flat")
+    invalid_ << "\t- Only a 'Flat' L1-Instruction-Memory Interface-Type is "
+                "supported. Interface-Type used is "
+             << l1iType << "\n";
 }
 
 ryml::Tree ModelConfig::getConfig() { return configTree_; }

--- a/src/lib/config/ModelConfig.cc
+++ b/src/lib/config/ModelConfig.cc
@@ -889,17 +889,18 @@ void ModelConfig::postValidation() {
 
   // Ensure the L1-[Data|Instruction]-Memory:Interface-Type restrictions are
   // enforced
+  std::string simMode =
+      configTree_["Core"]["Simulation-Mode"].as<std::string>();
   // Currently, only outoforder core types can use non-Flat L1-Data-Memory
   // interfaces
-  if (configTree_["Core"]["Simulation-Mode"].as<std::string>() !=
-      "outoforder") {
+  if (simMode != "outoforder") {
     std::string l1dType =
         configTree_["L1-Data-Memory"]["Interface-Type"].as<std::string>();
     if (l1dType != "Flat")
-      invalid_
-          << "\t- Only a 'Flat' L1-Data-Memory Interface-Type may be used "
-             "for a non-outoforder Simulation-Mode. Interface-Type used is "
-          << l1dType << "\n";
+      invalid_ << "\t- Only a Flat L1-Data-Memory Interface-Type may be used "
+                  "with the "
+               << simMode << " Simulation-Mode. Interface-Type used is "
+               << l1dType << "\n";
   }
 
   // Currently, only a Flat L1-Instruction-Memory:Interface-Type is supported

--- a/test/regression/aarch64/MicroOperation.cc
+++ b/test/regression/aarch64/MicroOperation.cc
@@ -1084,7 +1084,9 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         std::make_tuple(EMULATION, "{Core: {Micro-Operations: True}}"),
         std::make_tuple(INORDER, "{Core: {Micro-Operations: True}}"),
-        std::make_tuple(OUTOFORDER, "{Core: {Micro-Operations: True}}")),
+        std::make_tuple(OUTOFORDER,
+                        "{Core: {Micro-Operations: True}, L1-Data-Memory: "
+                        "{Interface-Type: Fixed}}")),
     paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/SmokeTest.cc
+++ b/test/regression/aarch64/SmokeTest.cc
@@ -57,10 +57,13 @@ TEST_P(SmokeTest, heap) {
   EXPECT_EQ(getMemoryValue<uint32_t>(process_->getHeapStart() + 4), 42u);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, SmokeTest,
-                         ::testing::Values(std::make_tuple(EMULATION, "{}"),
-                                           std::make_tuple(INORDER, "{}"),
-                                           std::make_tuple(OUTOFORDER, "{}")),
-                         paramToString);
+INSTANTIATE_TEST_SUITE_P(
+    AArch64, SmokeTest,
+    ::testing::Values(std::make_tuple(EMULATION, "{}"),
+                      std::make_tuple(INORDER, "{}"),
+                      std::make_tuple(OUTOFORDER,
+                                      "{L1-Data-Memory: "
+                                      "{Interface-Type: Fixed}}")),
+    paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -871,10 +871,13 @@ TEST_P(Syscall, ftruncate) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(23), 0);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, Syscall,
-                         ::testing::Values(std::make_tuple(EMULATION, "{}"),
-                                           std::make_tuple(INORDER, "{}"),
-                                           std::make_tuple(OUTOFORDER, "{}")),
-                         paramToString);
+INSTANTIATE_TEST_SUITE_P(
+    AArch64, Syscall,
+    ::testing::Values(std::make_tuple(EMULATION, "{}"),
+                      std::make_tuple(INORDER, "{}"),
+                      std::make_tuple(OUTOFORDER,
+                                      "{L1-Data-Memory: "
+                                      "{Interface-Type: Fixed}}")),
+    paramToString);
 
 }  // namespace

--- a/test/regression/aarch64/SystemRegisters.cc
+++ b/test/regression/aarch64/SystemRegisters.cc
@@ -85,10 +85,13 @@ TEST_P(SystemRegister, counter_timers) {
   EXPECT_EQ(getSystemRegister(0xdf02), 2);
 }
 
-INSTANTIATE_TEST_SUITE_P(AArch64, SystemRegister,
-                         ::testing::Values(std::make_tuple(EMULATION, "{}"),
-                                           std::make_tuple(INORDER, "{}"),
-                                           std::make_tuple(OUTOFORDER, "{}")),
-                         paramToString);
+INSTANTIATE_TEST_SUITE_P(
+    AArch64, SystemRegister,
+    ::testing::Values(std::make_tuple(EMULATION, "{}"),
+                      std::make_tuple(INORDER, "{}"),
+                      std::make_tuple(OUTOFORDER,
+                                      "{L1-Data-Memory: "
+                                      "{Interface-Type: Fixed}}")),
+    paramToString);
 
 }  // namespace

--- a/test/regression/riscv/LoadStoreQueue.cc
+++ b/test/regression/riscv/LoadStoreQueue.cc
@@ -97,10 +97,13 @@ TEST_P(LoadStoreQueue, SpeculativeInvalidLoad) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(5), 12u);
 }
 
-INSTANTIATE_TEST_SUITE_P(RISCV, LoadStoreQueue,
-                         ::testing::Values(std::make_tuple(EMULATION, "{}"),
-                                           std::make_tuple(INORDER, "{}"),
-                                           std::make_tuple(OUTOFORDER, "{}")),
-                         paramToString);
+INSTANTIATE_TEST_SUITE_P(
+    RISCV, LoadStoreQueue,
+    ::testing::Values(std::make_tuple(EMULATION, "{}"),
+                      std::make_tuple(INORDER, "{}"),
+                      std::make_tuple(OUTOFORDER,
+                                      "{L1-Data-Memory: "
+                                      "{Interface-Type: Fixed}}")),
+    paramToString);
 
 }  // namespace

--- a/test/regression/riscv/RISCVRegressionTest.hh
+++ b/test/regression/riscv/RISCVRegressionTest.hh
@@ -17,7 +17,7 @@ static const char* RISCV_ADDITIONAL_CONFIG = R"YAML(
     },
   L1-Data-Memory:
     {
-      Interface-Type: Fixed,
+      Interface-Type: Flat,
     },
   L1-Instruction-Memory:
     {

--- a/test/regression/riscv/SmokeTest.cc
+++ b/test/regression/riscv/SmokeTest.cc
@@ -12,10 +12,13 @@ TEST_P(SmokeTest, instruction) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(15), 32u);
 }
 
-INSTANTIATE_TEST_SUITE_P(RISCV, SmokeTest,
-                         ::testing::Values(std::make_tuple(EMULATION, "{}"),
-                                           std::make_tuple(INORDER, "{}"),
-                                           std::make_tuple(OUTOFORDER, "{}")),
-                         paramToString);
+INSTANTIATE_TEST_SUITE_P(
+    RISCV, SmokeTest,
+    ::testing::Values(std::make_tuple(EMULATION, "{}"),
+                      std::make_tuple(INORDER, "{}"),
+                      std::make_tuple(OUTOFORDER,
+                                      "{L1-Data-Memory: "
+                                      "{Interface-Type: Fixed}}")),
+    paramToString);
 
 }  // namespace

--- a/test/regression/riscv/Syscall.cc
+++ b/test/regression/riscv/Syscall.cc
@@ -880,9 +880,12 @@ TEST_P(Syscall, ftruncate) {
   EXPECT_EQ(getGeneralRegister<uint64_t>(28), 0);
 }
 
-INSTANTIATE_TEST_SUITE_P(RISCV, Syscall,
-                         ::testing::Values(std::make_tuple(EMULATION, "{}"),
-                                           std::make_tuple(INORDER, "{}"),
-                                           std::make_tuple(OUTOFORDER, "{}")),
-                         paramToString);
+INSTANTIATE_TEST_SUITE_P(
+    RISCV, Syscall,
+    ::testing::Values(std::make_tuple(EMULATION, "{}"),
+                      std::make_tuple(INORDER, "{}"),
+                      std::make_tuple(OUTOFORDER,
+                                      "{L1-Data-Memory: "
+                                      "{Interface-Type: Fixed}}")),
+    paramToString);
 }  // namespace


### PR DESCRIPTION
This PR applies the restrictions for memory interface types possibly based on the Simulation-Mode in use. It also updates the regression test suite to use a fixed L1D for outoforder tests.

closes #372 