### PR TITLE
Architecture Class cleanup

### DIFF
--- a/src/include/simeng/Instruction.hh
+++ b/src/include/simeng/Instruction.hh
@@ -13,6 +13,19 @@ using InstructionException = short;
 
 namespace simeng {
 
+/** A struct holding user-defined execution information for an
+ * instruction. */
+struct ExecutionInfo {
+  /** The latency for the instruction. */
+  uint16_t latency = 1;
+
+  /** The execution throughput for the instruction. */
+  uint16_t stallCycles = 1;
+
+  /** The ports that support the instruction. */
+  std::vector<uint16_t> ports = {};
+};
+
 /** An abstract instruction definition.
  * Each supported ISA should provide a derived implementation of this class. */
 class Instruction {

--- a/src/include/simeng/arch/Architecture.hh
+++ b/src/include/simeng/arch/Architecture.hh
@@ -111,13 +111,6 @@ class Architecture {
   /** A map to hold the relationship between instruction opcode and
    * user-defined execution information. */
   std::unordered_map<uint16_t, ExecutionInfo> opcodeExecutionInfo_;
-
- private:
-  /** Retrieve an ExecutionInfo object for the requested instruction. If a
-   * opcode-based override has been defined for the latency and/or
-   * port information, return that instead of the group-defined execution
-   * information. */
-  virtual ExecutionInfo getExecutionInfo(const Instruction& insn) const = 0;
 };
 
 }  // namespace arch

--- a/src/include/simeng/arch/aarch64/Architecture.hh
+++ b/src/include/simeng/arch/aarch64/Architecture.hh
@@ -29,12 +29,6 @@ class Architecture : public arch::Architecture {
                     uint64_t instructionAddress,
                     MacroOp& output) const override;
 
-  /** Retrieve an ExecutionInfo object for the requested instruction. If a
-   * opcode-based override has been defined for the latency and/or
-   * port information, return that instead of the group-defined execution
-   * information. */
-  virtual ExecutionInfo getExecutionInfo(const Instruction& insn) const;
-
   /** Returns a zero-indexed register tag for a system register encoding.
    * Returns -1 in the case that the system register has no mapping. */
   int32_t getSystemRegisterTag(uint16_t reg) const override;
@@ -56,6 +50,12 @@ class Architecture : public arch::Architecture {
   /** Updates System registers of any system-based timers. */
   void updateSystemTimerRegisters(RegisterFileSet* regFile,
                                   const uint64_t iterations) const override;
+
+  /** Retrieve an ExecutionInfo object for the requested instruction. If a
+   * opcode-based override has been defined for the latency and/or
+   * port information, return that instead of the group-defined execution
+   * information. */
+  virtual ExecutionInfo getExecutionInfo(const Instruction& insn) const;
 
   /** Returns the current vector length set by the provided configuration. */
   uint64_t getVectorLength() const;

--- a/src/include/simeng/arch/aarch64/Architecture.hh
+++ b/src/include/simeng/arch/aarch64/Architecture.hh
@@ -91,7 +91,7 @@ class Architecture : public arch::Architecture {
   uint64_t SVL_;
 
   /** A copy of the value of the SVCR system register. */
-  mutable uint64_t SVCRval_;
+  mutable uint64_t SVCRval_ = 0;
 
   /** System Register of Virtual Counter Timer. */
   simeng::Register VCTreg_;

--- a/src/include/simeng/arch/aarch64/Architecture.hh
+++ b/src/include/simeng/arch/aarch64/Architecture.hh
@@ -29,6 +29,12 @@ class Architecture : public arch::Architecture {
                     uint64_t instructionAddress,
                     MacroOp& output) const override;
 
+  /** Retrieve an ExecutionInfo object for the requested instruction. If a
+   * opcode-based override has been defined for the latency and/or
+   * port information, return that instead of the group-defined execution
+   * information. */
+  virtual ExecutionInfo getExecutionInfo(const Instruction& insn) const;
+
   /** Returns a zero-indexed register tag for a system register encoding.
    * Returns -1 in the case that the system register has no mapping. */
   int32_t getSystemRegisterTag(uint16_t reg) const override;
@@ -65,13 +71,6 @@ class Architecture : public arch::Architecture {
   void setSVCRval(const uint64_t newVal) const;
 
  private:
-  /** Retrieve an ExecutionInfo object for the requested instruction. If a
-   * opcode-based override has been defined for the latency and/or
-   * port information, return that instead of the group-defined execution
-   * information. */
-  virtual ExecutionInfo getExecutionInfo(
-      const simeng::Instruction& insn) const override;
-
   /** A decoding cache, mapping an instruction word to a previously decoded
    * instruction. Instructions are added to the cache as they're decoded, to
    * reduce the overhead of future decoding. */
@@ -103,8 +102,6 @@ class Architecture : public arch::Architecture {
   /** Modulo component used to define the frequency at which the VCT is updated.
    */
   double vctModulo_;
-
-  friend class MicroDecoder;
 };
 
 }  // namespace aarch64

--- a/src/include/simeng/arch/aarch64/Architecture.hh
+++ b/src/include/simeng/arch/aarch64/Architecture.hh
@@ -20,7 +20,9 @@ class Architecture : public arch::Architecture {
  public:
   Architecture(kernel::Linux& kernel,
                ryml::ConstNodeRef config = config::SimInfo::getConfig());
+
   ~Architecture();
+
   /** Pre-decode instruction memory into a macro-op of `Instruction`
    * instances. Returns the number of bytes consumed to produce it (always 4),
    * and writes into the supplied macro-op vector. */
@@ -46,16 +48,16 @@ class Architecture : public arch::Architecture {
   /** Returns the maximum size of a valid instruction in bytes. */
   uint8_t getMaxInstructionSize() const override;
 
+  /** Updates System registers of any system-based timers. */
+  void updateSystemTimerRegisters(RegisterFileSet* regFile,
+                                  const uint64_t iterations) const override;
+
   /** Returns the current vector length set by the provided configuration. */
   uint64_t getVectorLength() const;
 
   /** Returns the current streaming vector length set by the provided
    * configuration. */
   uint64_t getStreamingVectorLength() const;
-
-  /** Updates System registers of any system-based timers. */
-  void updateSystemTimerRegisters(RegisterFileSet* regFile,
-                                  const uint64_t iterations) const override;
 
   /** Retrieve an ExecutionInfo object for the requested instruction. If a
    * opcode-based override has been defined for the latency and/or

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -176,19 +176,6 @@ const uint8_t MATRIX = 5;
 const Register ZERO_REGISTER = {GENERAL, (uint16_t)-1};
 }  // namespace RegisterType
 
-/** A struct holding user-defined execution information for a aarch64
- * instruction. */
-struct ExecutionInfo {
-  /** The latency for the instruction. */
-  uint16_t latency = 1;
-
-  /** The execution throughput for the instruction. */
-  uint16_t stallCycles = 1;
-
-  /** The ports that support the instruction. */
-  std::vector<uint16_t> ports = {};
-};
-
 /** The various exceptions that can be raised by an individual instruction. */
 enum class InstructionException {
   None = 0,

--- a/src/include/simeng/arch/riscv/Architecture.hh
+++ b/src/include/simeng/arch/riscv/Architecture.hh
@@ -6,7 +6,6 @@
 #include "simeng/arch/Architecture.hh"
 #include "simeng/arch/riscv/ExceptionHandler.hh"
 #include "simeng/arch/riscv/Instruction.hh"
-#include "simeng/kernel/Linux.hh"
 
 using csh = size_t;
 
@@ -19,7 +18,9 @@ class Architecture : public arch::Architecture {
  public:
   Architecture(kernel::Linux& kernel,
                ryml::ConstNodeRef config = config::SimInfo::getConfig());
+
   ~Architecture();
+
   /** Pre-decode instruction memory into a macro-op of `Instruction`
    * instances. Returns the number of bytes consumed to produce it (always 4),
    * and writes into the supplied macro-op vector. */
@@ -53,33 +54,18 @@ class Architecture : public arch::Architecture {
    * opcode-based override has been defined for the latency and/or
    * port information, return that instead of the group-defined execution
    * information. */
-  ExecutionInfo getExecutionInfo(Instruction& insn) const;
+  ExecutionInfo getExecutionInfo(
+      const simeng::Instruction& insn) const override;
 
   /** A decoding cache, mapping an instruction word to a previously decoded
    * instruction. Instructions are added to the cache as they're decoded, to
    * reduce the overhead of future decoding. */
-  static std::unordered_map<uint32_t, Instruction> decodeCache_;
+  mutable std::unordered_map<uint32_t, Instruction> decodeCache_;
+
   /** A decoding metadata cache, mapping an instruction word to a previously
    * decoded instruction metadata bundle. Metadata is added to the cache as it's
    * decoded, to reduce the overhead of future decoding. */
-  static std::forward_list<InstructionMetadata> metadataCache_;
-
-  /** A mapping from system register encoding to a zero-indexed tag. */
-  std::unordered_map<uint16_t, uint16_t> systemRegisterMap_;
-
-  /** A map to hold the relationship between aarch64 instruction groups and
-   * user-defined execution information. */
-  std::unordered_map<uint16_t, ExecutionInfo> groupExecutionInfo_;
-
-  /** A map to hold the relationship between aarch64 instruction opcode and
-   * user-defined execution information. */
-  std::unordered_map<uint16_t, ExecutionInfo> opcodeExecutionInfo_;
-
-  /** A Capstone decoding library handle, for decoding instructions. */
-  csh capstoneHandle_;
-
-  /** A reference to a Linux kernel object to forward syscalls to. */
-  kernel::Linux& linux_;
+  mutable std::forward_list<InstructionMetadata> metadataCache_;
 
   /** System Register of Processor Cycle Counter. */
   simeng::Register cycleSystemReg_;

--- a/src/include/simeng/arch/riscv/Architecture.hh
+++ b/src/include/simeng/arch/riscv/Architecture.hh
@@ -49,11 +49,11 @@ class Architecture : public arch::Architecture {
                                   const uint64_t iterations) const override;
 
  private:
-  /** Retrieve an executionInfo object for the requested instruction. If a
+  /** Retrieve an ExecutionInfo object for the requested instruction. If a
    * opcode-based override has been defined for the latency and/or
    * port information, return that instead of the group-defined execution
    * information. */
-  executionInfo getExecutionInfo(Instruction& insn) const;
+  ExecutionInfo getExecutionInfo(Instruction& insn) const;
 
   /** A decoding cache, mapping an instruction word to a previously decoded
    * instruction. Instructions are added to the cache as they're decoded, to
@@ -69,11 +69,11 @@ class Architecture : public arch::Architecture {
 
   /** A map to hold the relationship between aarch64 instruction groups and
    * user-defined execution information. */
-  std::unordered_map<uint16_t, executionInfo> groupExecutionInfo_;
+  std::unordered_map<uint16_t, ExecutionInfo> groupExecutionInfo_;
 
   /** A map to hold the relationship between aarch64 instruction opcode and
    * user-defined execution information. */
-  std::unordered_map<uint16_t, executionInfo> opcodeExecutionInfo_;
+  std::unordered_map<uint16_t, ExecutionInfo> opcodeExecutionInfo_;
 
   /** A Capstone decoding library handle, for decoding instructions. */
   csh capstoneHandle_;

--- a/src/include/simeng/arch/riscv/Architecture.hh
+++ b/src/include/simeng/arch/riscv/Architecture.hh
@@ -54,8 +54,7 @@ class Architecture : public arch::Architecture {
    * opcode-based override has been defined for the latency and/or
    * port information, return that instead of the group-defined execution
    * information. */
-  ExecutionInfo getExecutionInfo(
-      const simeng::Instruction& insn) const override;
+  ExecutionInfo getExecutionInfo(const Instruction& insn) const;
 
   /** A decoding cache, mapping an instruction word to a previously decoded
    * instruction. Instructions are added to the cache as they're decoded, to

--- a/src/include/simeng/arch/riscv/Instruction.hh
+++ b/src/include/simeng/arch/riscv/Instruction.hh
@@ -28,19 +28,6 @@ const uint8_t SYSTEM = 2;
 const Register ZERO_REGISTER = {GENERAL, (uint16_t)0};
 }  // namespace RegisterType
 
-/** A struct holding user-defined execution information for a aarch64
- * instruction. */
-struct executionInfo {
-  /** The latency for the instruction. */
-  uint16_t latency = 1;
-
-  /** The execution throughput for the instruction. */
-  uint16_t stallCycles = 1;
-
-  /** The ports that support the instruction. */
-  std::vector<uint16_t> ports = {};
-};
-
 /** The various exceptions that can be raised by an individual instruction. */
 enum class InstructionException {
   None = 0,
@@ -158,7 +145,7 @@ class Instruction : public simeng::Instruction {
 
   /** Set this instruction's execution information including it's execution
    * latency and throughput, and the set of ports which support it. */
-  void setExecutionInfo(const executionInfo& info);
+  void setExecutionInfo(const ExecutionInfo& info);
 
   /** Get this instruction's supported set of ports. */
   const std::vector<uint16_t>& getSupportedPorts() override;

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -133,13 +133,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
   }
 }
 
-Architecture::~Architecture() {
-  cs_close(&capstoneHandle_);
-  decodeCache_.clear();
-  metadataCache_.clear();
-  groupExecutionInfo_.clear();
-  SVCRval_ = 0;
-}
+Architecture::~Architecture() { cs_close(&capstoneHandle_); }
 
 uint8_t Architecture::predecode(const void* ptr, uint16_t bytesAvailable,
                                 uint64_t instructionAddress,

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -8,12 +8,12 @@ namespace arch {
 namespace aarch64 {
 
 Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
-    : arch::Architecture(kernel) {
-  microDecoder_ = std::make_unique<MicroDecoder>();
-  VL_ = config["Core"]["Vector-Length"].as<uint64_t>();
-  SVL_ = config["Core"]["Streaming-Vector-Length"].as<uint64_t>();
-  vctModulo_ = (config["Core"]["Clock-Frequency-GHz"].as<float>() * 1e9) /
-               (config["Core"]["Timer-Frequency-MHz"].as<uint32_t>() * 1e6);
+    : arch::Architecture(kernel),
+      microDecoder_(std::make_unique<MicroDecoder>()),
+      VL_(config["Core"]["Vector-Length"].as<uint64_t>()),
+      SVL_(config["Core"]["Streaming-Vector-Length"].as<uint64_t>()),
+      vctModulo_((config["Core"]["Clock-Frequency-GHz"].as<float>() * 1e9) /
+                 (config["Core"]["Timer-Frequency-MHz"].as<uint32_t>() * 1e6)) {
   if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &capstoneHandle_) != CS_ERR_OK) {
     std::cerr << "[SimEng:Architecture] Could not create capstone handle"
               << std::endl;

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -130,8 +130,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
         // If latency information hasn't been defined, set to zero as to inform
         // later access to use group defined latencies instead
         uint16_t opcode = opcode_node[j].as<uint16_t>();
-        opcodeExecutionInfo_.try_emplace(
-            opcode, simeng::arch::aarch64::ExecutionInfo{0, 0, {}});
+        opcodeExecutionInfo_.try_emplace(opcode, ExecutionInfo{0, 0, {}});
         opcodeExecutionInfo_[opcode].ports.push_back(static_cast<uint8_t>(i));
       }
     }

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -207,16 +207,14 @@ uint8_t Architecture::predecode(const void* ptr, uint16_t bytesAvailable,
   return 4;
 }
 
-ExecutionInfo Architecture::getExecutionInfo(
-    const simeng::Instruction& insn) const {
-  auto insn_new = reinterpret_cast<const arch::aarch64::Instruction&>(insn);
+ExecutionInfo Architecture::getExecutionInfo(const Instruction& insn) const {
   // Assume no opcode-based override
-  ExecutionInfo exeInfo = groupExecutionInfo_.at(insn_new.getGroup());
-  if (opcodeExecutionInfo_.find(insn_new.getMetadata().opcode) !=
+  ExecutionInfo exeInfo = groupExecutionInfo_.at(insn.getGroup());
+  if (opcodeExecutionInfo_.find(insn.getMetadata().opcode) !=
       opcodeExecutionInfo_.end()) {
     // Replace with overrided values
     ExecutionInfo overrideInfo =
-        opcodeExecutionInfo_.at(insn_new.getMetadata().opcode);
+        opcodeExecutionInfo_.at(insn.getMetadata().opcode);
     if (overrideInfo.latency != 0) exeInfo.latency = overrideInfo.latency;
     if (overrideInfo.stallCycles != 0)
       exeInfo.stallCycles = overrideInfo.stallCycles;

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -135,12 +135,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
   }
 }
 
-Architecture::~Architecture() {
-  cs_close(&capstoneHandle_);
-  decodeCache_.clear();
-  metadataCache_.clear();
-  groupExecutionInfo_.clear();
-}
+Architecture::~Architecture() { cs_close(&capstoneHandle_); }
 
 uint8_t Architecture::predecode(const void* ptr, uint16_t bytesAvailable,
                                 uint64_t instructionAddress,

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -206,16 +206,14 @@ uint8_t Architecture::predecode(const void* ptr, uint16_t bytesAvailable,
   return 4;
 }
 
-ExecutionInfo Architecture::getExecutionInfo(
-    const simeng::Instruction& insn) const {
-  auto insn_new = reinterpret_cast<const arch::riscv::Instruction&>(insn);
+ExecutionInfo Architecture::getExecutionInfo(const Instruction& insn) const {
   // Assume no opcode-based override
-  ExecutionInfo exeInfo = groupExecutionInfo_.at(insn_new.getGroup());
-  if (opcodeExecutionInfo_.find(insn_new.getMetadata().opcode) !=
+  ExecutionInfo exeInfo = groupExecutionInfo_.at(insn.getGroup());
+  if (opcodeExecutionInfo_.find(insn.getMetadata().opcode) !=
       opcodeExecutionInfo_.end()) {
     // Replace with overrided values
     ExecutionInfo overrideInfo =
-        opcodeExecutionInfo_.at(insn_new.getMetadata().opcode);
+        opcodeExecutionInfo_.at(insn.getMetadata().opcode);
     if (overrideInfo.latency != 0) exeInfo.latency = overrideInfo.latency;
     if (overrideInfo.stallCycles != 0)
       exeInfo.stallCycles = overrideInfo.stallCycles;

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -40,7 +40,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
       RegisterType::SYSTEM,
       static_cast<uint16_t>(getSystemRegisterTag(RISCV_SYSREG_CYCLE))};
 
-  // Instantiate an executionInfo entry for each group in the InstructionGroup
+  // Instantiate an ExecutionInfo entry for each group in the InstructionGroup
   // namespace.
   for (int i = 0; i < NUM_GROUPS; i++) {
     groupExecutionInfo_[i] = {1, 1, {}};
@@ -131,8 +131,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
         // If latency information hasn't been defined, set to zero as to inform
         // later access to use group defined latencies instead
         uint16_t opcode = opcode_node[j].as<uint16_t>();
-        opcodeExecutionInfo_.try_emplace(
-            opcode, simeng::arch::riscv::executionInfo{0, 0, {}});
+        opcodeExecutionInfo_.try_emplace(opcode, ExecutionInfo{0, 0, {}});
         opcodeExecutionInfo_[opcode].ports.push_back(static_cast<uint8_t>(i));
       }
     }
@@ -210,13 +209,13 @@ uint8_t Architecture::predecode(const void* ptr, uint16_t bytesAvailable,
   return 4;
 }
 
-executionInfo Architecture::getExecutionInfo(Instruction& insn) const {
+ExecutionInfo Architecture::getExecutionInfo(Instruction& insn) const {
   // Assume no opcode-based override
-  executionInfo exeInfo = groupExecutionInfo_.at(insn.getGroup());
+  ExecutionInfo exeInfo = groupExecutionInfo_.at(insn.getGroup());
   if (opcodeExecutionInfo_.find(insn.getMetadata().opcode) !=
       opcodeExecutionInfo_.end()) {
     // Replace with overrided values
-    executionInfo overrideInfo =
+    ExecutionInfo overrideInfo =
         opcodeExecutionInfo_.at(insn.getMetadata().opcode);
     if (overrideInfo.latency != 0) exeInfo.latency = overrideInfo.latency;
     if (overrideInfo.stallCycles != 0)

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -134,6 +134,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
     }
   }
 }
+
 Architecture::~Architecture() {
   cs_close(&capstoneHandle_);
   decodeCache_.clear();
@@ -206,34 +207,18 @@ uint8_t Architecture::predecode(const void* ptr, uint16_t bytesAvailable,
   return 4;
 }
 
-ExecutionInfo Architecture::getExecutionInfo(const Instruction& insn) const {
-  // Assume no opcode-based override
-  ExecutionInfo exeInfo = groupExecutionInfo_.at(insn.getGroup());
-  if (opcodeExecutionInfo_.find(insn.getMetadata().opcode) !=
-      opcodeExecutionInfo_.end()) {
-    // Replace with overrided values
-    ExecutionInfo overrideInfo =
-        opcodeExecutionInfo_.at(insn.getMetadata().opcode);
-    if (overrideInfo.latency != 0) exeInfo.latency = overrideInfo.latency;
-    if (overrideInfo.stallCycles != 0)
-      exeInfo.stallCycles = overrideInfo.stallCycles;
-    if (overrideInfo.ports.size()) exeInfo.ports = overrideInfo.ports;
-  }
-  return exeInfo;
-}
-
-std::shared_ptr<arch::ExceptionHandler> Architecture::handleException(
-    const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
-    MemoryInterface& memory) const {
-  return std::make_shared<ExceptionHandler>(instruction, core, memory, linux_);
-}
-
 int32_t Architecture::getSystemRegisterTag(uint16_t reg) const {
   // Check below is done for speculative instructions that may be passed into
   // the function but will not be executed. If such invalid speculative
   // instructions get through they can cause an out-of-range error.
   if (!systemRegisterMap_.count(reg)) return -1;
   return systemRegisterMap_.at(reg);
+}
+
+std::shared_ptr<arch::ExceptionHandler> Architecture::handleException(
+    const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
+    MemoryInterface& memory) const {
+  return std::make_shared<ExceptionHandler>(instruction, core, memory, linux_);
 }
 
 ProcessStateChange Architecture::getInitialState() const {
@@ -254,6 +239,22 @@ uint8_t Architecture::getMaxInstructionSize() const { return 4; }
 void Architecture::updateSystemTimerRegisters(RegisterFileSet* regFile,
                                               const uint64_t iterations) const {
   regFile->set(cycleSystemReg_, iterations);
+}
+
+ExecutionInfo Architecture::getExecutionInfo(const Instruction& insn) const {
+  // Assume no opcode-based override
+  ExecutionInfo exeInfo = groupExecutionInfo_.at(insn.getGroup());
+  if (opcodeExecutionInfo_.find(insn.getMetadata().opcode) !=
+      opcodeExecutionInfo_.end()) {
+    // Replace with overrided values
+    ExecutionInfo overrideInfo =
+        opcodeExecutionInfo_.at(insn.getMetadata().opcode);
+    if (overrideInfo.latency != 0) exeInfo.latency = overrideInfo.latency;
+    if (overrideInfo.stallCycles != 0)
+      exeInfo.stallCycles = overrideInfo.stallCycles;
+    if (overrideInfo.ports.size()) exeInfo.ports = overrideInfo.ports;
+  }
+  return exeInfo;
 }
 
 }  // namespace riscv

--- a/src/lib/arch/riscv/Instruction.cc
+++ b/src/lib/arch/riscv/Instruction.cc
@@ -149,7 +149,7 @@ uint16_t Instruction::getGroup() const {
   return base + 2;  // Default return is {Data type}_SIMPLE_ARTH
 }
 
-void Instruction::setExecutionInfo(const executionInfo& info) {
+void Instruction::setExecutionInfo(const ExecutionInfo& info) {
   if (isLoad_ || isStore_) {
     lsqExecutionLatency_ = info.latency;
   } else {

--- a/test/unit/MockArchitecture.hh
+++ b/test/unit/MockArchitecture.hh
@@ -8,6 +8,7 @@ namespace simeng {
 /** Mock implementation of the `Architecture` interface. */
 class MockArchitecture : public arch::Architecture {
  public:
+  MockArchitecture(kernel::Linux& kernel) : arch::Architecture(kernel) {}
   MOCK_CONST_METHOD4(predecode,
                      uint8_t(const void* ptr, uint16_t bytesAvailable,
                              uint64_t instructionAddress, MacroOp& output));
@@ -21,6 +22,7 @@ class MockArchitecture : public arch::Architecture {
   MOCK_CONST_METHOD0(getMaxInstructionSize, uint8_t());
   MOCK_CONST_METHOD2(updateSystemTimerRegisters,
                      void(RegisterFileSet* regFile, const uint64_t iterations));
+  MOCK_CONST_METHOD1(getExecutionInfo, ExecutionInfo(const Instruction& insn));
 };
 
 }  // namespace simeng

--- a/test/unit/MockArchitecture.hh
+++ b/test/unit/MockArchitecture.hh
@@ -22,7 +22,6 @@ class MockArchitecture : public arch::Architecture {
   MOCK_CONST_METHOD0(getMaxInstructionSize, uint8_t());
   MOCK_CONST_METHOD2(updateSystemTimerRegisters,
                      void(RegisterFileSet* regFile, const uint64_t iterations));
-  MOCK_CONST_METHOD1(getExecutionInfo, ExecutionInfo(const Instruction& insn));
 };
 
 }  // namespace simeng

--- a/test/unit/aarch64/ArchitectureTest.cc
+++ b/test/unit/aarch64/ArchitectureTest.cc
@@ -214,6 +214,25 @@ TEST_F(AArch64ArchitectureTest, updateSystemTimerRegisters) {
   }
 }
 
+TEST_F(AArch64ArchitectureTest, getExecutionInfo) {
+  MacroOp insn;
+  uint64_t bytes = arch->predecode(validInstrBytes.data(),
+                                   validInstrBytes.size(), 0x4, insn);
+  // Insn[0] = fdivr z1.s, p0/m, z1.s, z0.s
+  Instruction* aarch64Insn = reinterpret_cast<Instruction*>(insn[0].get());
+  EXPECT_EQ(bytes, 4);
+  EXPECT_EQ(aarch64Insn->getInstructionAddress(), 0x4);
+  EXPECT_EQ(aarch64Insn->exceptionEncountered(), false);
+
+  ExecutionInfo info = arch->getExecutionInfo(*aarch64Insn);
+
+  // Latencies and Port numbers from a64fx.yaml
+  EXPECT_EQ(info.latency, 98);
+  EXPECT_EQ(info.stallCycles, 98);
+  std::vector<uint16_t> ports = {0};
+  EXPECT_EQ(info.ports, ports);
+}
+
 TEST_F(AArch64ArchitectureTest, get_set_SVCRVal) {
   EXPECT_EQ(arch->getSVCRval(), 0);
   arch->setSVCRval(3);

--- a/test/unit/aarch64/ArchitectureTest.cc
+++ b/test/unit/aarch64/ArchitectureTest.cc
@@ -214,25 +214,6 @@ TEST_F(AArch64ArchitectureTest, updateSystemTimerRegisters) {
   }
 }
 
-TEST_F(AArch64ArchitectureTest, getExecutionInfo) {
-  MacroOp insn;
-  uint64_t bytes = arch->predecode(validInstrBytes.data(),
-                                   validInstrBytes.size(), 0x4, insn);
-  // Insn[0] = fdivr z1.s, p0/m, z1.s, z0.s
-  Instruction* aarch64Insn = reinterpret_cast<Instruction*>(insn[0].get());
-  EXPECT_EQ(bytes, 4);
-  EXPECT_EQ(aarch64Insn->getInstructionAddress(), 0x4);
-  EXPECT_EQ(aarch64Insn->exceptionEncountered(), false);
-
-  ExecutionInfo info = arch->getExecutionInfo(*aarch64Insn);
-
-  // Latencies and Port numbers from a64fx.yaml
-  EXPECT_EQ(info.latency, 98);
-  EXPECT_EQ(info.stallCycles, 98);
-  std::vector<uint16_t> ports = {0};
-  EXPECT_EQ(info.ports, ports);
-}
-
 TEST_F(AArch64ArchitectureTest, get_set_SVCRVal) {
   EXPECT_EQ(arch->getSVCRval(), 0);
   arch->setSVCRval(3);

--- a/test/unit/aarch64/InstructionTest.cc
+++ b/test/unit/aarch64/InstructionTest.cc
@@ -1,5 +1,4 @@
 #include "../ConfigInit.hh"
-#include "../MockArchitecture.hh"
 #include "arch/aarch64/InstructionMetadata.hh"
 #include "gmock/gmock.h"
 #include "simeng/arch/aarch64/Instruction.hh"

--- a/test/unit/pipeline/FetchUnitTest.cc
+++ b/test/unit/pipeline/FetchUnitTest.cc
@@ -6,7 +6,6 @@
 #include "gtest/gtest.h"
 #include "simeng/Instruction.hh"
 #include "simeng/arch/Architecture.hh"
-// #include "simeng/kernel/Linux.hh"
 #include "simeng/pipeline/FetchUnit.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
 

--- a/test/unit/pipeline/FetchUnitTest.cc
+++ b/test/unit/pipeline/FetchUnitTest.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "simeng/Instruction.hh"
 #include "simeng/arch/Architecture.hh"
+#include "simeng/kernel/Linux.hh"
 #include "simeng/pipeline/FetchUnit.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
 
@@ -29,6 +30,9 @@ class PipelineFetchUnitTest : public testing::Test {
  public:
   PipelineFetchUnitTest()
       : output(1, {}),
+        linux(config::SimInfo::getConfig()["CPU-Info"]["Special-File-Dir-Path"]
+                  .as<std::string>()),
+        isa(linux),
         fetchBuffer({{0, 16}, 0, 0}),
         completedReads(&fetchBuffer, 1),
         fetchUnit(output, memory, 1024, 0, blockSize, isa, predictor),
@@ -45,6 +49,7 @@ class PipelineFetchUnitTest : public testing::Test {
 
   PipelineBuffer<MacroOp> output;
   MockMemoryInterface memory;
+  kernel::Linux linux;
   MockArchitecture isa;
   MockBranchPredictor predictor;
 

--- a/test/unit/pipeline/FetchUnitTest.cc
+++ b/test/unit/pipeline/FetchUnitTest.cc
@@ -6,7 +6,7 @@
 #include "gtest/gtest.h"
 #include "simeng/Instruction.hh"
 #include "simeng/arch/Architecture.hh"
-#include "simeng/kernel/Linux.hh"
+// #include "simeng/kernel/Linux.hh"
 #include "simeng/pipeline/FetchUnit.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
 

--- a/test/unit/riscv/InstructionTest.cc
+++ b/test/unit/riscv/InstructionTest.cc
@@ -1,5 +1,4 @@
 #include "../ConfigInit.hh"
-#include "../MockArchitecture.hh"
 #include "arch/riscv/InstructionMetadata.hh"
 #include "gmock/gmock.h"
 #include "simeng/arch/riscv/Instruction.hh"


### PR DESCRIPTION
This PR moves common variables into the base Architecture class, ensures functions in `.cc` and `.hh` are in the same order, and generally makes the classes consistent with the codebase.

Closes Issue #357 