### PR TITLE
st1w dirtied memory fix

### DIFF
--- a/src/lib/kernel/LinuxProcess.cc
+++ b/src/lib/kernel/LinuxProcess.cc
@@ -79,7 +79,7 @@ LinuxProcess::LinuxProcess(span<char> instructions, ryml::ConstNodeRef config)
       alignToBoundary(heapStart_ + (HEAP_SIZE + STACK_SIZE) / 2, pageSize_);
 
   size_ = heapStart_ + HEAP_SIZE + STACK_SIZE;
-  char* unwrappedProcImgPtr = (char*)malloc(size_ * sizeof(char));
+  char* unwrappedProcImgPtr = (char*)calloc(size_, sizeof(char));
   std::copy(instructions.begin(), instructions.end(), unwrappedProcImgPtr);
 
   createStack(&unwrappedProcImgPtr);


### PR DESCRIPTION
In this PR, `calloc` has been used instead of `malloc` when allocating memory for newly created ELF process images. This ensures all the memory is zero'ed out as to meet expectations of the initial memory space.