### PR TITLE
Added fix for returning a consistent nan value from a divide by zero

### DIFF
--- a/src/include/simeng/arch/aarch64/helpers/neon.hh
+++ b/src/include/simeng/arch/aarch64/helpers/neon.hh
@@ -319,6 +319,26 @@ RegisterValue vecFmla_3vecs(std::vector<RegisterValue>& operands) {
   return {out, 256};
 }
 
+/** Helper function for NEON instructions with the format `fdiv vd, vn, vm`.
+ * T represents the type of operands (e.g. for vn.2d, T = uint64_t).
+ * I represents the number of elements in the output array to be updated (e.g.
+ * for vd.8b I = 8).
+ * Returns correctly formatted RegisterValue. */
+template <typename T, int I>
+std::enable_if_t<std::is_floating_point_v<T>, RegisterValue> vecFDiv(
+    std::vector<RegisterValue>& operands) {
+  const T* n = operands[0].getAsVector<T>();
+  const T* m = operands[1].getAsVector<T>();
+  T out[16 / sizeof(T)] = {0};
+  for (int i = 0; i < I; i++) {
+    if (m[i] == 0)
+      out[i] = sizeof(T) == 8 ? std::nan("") : std::nanf("");
+    else
+      out[i] = n[i] / m[i];
+  }
+  return {out, 256};
+}
+
 /** Helper function for NEON instructions with the format `fmla vd,
  *  vn, vm[index]`.
  * T represents the type of operands (e.g. for vn.2d, T = double).

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -1653,14 +1653,22 @@ void Instruction::execute() {
       }
       case Opcode::AArch64_FDIVR_ZPmZ_D: {  // fdivr zdn.d, pg/m, zdn.d, zm.d
         results[0] = sveLogicOpPredicated_3vecs<double>(
-            operands, VL_bits,
-            [](double x, double y) -> double { return (y / x); });
+            operands, VL_bits, [](double x, double y) -> double {
+              if (x == 0)
+                return std::nan(0);
+              else
+                return (y / x);
+            });
         break;
       }
       case Opcode::AArch64_FDIVR_ZPmZ_S: {  // fdivr zdn.s, pg/m, zdn.s, zm.s
         results[0] = sveLogicOpPredicated_3vecs<float>(
-            operands, VL_bits,
-            [](float x, float y) -> float { return (y / x); });
+            operands, VL_bits, [](float x, float y) -> float {
+              if (x == 0)
+                return std::nanf(0);
+              else
+                return (y / x);
+            });
         break;
       }
       case Opcode::AArch64_FDIVSrr: {  // fdiv sd, sn, sm
@@ -1669,13 +1677,22 @@ void Instruction::execute() {
       }
       case Opcode::AArch64_FDIV_ZPmZ_D: {  // fdiv zdn.d, pg/m, zdn.d, zm.d
         results[0] = sveLogicOpPredicated_3vecs<double>(
-            operands, VL_bits,
-            [](double x, double y) -> double { return (x / y); });
+            operands, VL_bits, [](double x, double y) -> double {
+              if (y == 0)
+                return std::nan(0);
+              else
+                return (x / y);
+            });
         break;
       }
       case Opcode::AArch64_FDIVv2f64: {  // fdiv vd.2d, vn.2d, vm.2d
         results[0] = vecLogicOp_3vecs<double, 2>(
-            operands, [](double x, double y) -> double { return x / y; });
+            operands, [](double x, double y) -> double {
+              if (y == 0)
+                return std::nanf(0);
+              else
+                return x / y;
+            });
         break;
       }
       case Opcode::AArch64_FDUP_ZI_D: {  // fdup zd.d, #imm

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -1652,23 +1652,11 @@ void Instruction::execute() {
         break;
       }
       case Opcode::AArch64_FDIVR_ZPmZ_D: {  // fdivr zdn.d, pg/m, zdn.d, zm.d
-        results[0] = sveLogicOpPredicated_3vecs<double>(
-            operands, VL_bits, [](double x, double y) -> double {
-              if (x == 0)
-                return std::nan(0);
-              else
-                return (y / x);
-            });
+        results[0] = sveFDivPredicated<double, true>(operands, VL_bits);
         break;
       }
       case Opcode::AArch64_FDIVR_ZPmZ_S: {  // fdivr zdn.s, pg/m, zdn.s, zm.s
-        results[0] = sveLogicOpPredicated_3vecs<float>(
-            operands, VL_bits, [](float x, float y) -> float {
-              if (x == 0)
-                return std::nanf(0);
-              else
-                return (y / x);
-            });
+        results[0] = sveFDivPredicated<float, true>(operands, VL_bits);
         break;
       }
       case Opcode::AArch64_FDIVSrr: {  // fdiv sd, sn, sm
@@ -1676,23 +1664,11 @@ void Instruction::execute() {
         break;
       }
       case Opcode::AArch64_FDIV_ZPmZ_D: {  // fdiv zdn.d, pg/m, zdn.d, zm.d
-        results[0] = sveLogicOpPredicated_3vecs<double>(
-            operands, VL_bits, [](double x, double y) -> double {
-              if (y == 0)
-                return std::nan(0);
-              else
-                return (x / y);
-            });
+        results[0] = sveFDivPredicated<double>(operands, VL_bits);
         break;
       }
       case Opcode::AArch64_FDIVv2f64: {  // fdiv vd.2d, vn.2d, vm.2d
-        results[0] = vecLogicOp_3vecs<double, 2>(
-            operands, [](double x, double y) -> double {
-              if (y == 0)
-                return std::nanf(0);
-              else
-                return x / y;
-            });
+        results[0] = vecFDiv<double, 2>(operands);
         break;
       }
       case Opcode::AArch64_FDUP_ZI_D: {  // fdup zd.d, #imm

--- a/test/regression/aarch64/instructions/float.cc
+++ b/test/regression/aarch64/instructions/float.cc
@@ -539,8 +539,8 @@ TEST_P(InstFloat, fcvtzu) {
   dheap[1] = -42.76;
   dheap[2] = -0.125;
   dheap[3] = 321.5;
-  dheap[4] = std::nan(0);
-  dheap[5] = -std::nan(0);
+  dheap[4] = std::nan("");
+  dheap[5] = -std::nan("");
   dheap[6] = INFINITY;
   dheap[7] = -INFINITY;
   dheap[8] = 4294967296.0;            // uint32_max + 1
@@ -654,8 +654,8 @@ TEST_P(InstFloat, fcvtzu) {
   fheap[1] = -42.76f;
   fheap[2] = -0.125f;
   fheap[3] = 321.5f;
-  fheap[4] = std::nanf(0);
-  fheap[5] = -std::nanf(0);
+  fheap[4] = std::nanf("");
+  fheap[5] = -std::nanf("");
   fheap[6] = INFINITY;
   fheap[7] = -INFINITY;
   fheap[8] = 4294967296.0;            // uint32_max + 1

--- a/test/unit/aarch64/InstructionTest.cc
+++ b/test/unit/aarch64/InstructionTest.cc
@@ -365,7 +365,7 @@ TEST_F(AArch64InstructionTest, supplyOperand) {
   insn.execute();
   EXPECT_TRUE(insn.hasExecuted());
   auto results = insn.getResults();
-  float vals[4] = {1.f, 1.f, std::nanf(0), std::nanf(0)};
+  float vals[4] = {1.f, 1.f, std::nanf(""), std::nanf("")};
   RegisterValue refRes = {vals, 256};
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(results[0], refRes);

--- a/test/unit/aarch64/InstructionTest.cc
+++ b/test/unit/aarch64/InstructionTest.cc
@@ -365,7 +365,7 @@ TEST_F(AArch64InstructionTest, supplyOperand) {
   insn.execute();
   EXPECT_TRUE(insn.hasExecuted());
   auto results = insn.getResults();
-  uint64_t vals[2] = {0x3f8000003f800000, 0x7fc000007fc00000};
+  float vals[4] = {1.f, 1.f, std::nanf(0), std::nanf(0)};
   RegisterValue refRes = {vals, 256};
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(results[0], refRes);


### PR DESCRIPTION
This PR aims to fix the issues of differing bit-level values for a NaN value return from a vector divide by 0.

closes #380 