### PR TITLE
Core class cleanup

### DIFF
--- a/src/include/simeng/Core.hh
+++ b/src/include/simeng/Core.hh
@@ -27,8 +27,7 @@ class Core {
         registerFileSet_(regFileStructure),
         clockFrequency_(
             config::SimInfo::getConfig()["Core"]["Clock-Frequency-GHz"]
-                .as<float>() *
-            1e9) {}
+                .as<float>()) {}
 
   virtual ~Core() {}
 
@@ -45,11 +44,14 @@ class Core {
   /** Retrieve the number of instructions retired. */
   virtual uint64_t getInstructionsRetiredCount() const = 0;
 
-  /** Retrieve the simulated nanoseconds elapsed since the core started. */
-  virtual uint64_t getSystemTimer() const = 0;
-
   /** Retrieve a map of statistics to report. */
   virtual std::map<std::string, std::string> getStats() const = 0;
+
+  /** Retrieve the simulated nanoseconds elapsed since the core started. */
+  uint64_t getSystemTimer() const {
+    // TODO: This will need to be changed if we start supporting DVFS.
+    return (ticks_ / clockFrequency_);
+  }
 
  protected:
   /** Apply changes to the process state. */
@@ -111,8 +113,8 @@ class Core {
   /** Whether or not the core has halted. */
   bool hasHalted_ = false;
 
-  /** Clock frequency of core in Hz */
-  uint64_t clockFrequency_ = 0;
+  /** Clock frequency of core in GHz */
+  float clockFrequency_ = 0.0f;
 };
 
 }  // namespace simeng

--- a/src/include/simeng/Core.hh
+++ b/src/include/simeng/Core.hh
@@ -5,9 +5,9 @@
 #include <string>
 
 #include "simeng/ArchitecturalRegisterFileSet.hh"
-#include "simeng/MemoryInterface.hh"
 #include "simeng/arch/ProcessStateChange.hh"
 #include "simeng/config/SimInfo.hh"
+#include "simeng/memory/MemoryInterface.hh"
 
 namespace simeng {
 
@@ -20,7 +20,7 @@ class ExceptionHandler;
 /** An abstract core model. */
 class Core {
  public:
-  Core(MemoryInterface& dataMemory, const arch::Architecture& isa,
+  Core(memory::MemoryInterface& dataMemory, const arch::Architecture& isa,
        const std::vector<RegisterFileStructure>& regFileStructure)
       : dataMemory_(dataMemory),
         isa_(isa),
@@ -94,7 +94,7 @@ class Core {
   }
 
   /** A memory interface to access data. */
-  MemoryInterface& dataMemory_;
+  memory::MemoryInterface& dataMemory_;
 
   /** The currently used ISA. */
   const arch::Architecture& isa_;

--- a/src/include/simeng/Core.hh
+++ b/src/include/simeng/Core.hh
@@ -4,15 +4,31 @@
 #include <map>
 #include <string>
 
+#include "simeng/ArchitecturalRegisterFileSet.hh"
+#include "simeng/MemoryInterface.hh"
 #include "simeng/config/SimInfo.hh"
 
 namespace simeng {
 
-class ArchitecturalRegisterFileSet;
+namespace arch {
+// Forward declare Architecture and ExceptionHandler classes.
+class Architecture;
+class ExceptionHandler;
+}  // namespace arch
 
 /** An abstract core model. */
 class Core {
  public:
+  Core(MemoryInterface& dataMemory, const arch::Architecture& isa,
+       const std::vector<RegisterFileStructure>& regFileStructure)
+      : dataMemory_(dataMemory),
+        isa_(isa),
+        registerFileSet_(regFileStructure),
+        clockFrequency_(
+            config::SimInfo::getConfig()["Core"]["Clock-Frequency-GHz"]
+                .as<float>() *
+            1e9) {}
+
   virtual ~Core() {}
 
   /** Tick the core. */
@@ -33,6 +49,28 @@ class Core {
 
   /** Retrieve a map of statistics to report. */
   virtual std::map<std::string, std::string> getStats() const = 0;
+
+ protected:
+  /** A memory interface to access data. */
+  MemoryInterface& dataMemory_;
+
+  /** The currently used ISA. */
+  const arch::Architecture& isa_;
+
+  /** The core's register file set. */
+  RegisterFileSet registerFileSet_;
+
+  /** The active exception handler. */
+  std::shared_ptr<arch::ExceptionHandler> exceptionHandler_;
+
+  /** The number of times this core has been ticked. */
+  uint64_t ticks_ = 0;
+
+  /** Whether or not the core has halted. */
+  bool hasHalted_ = false;
+
+  /** Clock frequency of core in Hz */
+  uint64_t clockFrequency_ = 0;
 };
 
 }  // namespace simeng

--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -5,8 +5,6 @@
 #include "simeng/AlwaysNotTakenPredictor.hh"
 #include "simeng/Core.hh"
 #include "simeng/Elf.hh"
-#include "simeng/FixedLatencyMemoryInterface.hh"
-#include "simeng/FlatMemoryInterface.hh"
 #include "simeng/GenericPredictor.hh"
 #include "simeng/PerceptronPredictor.hh"
 #include "simeng/SpecialFileDirGen.hh"
@@ -15,6 +13,8 @@
 #include "simeng/arch/riscv/Architecture.hh"
 #include "simeng/config/SimInfo.hh"
 #include "simeng/kernel/Linux.hh"
+#include "simeng/memory/FixedLatencyMemoryInterface.hh"
+#include "simeng/memory/FlatMemoryInterface.hh"
 #include "simeng/models/emulation/Core.hh"
 #include "simeng/models/inorder/Core.hh"
 #include "simeng/models/outoforder/Core.hh"
@@ -52,10 +52,11 @@ class CoreInstance {
   ~CoreInstance();
 
   /** Set the SimEng L1 instruction cache memory. */
-  void setL1InstructionMemory(std::shared_ptr<simeng::MemoryInterface> memRef);
+  void setL1InstructionMemory(
+      std::shared_ptr<simeng::memory::MemoryInterface> memRef);
 
   /** Set the SimEng L1 data cache memory. */
-  void setL1DataMemory(std::shared_ptr<simeng::MemoryInterface> memRef);
+  void setL1DataMemory(std::shared_ptr<simeng::memory::MemoryInterface> memRef);
 
   /** Construct the core and all its associated simulation objects after the
    * process and memory interfaces have been instantiated. */
@@ -65,10 +66,10 @@ class CoreInstance {
   std::shared_ptr<simeng::Core> getCore() const;
 
   /** Getter for the create data memory object. */
-  std::shared_ptr<simeng::MemoryInterface> getDataMemory() const;
+  std::shared_ptr<simeng::memory::MemoryInterface> getDataMemory() const;
 
   /** Getter for the create instruction memory object. */
-  std::shared_ptr<simeng::MemoryInterface> getInstructionMemory() const;
+  std::shared_ptr<simeng::memory::MemoryInterface> getInstructionMemory() const;
 
   /** Getter for a shared pointer to the created process image. */
   std::shared_ptr<char> getProcessImage() const;
@@ -95,10 +96,10 @@ class CoreInstance {
   void createProcessMemory();
 
   /** Construct the SimEng L1 instruction cache memory. */
-  void createL1InstructionMemory(const simeng::MemInterfaceType type);
+  void createL1InstructionMemory(const memory::MemInterfaceType type);
 
   /** Construct the SimEng L1 data cache memory. */
-  void createL1DataMemory(const simeng::MemInterfaceType type);
+  void createL1DataMemory(const memory::MemInterfaceType type);
 
   /** Construct the special file directory. */
   void createSpecialFileDirectory();
@@ -146,10 +147,10 @@ class CoreInstance {
   std::shared_ptr<simeng::Core> core_ = nullptr;
 
   /** Reference to the SimEng data memory object. */
-  std::shared_ptr<simeng::MemoryInterface> dataMemory_ = nullptr;
+  std::shared_ptr<simeng::memory::MemoryInterface> dataMemory_ = nullptr;
 
   /** Reference to the SimEng instruction memory object. */
-  std::shared_ptr<simeng::MemoryInterface> instructionMemory_ = nullptr;
+  std::shared_ptr<simeng::memory::MemoryInterface> instructionMemory_ = nullptr;
 };
 
 }  // namespace simeng

--- a/src/include/simeng/Elf.hh
+++ b/src/include/simeng/Elf.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/include/simeng/Instruction.hh
+++ b/src/include/simeng/Instruction.hh
@@ -5,7 +5,7 @@
 #include "capstone/capstone.h"
 #include "simeng/BranchPredictor.hh"
 #include "simeng/MemoryInterface.hh"
-#include "simeng/RegisterFileSet.hh"
+#include "simeng/Register.hh"
 #include "simeng/RegisterValue.hh"
 #include "simeng/span.hh"
 

--- a/src/include/simeng/Instruction.hh
+++ b/src/include/simeng/Instruction.hh
@@ -4,9 +4,9 @@
 
 #include "capstone/capstone.h"
 #include "simeng/BranchPredictor.hh"
-#include "simeng/MemoryInterface.hh"
 #include "simeng/Register.hh"
 #include "simeng/RegisterValue.hh"
+#include "simeng/memory/MemoryInterface.hh"
 #include "simeng/span.hh"
 
 using InstructionException = short;
@@ -84,13 +84,14 @@ class Instruction {
   virtual const span<RegisterValue> getResults() const = 0;
 
   /** Generate memory addresses this instruction wishes to access. */
-  virtual span<const MemoryAccessTarget> generateAddresses() = 0;
+  virtual span<const memory::MemoryAccessTarget> generateAddresses() = 0;
 
   /** Provide data from a requested memory address. */
   virtual void supplyData(uint64_t address, const RegisterValue& data) = 0;
 
   /** Retrieve previously generated memory addresses. */
-  virtual span<const MemoryAccessTarget> getGeneratedAddresses() const = 0;
+  virtual span<const memory::MemoryAccessTarget> getGeneratedAddresses()
+      const = 0;
 
   /** Retrieve supplied memory data. */
   virtual span<const RegisterValue> getData() const = 0;

--- a/src/include/simeng/Register.hh
+++ b/src/include/simeng/Register.hh
@@ -1,0 +1,29 @@
+#pragma once
+#include <iostream>
+
+namespace simeng {
+
+/** A generic register identifier. */
+struct Register {
+  /** An identifier representing the type of register - e.g. 0 = general, 1 =
+   * vector. Used to determine which register file to access. */
+  uint8_t type;
+
+  /** A tag identifying the register. May correspond to either physical or
+   * architectural register, depending on point of usage. */
+  uint16_t tag;
+
+  /** A boolean identifier for whether the creation of this register has been a
+   * result of a register renaming scheme. */
+  bool renamed = false;
+
+  /** Check for equality of two register identifiers. */
+  bool operator==(const Register& other) const {
+    return (other.type == type && other.tag == tag);
+  }
+
+  /** Check for inequality of two register identifiers. */
+  bool operator!=(const Register& other) const { return !(other == *this); }
+};
+
+}  // namespace simeng

--- a/src/include/simeng/RegisterFileSet.hh
+++ b/src/include/simeng/RegisterFileSet.hh
@@ -2,31 +2,10 @@
 
 #include <vector>
 
+#include "simeng/Register.hh"
 #include "simeng/RegisterValue.hh"
 
 namespace simeng {
-
-/** A generic register identifier. */
-struct Register {
-  /** An identifier representing the type of register - e.g. 0 = general, 1 =
-   * vector. Used to determine which register file to access. */
-  uint8_t type;
-
-  /** A tag identifying the register. May correspond to either physical or
-   * architectural register, depending on point of usage. */
-  uint16_t tag;
-
-  /** A boolean identifier for whether the creation of this register has been a
-   * result of a register renaming scheme. */
-  bool renamed = false;
-
-  /** Check for equality of two register identifiers. */
-  bool operator==(const Register& other) const;
-
-  /** Check for inequality of two register identifiers. */
-  bool operator!=(const Register& other) const;
-};
-std::ostream& operator<<(std::ostream& os, simeng::Register const& reg);
 
 /** Defines the structure of a register file. */
 struct RegisterFileStructure {

--- a/src/include/simeng/arch/Architecture.hh
+++ b/src/include/simeng/arch/Architecture.hh
@@ -6,9 +6,9 @@
 #include "simeng/BranchPredictor.hh"
 #include "simeng/Core.hh"
 #include "simeng/Instruction.hh"
-#include "simeng/MemoryInterface.hh"
 #include "simeng/arch/ProcessStateChange.hh"
 #include "simeng/kernel/Linux.hh"
+#include "simeng/memory/MemoryInterface.hh"
 
 namespace simeng {
 
@@ -66,7 +66,7 @@ class Architecture {
    * obtained. */
   virtual std::shared_ptr<ExceptionHandler> handleException(
       const std::shared_ptr<Instruction>& instruction, const Core& core,
-      MemoryInterface& memory) const = 0;
+      memory::MemoryInterface& memory) const = 0;
 
   /** Retrieve the initial process state. */
   virtual ProcessStateChange getInitialState() const = 0;

--- a/src/include/simeng/arch/Architecture.hh
+++ b/src/include/simeng/arch/Architecture.hh
@@ -7,6 +7,7 @@
 #include "simeng/Core.hh"
 #include "simeng/Instruction.hh"
 #include "simeng/MemoryInterface.hh"
+#include "simeng/arch/ProcessStateChange.hh"
 #include "simeng/kernel/Linux.hh"
 
 namespace simeng {
@@ -14,23 +15,6 @@ namespace simeng {
 using MacroOp = std::vector<std::shared_ptr<Instruction>>;
 
 namespace arch {
-
-/** The types of changes that can be made to values within the process state. */
-enum class ChangeType { REPLACEMENT, INCREMENT, DECREMENT };
-
-/** A structure describing a set of changes to the process state. */
-struct ProcessStateChange {
-  /** Type of changes to be made */
-  ChangeType type;
-  /** Registers to modify */
-  std::vector<Register> modifiedRegisters;
-  /** Values to set modified registers to */
-  std::vector<RegisterValue> modifiedRegisterValues;
-  /** Memory address/width pairs to modify */
-  std::vector<MemoryAccessTarget> memoryAddresses;
-  /** Values to write to memory */
-  std::vector<RegisterValue> memoryAddressValues;
-};
 
 /** The result from a handled exception. */
 struct ExceptionResult {

--- a/src/include/simeng/arch/ProcessStateChange.hh
+++ b/src/include/simeng/arch/ProcessStateChange.hh
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <vector>
+
+#include "simeng/MemoryInterface.hh"
+#include "simeng/Register.hh"
+#include "simeng/RegisterValue.hh"
+
 namespace simeng {
 
 namespace arch {

--- a/src/include/simeng/arch/ProcessStateChange.hh
+++ b/src/include/simeng/arch/ProcessStateChange.hh
@@ -4,7 +4,7 @@
 
 #include "simeng/Register.hh"
 #include "simeng/RegisterValue.hh"
-#include "simeng/memory/MemoryInterface.hh"
+#include "simeng/memory/MemoryAccessTarget.hh"
 
 namespace simeng {
 

--- a/src/include/simeng/arch/ProcessStateChange.hh
+++ b/src/include/simeng/arch/ProcessStateChange.hh
@@ -2,9 +2,9 @@
 
 #include <vector>
 
-#include "simeng/MemoryInterface.hh"
 #include "simeng/Register.hh"
 #include "simeng/RegisterValue.hh"
+#include "simeng/memory/MemoryInterface.hh"
 
 namespace simeng {
 
@@ -22,7 +22,7 @@ struct ProcessStateChange {
   /** Values to set modified registers to */
   std::vector<RegisterValue> modifiedRegisterValues;
   /** Memory address/width pairs to modify */
-  std::vector<MemoryAccessTarget> memoryAddresses;
+  std::vector<memory::MemoryAccessTarget> memoryAddresses;
   /** Values to write to memory */
   std::vector<RegisterValue> memoryAddressValues;
 };

--- a/src/include/simeng/arch/ProcessStateChange.hh
+++ b/src/include/simeng/arch/ProcessStateChange.hh
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace simeng {
+
+namespace arch {
+
+/** The types of changes that can be made to values within the process state. */
+enum class ChangeType { REPLACEMENT, INCREMENT, DECREMENT };
+
+/** A structure describing a set of changes to the process state. */
+struct ProcessStateChange {
+  /** Type of changes to be made */
+  ChangeType type;
+  /** Registers to modify */
+  std::vector<Register> modifiedRegisters;
+  /** Values to set modified registers to */
+  std::vector<RegisterValue> modifiedRegisterValues;
+  /** Memory address/width pairs to modify */
+  std::vector<MemoryAccessTarget> memoryAddresses;
+  /** Values to write to memory */
+  std::vector<RegisterValue> memoryAddressValues;
+};
+
+}  // namespace arch
+}  // namespace simeng

--- a/src/include/simeng/arch/aarch64/Architecture.hh
+++ b/src/include/simeng/arch/aarch64/Architecture.hh
@@ -39,7 +39,7 @@ class Architecture : public arch::Architecture {
    * the exception is resolved, and results then obtained. */
   std::shared_ptr<arch::ExceptionHandler> handleException(
       const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
-      MemoryInterface& memory) const override;
+      memory::MemoryInterface& memory) const override;
 
   /** Retrieve the initial process state. */
   ProcessStateChange getInitialState() const override;

--- a/src/include/simeng/arch/aarch64/ExceptionHandler.hh
+++ b/src/include/simeng/arch/aarch64/ExceptionHandler.hh
@@ -16,7 +16,7 @@ class ExceptionHandler : public simeng::arch::ExceptionHandler {
   /** Create an exception handler with references to the instruction that caused
    * the exception, along with the core model object and process memory. */
   ExceptionHandler(const std::shared_ptr<simeng::Instruction>& instruction,
-                   const Core& core, MemoryInterface& memory,
+                   const Core& core, memory::MemoryInterface& memory,
                    kernel::Linux& linux);
 
   /** Progress handling of the exception, by calling and returning the result of
@@ -78,7 +78,7 @@ class ExceptionHandler : public simeng::arch::ExceptionHandler {
   const Core& core_;
 
   /** The process memory. */
-  MemoryInterface& memory_;
+  memory::MemoryInterface& memory_;
 
   /** The Linux kernel to forward syscalls to. */
   kernel::Linux& linux_;

--- a/src/include/simeng/arch/aarch64/Instruction.hh
+++ b/src/include/simeng/arch/aarch64/Instruction.hh
@@ -271,10 +271,10 @@ class Instruction : public simeng::Instruction {
   const span<RegisterValue> getResults() const override;
 
   /** Generate memory addresses this instruction wishes to access. */
-  span<const MemoryAccessTarget> generateAddresses() override;
+  span<const memory::MemoryAccessTarget> generateAddresses() override;
 
   /** Retrieve previously generated memory addresses. */
-  span<const MemoryAccessTarget> getGeneratedAddresses() const override;
+  span<const memory::MemoryAccessTarget> getGeneratedAddresses() const override;
 
   /** Provide data from a requested memory address. */
   void supplyData(uint64_t address, const RegisterValue& data) override;
@@ -427,15 +427,16 @@ class Instruction : public simeng::Instruction {
   // Memory
   /** Set the accessed memory addresses, and create a corresponding memory data
    * vector. */
-  void setMemoryAddresses(const std::vector<MemoryAccessTarget>& addresses);
+  void setMemoryAddresses(
+      const std::vector<memory::MemoryAccessTarget>& addresses);
 
-  void setMemoryAddresses(std::vector<MemoryAccessTarget>&& addresses);
+  void setMemoryAddresses(std::vector<memory::MemoryAccessTarget>&& addresses);
 
-  void setMemoryAddresses(MemoryAccessTarget address);
+  void setMemoryAddresses(memory::MemoryAccessTarget address);
 
   /** The memory addresses this instruction accesses, as a vector of {offset,
    * width} pairs. */
-  std::vector<MemoryAccessTarget> memoryAddresses_;
+  std::vector<memory::MemoryAccessTarget> memoryAddresses_;
 
   /** A vector of memory values, that were either loaded memory, or are prepared
    * for sending to memory (according to instruction type). Each entry

--- a/src/include/simeng/arch/riscv/Architecture.hh
+++ b/src/include/simeng/arch/riscv/Architecture.hh
@@ -37,7 +37,7 @@ class Architecture : public arch::Architecture {
    * the exception is resolved, and results then obtained. */
   std::shared_ptr<arch::ExceptionHandler> handleException(
       const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
-      MemoryInterface& memory) const override;
+      memory::MemoryInterface& memory) const override;
 
   /** Retrieve the initial process state. */
   ProcessStateChange getInitialState() const override;

--- a/src/include/simeng/arch/riscv/ExceptionHandler.hh
+++ b/src/include/simeng/arch/riscv/ExceptionHandler.hh
@@ -16,7 +16,7 @@ class ExceptionHandler : public simeng::arch::ExceptionHandler {
   /** Create an exception handler with references to the instruction that caused
    * the exception, along with the core model object and process memory. */
   ExceptionHandler(const std::shared_ptr<simeng::Instruction>& instruction,
-                   const Core& core, MemoryInterface& memory,
+                   const Core& core, memory::MemoryInterface& memory,
                    kernel::Linux& linux);
 
   /** Progress handling of the exception, by calling and returning the result of
@@ -78,7 +78,7 @@ class ExceptionHandler : public simeng::arch::ExceptionHandler {
   const Core& core_;
 
   /** The process memory. */
-  MemoryInterface& memory_;
+  memory::MemoryInterface& memory_;
 
   /** The Linux kernel to forward syscalls to. */
   kernel::Linux& linux_;

--- a/src/include/simeng/arch/riscv/Instruction.hh
+++ b/src/include/simeng/arch/riscv/Instruction.hh
@@ -98,10 +98,10 @@ class Instruction : public simeng::Instruction {
   const span<RegisterValue> getResults() const override;
 
   /** Generate memory addresses this instruction wishes to access. */
-  span<const MemoryAccessTarget> generateAddresses() override;
+  span<const memory::MemoryAccessTarget> generateAddresses() override;
 
   /** Retrieve previously generated memory addresses. */
-  span<const MemoryAccessTarget> getGeneratedAddresses() const override;
+  span<const memory::MemoryAccessTarget> getGeneratedAddresses() const override;
 
   /** Provide data from a requested memory address. */
   void supplyData(uint64_t address, const RegisterValue& data) override;
@@ -239,11 +239,12 @@ class Instruction : public simeng::Instruction {
   // Memory
   /** Set the accessed memory addresses, and create a corresponding memory data
    * vector. */
-  void setMemoryAddresses(const std::vector<MemoryAccessTarget>& addresses);
+  void setMemoryAddresses(
+      const std::vector<memory::MemoryAccessTarget>& addresses);
 
   /** The memory addresses this instruction accesses, as a vector of {offset,
    * width} pairs. */
-  std::vector<MemoryAccessTarget> memoryAddresses_;
+  std::vector<memory::MemoryAccessTarget> memoryAddresses_;
 
   /** A vector of memory values, that were either loaded memory, or are prepared
    * for sending to memory (according to instruction type). Each entry

--- a/src/include/simeng/memory/FixedLatencyMemoryInterface.hh
+++ b/src/include/simeng/memory/FixedLatencyMemoryInterface.hh
@@ -3,9 +3,11 @@
 #include <queue>
 #include <vector>
 
-#include "simeng/MemoryInterface.hh"
+#include "simeng/memory/MemoryInterface.hh"
 
 namespace simeng {
+
+namespace memory {
 
 /** A fixed-latency memory interface request. */
 struct FixedLatencyMemoryInterfaceRequest {
@@ -86,4 +88,5 @@ class FixedLatencyMemoryInterface : public MemoryInterface {
   }
 };
 
+}  // namespace memory
 }  // namespace simeng

--- a/src/include/simeng/memory/FlatMemoryInterface.hh
+++ b/src/include/simeng/memory/FlatMemoryInterface.hh
@@ -2,9 +2,11 @@
 
 #include <vector>
 
-#include "simeng/MemoryInterface.hh"
+#include "simeng/memory/MemoryInterface.hh"
 
 namespace simeng {
+
+namespace memory {
 
 /** A memory interface to a flat memory system. */
 class FlatMemoryInterface : public MemoryInterface {
@@ -42,4 +44,5 @@ class FlatMemoryInterface : public MemoryInterface {
   std::vector<MemoryReadResult> completedReads_;
 };
 
+}  // namespace memory
 }  // namespace simeng

--- a/src/include/simeng/memory/MemoryAccessTarget.hh
+++ b/src/include/simeng/memory/MemoryAccessTarget.hh
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace simeng {
+
+namespace memory {
+
+/** A generic memory access target; describes a region of memory to access. */
+struct MemoryAccessTarget {
+  /** The address to access. */
+  uint64_t address;
+  /** The number of bytes to access at `address`. */
+  uint16_t size;
+
+  /** Check for equality of two access targets. */
+  bool operator==(const MemoryAccessTarget& other) const {
+    return (address == other.address && size == other.size);
+  };
+
+  /** Check for inequality of two access targets. */
+  bool operator!=(const MemoryAccessTarget& other) const {
+    return !(other == *this);
+  }
+};
+
+}  // namespace memory
+}  // namespace simeng

--- a/src/include/simeng/memory/MemoryInterface.hh
+++ b/src/include/simeng/memory/MemoryInterface.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simeng/RegisterValue.hh"
+#include "simeng/memory/MemoryReadResult.hh"
 #include "simeng/span.hh"
 
 namespace simeng {
@@ -13,34 +14,6 @@ enum class MemInterfaceType {
   Fixed,    // A fixed, non-zero, access latency interface
   External  // An interface generated outside of the standard SimEng
             // instantiation
-};
-
-/** A generic memory access target; describes a region of memory to access. */
-struct MemoryAccessTarget {
-  /** The address to access. */
-  uint64_t address;
-  /** The number of bytes to access at `address`. */
-  uint16_t size;
-
-  /** Check for equality of two access targets. */
-  bool operator==(const MemoryAccessTarget& other) const {
-    return (address == other.address && size == other.size);
-  };
-
-  /** Check for inequality of two access targets. */
-  bool operator!=(const MemoryAccessTarget& other) const {
-    return !(other == *this);
-  }
-};
-
-/** A structure used for the result of memory read operations. */
-struct MemoryReadResult {
-  /** The memory access that was requested. */
-  MemoryAccessTarget target;
-  /** The data returned by the request. */
-  RegisterValue data;
-  /** The request identifier provided by the requester. */
-  uint64_t requestId;
 };
 
 /** An abstract memory interface. Describes a connection to a memory system to

--- a/src/include/simeng/memory/MemoryInterface.hh
+++ b/src/include/simeng/memory/MemoryInterface.hh
@@ -5,6 +5,8 @@
 
 namespace simeng {
 
+namespace memory {
+
 /** The available memory interface types. */
 enum class MemInterfaceType {
   Flat,     // A zero access latency interface
@@ -74,4 +76,5 @@ class MemoryInterface {
   virtual void tick() = 0;
 };
 
+}  // namespace memory
 }  // namespace simeng

--- a/src/include/simeng/memory/MemoryReadResult.hh
+++ b/src/include/simeng/memory/MemoryReadResult.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "simeng/RegisterValue.hh"
+#include "simeng/memory/MemoryAccessTarget.hh"
+
+namespace simeng {
+
+namespace memory {
+
+/** A structure used for the result of memory read operations. */
+struct MemoryReadResult {
+  /** The memory access that was requested. */
+  MemoryAccessTarget target;
+  /** The data returned by the request. */
+  RegisterValue data;
+  /** The request identifier provided by the requester. */
+  uint64_t requestId;
+};
+
+}  // namespace memory
+}  // namespace simeng

--- a/src/include/simeng/models/emulation/Core.hh
+++ b/src/include/simeng/models/emulation/Core.hh
@@ -36,9 +36,6 @@ class Core : public simeng::Core {
   /** Retrieve the number of instructions retired. */
   uint64_t getInstructionsRetiredCount() const override;
 
-  /** Retrieve the simulated nanoseconds elapsed since the core started. */
-  uint64_t getSystemTimer() const override;
-
   /** Retrieve a map of statistics to report. */
   std::map<std::string, std::string> getStats() const override;
 

--- a/src/include/simeng/models/emulation/Core.hh
+++ b/src/include/simeng/models/emulation/Core.hh
@@ -7,7 +7,6 @@
 #include "simeng/ArchitecturalRegisterFileSet.hh"
 #include "simeng/Core.hh"
 #include "simeng/MemoryInterface.hh"
-#include "simeng/RegisterFileSet.hh"
 #include "simeng/arch/Architecture.hh"
 #include "simeng/span.hh"
 

--- a/src/include/simeng/models/emulation/Core.hh
+++ b/src/include/simeng/models/emulation/Core.hh
@@ -6,7 +6,6 @@
 
 #include "simeng/ArchitecturalRegisterFileSet.hh"
 #include "simeng/Core.hh"
-#include "simeng/MemoryInterface.hh"
 #include "simeng/arch/Architecture.hh"
 #include "simeng/span.hh"
 
@@ -20,9 +19,9 @@ class Core : public simeng::Core {
   /** Construct an emulation-style core, providing memory interfaces for
    * instructions and data, along with the instruction entry point and an ISA to
    * use. */
-  Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
-       uint64_t entryPoint, uint64_t programByteLength,
-       const arch::Architecture& isa);
+  Core(memory::MemoryInterface& instructionMemory,
+       memory::MemoryInterface& dataMemory, uint64_t entryPoint,
+       uint64_t programByteLength, const arch::Architecture& isa);
 
   /** Tick the core. */
   void tick() override;
@@ -54,7 +53,7 @@ class Core : public simeng::Core {
   void processExceptionHandler();
 
   /** A memory interface to access instructions. */
-  MemoryInterface& instructionMemory_;
+  memory::MemoryInterface& instructionMemory_;
 
   /** An architectural register file set, serving as a simple wrapper around the
    * register file set. */
@@ -67,7 +66,7 @@ class Core : public simeng::Core {
   std::queue<std::shared_ptr<Instruction>> microOps_;
 
   /** The previously generated addresses. */
-  std::vector<simeng::MemoryAccessTarget> previousAddresses_;
+  std::vector<simeng::memory::MemoryAccessTarget> previousAddresses_;
 
   /** The current program counter. */
   uint64_t pc_ = 0;

--- a/src/include/simeng/models/emulation/Core.hh
+++ b/src/include/simeng/models/emulation/Core.hh
@@ -60,30 +60,9 @@ class Core : public simeng::Core {
   /** A memory interface to access instructions. */
   MemoryInterface& instructionMemory_;
 
-  /** A memory interface to access data. */
-  MemoryInterface& dataMemory_;
-
-  /** The previously generated addresses. */
-  std::vector<simeng::MemoryAccessTarget> previousAddresses_;
-
-  /** The length of the available instruction memory. */
-  uint64_t programByteLength_;
-
-  /** The currently used ISA. */
-  const arch::Architecture& isa_;
-
-  /** The current program counter. */
-  uint64_t pc_ = 0;
-
-  /** The core's register file set. */
-  RegisterFileSet registerFileSet_;
-
   /** An architectural register file set, serving as a simple wrapper around the
    * register file set. */
   ArchitecturalRegisterFileSet architecturalRegisterFileSet_;
-
-  /** Whether or not the core has halted. */
-  bool hasHalted_ = false;
 
   /** A reusable macro-op vector to fill with uops. */
   MacroOp macroOp_;
@@ -91,14 +70,17 @@ class Core : public simeng::Core {
   /** An internal buffer for storing one or more uops. */
   std::queue<std::shared_ptr<Instruction>> microOps_;
 
-  /** The active exception handler. */
-  std::shared_ptr<arch::ExceptionHandler> exceptionHandler_;
+  /** The previously generated addresses. */
+  std::vector<simeng::MemoryAccessTarget> previousAddresses_;
+
+  /** The current program counter. */
+  uint64_t pc_ = 0;
+
+  /** The length of the available instruction memory. */
+  uint64_t programByteLength_ = 0;
 
   /** Is the core waiting on a data read? */
-  unsigned int pendingReads_ = 0;
-
-  /** The number of times this core has been ticked. */
-  uint64_t ticks_ = 0;
+  uint64_t pendingReads_ = 0;
 
   /** The number of instructions executed. */
   uint64_t instructionsExecuted_ = 0;

--- a/src/include/simeng/models/emulation/Core.hh
+++ b/src/include/simeng/models/emulation/Core.hh
@@ -54,9 +54,6 @@ class Core : public simeng::Core {
   /** Process an active exception handler. */
   void processExceptionHandler();
 
-  /** Apply changes to the process state. */
-  void applyStateChange(const arch::ProcessStateChange& change);
-
   /** A memory interface to access instructions. */
   MemoryInterface& instructionMemory_;
 

--- a/src/include/simeng/models/inorder/Core.hh
+++ b/src/include/simeng/models/inorder/Core.hh
@@ -40,9 +40,6 @@ class Core : public simeng::Core {
   /** Retrieve the number of instructions retired. */
   uint64_t getInstructionsRetiredCount() const override;
 
-  /** Retrieve the simulated nanoseconds elapsed since the core started. */
-  uint64_t getSystemTimer() const override;
-
   /** Generate a map of statistics to report. */
   std::map<std::string, std::string> getStats() const override;
 

--- a/src/include/simeng/models/inorder/Core.hh
+++ b/src/include/simeng/models/inorder/Core.hh
@@ -71,9 +71,6 @@ class Core : public simeng::Core {
   /** Read pending registers for the most recently decoded instruction. */
   void readRegisters();
 
-  /** Apply changes to the process state. */
-  void applyStateChange(const arch::ProcessStateChange& change);
-
   /** An architectural register file set, serving as a simple wrapper around the
    * register file set. */
   ArchitecturalRegisterFileSet architecturalRegisterFileSet_;

--- a/src/include/simeng/models/inorder/Core.hh
+++ b/src/include/simeng/models/inorder/Core.hh
@@ -4,7 +4,7 @@
 
 #include "simeng/ArchitecturalRegisterFileSet.hh"
 #include "simeng/Core.hh"
-#include "simeng/FlatMemoryInterface.hh"
+#include "simeng/memory/FlatMemoryInterface.hh"
 #include "simeng/pipeline/DecodeUnit.hh"
 #include "simeng/pipeline/ExecuteUnit.hh"
 #include "simeng/pipeline/FetchUnit.hh"
@@ -20,9 +20,10 @@ class Core : public simeng::Core {
   /** Construct a core model, providing an ISA and branch predictor to use,
    * along with a pointer and size of instruction memory, and a pointer to
    * process memory. */
-  Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
-       uint64_t processMemorySize, uint64_t entryPoint,
-       const arch::Architecture& isa, BranchPredictor& branchPredictor);
+  Core(memory::MemoryInterface& instructionMemory,
+       memory::MemoryInterface& dataMemory, uint64_t processMemorySize,
+       uint64_t entryPoint, const arch::Architecture& isa,
+       BranchPredictor& branchPredictor);
 
   /** Tick the core. Ticks each of the pipeline stages sequentially, then ticks
    * the buffers between them. Checks for and executes pipeline flushes at the
@@ -76,7 +77,7 @@ class Core : public simeng::Core {
   ArchitecturalRegisterFileSet architecturalRegisterFileSet_;
 
   /** The previously generated addresses. */
-  std::queue<simeng::MemoryAccessTarget> previousAddresses_;
+  std::queue<simeng::memory::MemoryAccessTarget> previousAddresses_;
 
   /** The buffer between fetch and decode. */
   pipeline::PipelineBuffer<MacroOp> fetchToDecodeBuffer_;

--- a/src/include/simeng/models/inorder/Core.hh
+++ b/src/include/simeng/models/inorder/Core.hh
@@ -52,8 +52,15 @@ class Core : public simeng::Core {
   /** Handle an exception raised during the cycle. */
   void handleException();
 
+  /** Process the active exception handler. */
+  void processExceptionHandler();
+
+  /** Handle requesting/execution of a load instruction. */
+  void handleLoad(const std::shared_ptr<Instruction>& instruction);
+
   /** Load and supply memory data requested by an instruction. */
   void loadData(const std::shared_ptr<Instruction>& instruction);
+
   /** Store data supplied by an instruction to memory. */
   void storeData(const std::shared_ptr<Instruction>& instruction);
 
@@ -64,30 +71,15 @@ class Core : public simeng::Core {
   /** Read pending registers for the most recently decoded instruction. */
   void readRegisters();
 
-  /** Process the active exception handler. */
-  void processExceptionHandler();
-
   /** Apply changes to the process state. */
   void applyStateChange(const arch::ProcessStateChange& change);
-
-  /** Handle requesting/execution of a load instruction. */
-  void handleLoad(const std::shared_ptr<Instruction>& instruction);
-
-  /** The process memory. */
-  MemoryInterface& dataMemory_;
-
-  /** A reference to the core's architecture. */
-  const arch::Architecture& isa_;
-
-  /** The core's register file set. */
-  RegisterFileSet registerFileSet_;
 
   /** An architectural register file set, serving as a simple wrapper around the
    * register file set. */
   ArchitecturalRegisterFileSet architecturalRegisterFileSet_;
 
-  /** The process memory. */
-  span<char> processMemory;
+  /** The previously generated addresses. */
+  std::queue<simeng::MemoryAccessTarget> previousAddresses_;
 
   /** The buffer between fetch and decode. */
   pipeline::PipelineBuffer<MacroOp> fetchToDecodeBuffer_;
@@ -98,9 +90,6 @@ class Core : public simeng::Core {
   /** The buffer between execute and writeback. */
   std::vector<pipeline::PipelineBuffer<std::shared_ptr<Instruction>>>
       completionSlots_;
-
-  /** The previously generated addresses. */
-  std::queue<simeng::MemoryAccessTarget> previousAddresses_;
 
   /** The fetch unit; fetches instructions from memory. */
   pipeline::FetchUnit fetchUnit_;
@@ -118,20 +107,11 @@ class Core : public simeng::Core {
   /** The number of times the pipeline has been flushed. */
   uint64_t flushes_ = 0;
 
-  /** The number of times this core has been ticked. */
-  uint64_t ticks_ = 0;
-
   /** Whether an exception was generated during the cycle. */
   bool exceptionGenerated_ = false;
 
   /** A pointer to the instruction responsible for generating the exception. */
   std::shared_ptr<Instruction> exceptionGeneratingInstruction_;
-
-  /** Whether the core has halted. */
-  bool hasHalted_ = false;
-
-  /** The active exception handler. */
-  std::shared_ptr<arch::ExceptionHandler> exceptionHandler_;
 };
 
 }  // namespace inorder

--- a/src/include/simeng/models/outoforder/Core.hh
+++ b/src/include/simeng/models/outoforder/Core.hh
@@ -69,23 +69,15 @@ class Core : public simeng::Core {
   /** Inspect units and flush pipelines if required. */
   void flushIfNeeded();
 
-  const arch::Architecture& isa_;
-
   const std::vector<simeng::RegisterFileStructure> physicalRegisterStructures_;
 
   const std::vector<uint16_t> physicalRegisterQuantities_;
-
-  /** The core's register file set. */
-  RegisterFileSet registerFileSet_;
 
   /** The core's register alias table. */
   pipeline::RegisterAliasTable registerAliasTable_;
 
   /** The mapped register file set. */
   pipeline::MappedRegisterFileSet mappedRegisterFileSet_;
-
-  /** The process memory. */
-  MemoryInterface& dataMemory_;
 
   /** The buffer between fetch and decode. */
   pipeline::PipelineBuffer<MacroOp> fetchToDecodeBuffer_;
@@ -106,14 +98,8 @@ class Core : public simeng::Core {
   std::vector<pipeline::PipelineBuffer<std::shared_ptr<Instruction>>>
       completionSlots_;
 
-  /** The core's load/store queue. */
-  pipeline::LoadStoreQueue loadStoreQueue_;
-
   /** The fetch unit; fetches instructions from memory. */
   pipeline::FetchUnit fetchUnit_;
-
-  /** The core's reorder buffer. */
-  pipeline::ReorderBuffer reorderBuffer_;
 
   /** The decode unit; decodes instructions into uops and reads operands. */
   pipeline::DecodeUnit decodeUnit_;
@@ -133,34 +119,28 @@ class Core : public simeng::Core {
   /** The writeback unit; writes uop results to the register files. */
   pipeline::WritebackUnit writebackUnit_;
 
+  /** The core's reorder buffer. */
+  pipeline::ReorderBuffer reorderBuffer_;
+
+  /** The core's load/store queue. */
+  pipeline::LoadStoreQueue loadStoreQueue_;
+
   /** The port allocator unit; allocates a port that an instruction will be
    * issued from based on a defined algorithm. */
   pipeline::PortAllocator& portAllocator_;
 
-  /** Clock frequency of core */
-  unsigned int clockFrequency_ = 2.5 * 1e9;
-
   /** Core commit width; maximum number of instruction that can be committed per
    * cycle. */
-  unsigned int commitWidth_ = 6;
+  uint64_t commitWidth_ = 0;
 
   /** The number of times the pipeline has been flushed. */
   uint64_t flushes_ = 0;
-
-  /** The number of times this core has been ticked. */
-  uint64_t ticks_ = 0;
 
   /** Whether an exception was generated during the cycle. */
   bool exceptionGenerated_ = false;
 
   /** A pointer to the instruction responsible for generating the exception. */
   std::shared_ptr<Instruction> exceptionGeneratingInstruction_;
-
-  /** Whether the core has halted. */
-  bool hasHalted_ = false;
-
-  /** The active exception handler. */
-  std::shared_ptr<arch::ExceptionHandler> exceptionHandler_;
 };
 
 }  // namespace outoforder

--- a/src/include/simeng/models/outoforder/Core.hh
+++ b/src/include/simeng/models/outoforder/Core.hh
@@ -2,7 +2,6 @@
 
 #include "simeng/ArchitecturalRegisterFileSet.hh"
 #include "simeng/Core.hh"
-#include "simeng/MemoryInterface.hh"
 #include "simeng/pipeline/DecodeUnit.hh"
 #include "simeng/pipeline/DispatchIssueUnit.hh"
 #include "simeng/pipeline/ExecuteUnit.hh"
@@ -26,10 +25,10 @@ class Core : public simeng::Core {
  public:
   /** Construct a core model, providing the process memory, and an ISA, branch
    * predictor, and port allocator to use. */
-  Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
-       uint64_t processMemorySize, uint64_t entryPoint,
-       const arch::Architecture& isa, BranchPredictor& branchPredictor,
-       pipeline::PortAllocator& portAllocator,
+  Core(memory::MemoryInterface& instructionMemory,
+       memory::MemoryInterface& dataMemory, uint64_t processMemorySize,
+       uint64_t entryPoint, const arch::Architecture& isa,
+       BranchPredictor& branchPredictor, pipeline::PortAllocator& portAllocator,
        ryml::ConstNodeRef config = config::SimInfo::getConfig());
 
   /** Tick the core. Ticks each of the pipeline stages sequentially, then ticks

--- a/src/include/simeng/models/outoforder/Core.hh
+++ b/src/include/simeng/models/outoforder/Core.hh
@@ -63,9 +63,6 @@ class Core : public simeng::Core {
   /** Process the active exception handler. */
   void processExceptionHandler();
 
-  /** Apply changes to the process state. */
-  void applyStateChange(const arch::ProcessStateChange& change);
-
   /** Inspect units and flush pipelines if required. */
   void flushIfNeeded();
 

--- a/src/include/simeng/models/outoforder/Core.hh
+++ b/src/include/simeng/models/outoforder/Core.hh
@@ -46,9 +46,6 @@ class Core : public simeng::Core {
   /** Retrieve the number of instructions retired. */
   uint64_t getInstructionsRetiredCount() const override;
 
-  /** Retrieve the simulated nanoseconds elapsed since the core started. */
-  uint64_t getSystemTimer() const override;
-
   /** Generate a map of statistics to report. */
   std::map<std::string, std::string> getStats() const override;
 

--- a/src/include/simeng/pipeline/FetchUnit.hh
+++ b/src/include/simeng/pipeline/FetchUnit.hh
@@ -2,8 +2,8 @@
 
 #include <queue>
 
-#include "simeng/MemoryInterface.hh"
 #include "simeng/arch/Architecture.hh"
+#include "simeng/memory/MemoryInterface.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
 
 namespace simeng {
@@ -38,7 +38,8 @@ class FetchUnit {
  public:
   /** Construct a fetch unit with a reference to an output buffer, the ISA, and
    * the current branch predictor, and information on the instruction memory. */
-  FetchUnit(PipelineBuffer<MacroOp>& output, MemoryInterface& instructionMemory,
+  FetchUnit(PipelineBuffer<MacroOp>& output,
+            memory::MemoryInterface& instructionMemory,
             uint64_t programByteLength, uint64_t entryPoint, uint16_t blockSize,
             const arch::Architecture& isa, BranchPredictor& branchPredictor);
 
@@ -76,7 +77,7 @@ class FetchUnit {
   uint64_t pc_ = 0;
 
   /** An interface to the instruction memory. */
-  MemoryInterface& instructionMemory_;
+  memory::MemoryInterface& instructionMemory_;
 
   /** The length of the available instruction memory. */
   uint64_t programByteLength_;

--- a/src/include/simeng/pipeline/LoadStoreQueue.hh
+++ b/src/include/simeng/pipeline/LoadStoreQueue.hh
@@ -7,7 +7,7 @@
 #include <unordered_map>
 
 #include "simeng/Instruction.hh"
-#include "simeng/MemoryInterface.hh"
+#include "simeng/memory/MemoryInterface.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
 
 namespace simeng {
@@ -19,7 +19,7 @@ enum accessType { LOAD = 0, STORE };
 /** A requestQueue_ entry. */
 struct requestEntry {
   /** The memory address(es) to be accessed. */
-  std::queue<simeng::MemoryAccessTarget> reqAddresses;
+  std::queue<simeng::memory::MemoryAccessTarget> reqAddresses;
   /** The instruction sending the request(s). */
   std::shared_ptr<Instruction> insn;
 };
@@ -32,7 +32,7 @@ class LoadStoreQueue {
    * for both load and store instructions, supplying completion slots for loads
    * and an operand forwarding handler. */
   LoadStoreQueue(
-      unsigned int maxCombinedSpace, MemoryInterface& memory,
+      unsigned int maxCombinedSpace, memory::MemoryInterface& memory,
       span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
       std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
       std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
@@ -47,7 +47,7 @@ class LoadStoreQueue {
    * operand forwarding handler. */
   LoadStoreQueue(
       unsigned int maxLoadQueueSpace, unsigned int maxStoreQueueSpace,
-      MemoryInterface& memory,
+      memory::MemoryInterface& memory,
       span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
       std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
       std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
@@ -149,7 +149,7 @@ class LoadStoreQueue {
   unsigned int getCombinedSpace() const;
 
   /** A pointer to process memory. */
-  MemoryInterface& memory_;
+  memory::MemoryInterface& memory_;
 
   /** The load instruction associated with the most recently discovered memory
    * order violation. */

--- a/src/include/simeng/pipeline/ReorderBuffer.hh
+++ b/src/include/simeng/pipeline/ReorderBuffer.hh
@@ -56,7 +56,7 @@ class ReorderBuffer {
   void commitMicroOps(uint64_t insnId);
 
   /** Commit and remove up to `maxCommitSize` instructions. */
-  unsigned int commit(unsigned int maxCommitSize);
+  unsigned int commit(uint64_t maxCommitSize);
 
   /** Flush all instructions with a sequence ID greater than `afterSeqId`. */
   void flush(uint64_t afterInsnId);

--- a/src/include/simeng/pipeline/WritebackUnit.hh
+++ b/src/include/simeng/pipeline/WritebackUnit.hh
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "simeng/Instruction.hh"
+#include "simeng/RegisterFileSet.hh"
 #include "simeng/pipeline/PipelineBuffer.hh"
 
 namespace simeng {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -14,9 +14,11 @@ set(SIMENG_SOURCES
     arch/riscv/Instruction_decode.cc
     arch/riscv/Instruction_execute.cc
     arch/riscv/InstructionMetadata.cc
+    config/ModelConfig.cc
     kernel/Linux.cc
     kernel/LinuxProcess.cc
-    config/ModelConfig.cc
+    memory/FixedLatencyMemoryInterface.cc
+    memory/FlatMemoryInterface.cc
     models/emulation/Core.cc
     models/inorder/Core.cc
     models/outoforder/Core.cc
@@ -38,8 +40,6 @@ set(SIMENG_SOURCES
     CMakeLists.txt
     CoreInstance.cc
     Elf.cc
-    FixedLatencyMemoryInterface.cc
-    FlatMemoryInterface.cc
     GenericPredictor.cc
     Instruction.cc
     PerceptronPredictor.cc

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -38,34 +38,34 @@ void CoreInstance::generateCoreModel(std::string executablePath,
   // as they must be set manually prior to the core's creation.
 
   // Convert Data-Memory's Interface-Type value from a string to
-  // simeng::MemInterfaceType
+  // memory::MemInterfaceType
   std::string dType_string =
       config_["L1-Data-Memory"]["Interface-Type"].as<std::string>();
-  MemInterfaceType dType = MemInterfaceType::Flat;
+  memory::MemInterfaceType dType = memory::MemInterfaceType::Flat;
   if (dType_string == "Fixed") {
-    dType = MemInterfaceType::Fixed;
+    dType = memory::MemInterfaceType::Fixed;
   } else if (dType_string == "External") {
-    dType = MemInterfaceType::External;
+    dType = memory::MemInterfaceType::External;
   }
   // Create data memory if appropriate
-  if (dType == MemInterfaceType::External) {
+  if (dType == memory::MemInterfaceType::External) {
     setDataMemory_ = true;
   } else {
     createL1DataMemory(dType);
   }
 
   // Convert Instruction-Memory's Interface-Type value from a string to
-  // simeng::MemInterfaceType
+  // memory::MemInterfaceType
   std::string iType_string =
       config_["L1-Instruction-Memory"]["Interface-Type"].as<std::string>();
-  MemInterfaceType iType = MemInterfaceType::Flat;
+  memory::MemInterfaceType iType = memory::MemInterfaceType::Flat;
   if (iType_string == "Fixed") {
-    iType = MemInterfaceType::Fixed;
+    iType = memory::MemInterfaceType::Fixed;
   } else if (iType_string == "External") {
-    iType = MemInterfaceType::External;
+    iType = memory::MemInterfaceType::External;
   }
   // Create instruction memory if appropriate
-  if (iType == MemInterfaceType::External) {
+  if (iType == memory::MemInterfaceType::External) {
     setInstructionMemory_ = true;
   } else {
     createL1InstructionMemory(iType);
@@ -135,15 +135,16 @@ void CoreInstance::createProcessMemory() {
   return;
 }
 
-void CoreInstance::createL1InstructionMemory(const MemInterfaceType type) {
+void CoreInstance::createL1InstructionMemory(
+    const memory::MemInterfaceType type) {
   // Create a L1I cache instance based on type supplied
-  if (type == MemInterfaceType::Flat) {
-    instructionMemory_ = std::make_shared<FlatMemoryInterface>(
+  if (type == memory::MemInterfaceType::Flat) {
+    instructionMemory_ = std::make_shared<memory::FlatMemoryInterface>(
         processMemory_.get(), processMemorySize_);
-  } else if (type == MemInterfaceType::Fixed) {
+  } else if (type == memory::MemInterfaceType::Fixed) {
     uint16_t accessLat =
         config_["LSQ-L1-Interface"]["Access-Latency"].as<uint16_t>();
-    instructionMemory_ = std::make_shared<FixedLatencyMemoryInterface>(
+    instructionMemory_ = std::make_shared<memory::FixedLatencyMemoryInterface>(
         processMemory_.get(), processMemorySize_, accessLat);
   } else {
     std::cerr
@@ -157,7 +158,7 @@ void CoreInstance::createL1InstructionMemory(const MemInterfaceType type) {
 }
 
 void CoreInstance::setL1InstructionMemory(
-    std::shared_ptr<MemoryInterface> memRef) {
+    std::shared_ptr<memory::MemoryInterface> memRef) {
   assert(setInstructionMemory_ &&
          "setL1InstructionMemory(...) called but the interface was created by "
          "the CoreInstance class.");
@@ -166,15 +167,15 @@ void CoreInstance::setL1InstructionMemory(
   return;
 }
 
-void CoreInstance::createL1DataMemory(const MemInterfaceType type) {
+void CoreInstance::createL1DataMemory(const memory::MemInterfaceType type) {
   // Create a L1D cache instance based on type supplied
-  if (type == MemInterfaceType::Flat) {
-    dataMemory_ = std::make_shared<FlatMemoryInterface>(processMemory_.get(),
-                                                        processMemorySize_);
-  } else if (type == MemInterfaceType::Fixed) {
+  if (type == memory::MemInterfaceType::Flat) {
+    dataMemory_ = std::make_shared<memory::FlatMemoryInterface>(
+        processMemory_.get(), processMemorySize_);
+  } else if (type == memory::MemInterfaceType::Fixed) {
     uint16_t accessLat =
         config_["LSQ-L1-Interface"]["Access-Latency"].as<uint16_t>();
-    dataMemory_ = std::make_shared<FixedLatencyMemoryInterface>(
+    dataMemory_ = std::make_shared<memory::FixedLatencyMemoryInterface>(
         processMemory_.get(), processMemorySize_, accessLat);
   } else {
     std::cerr << "[SimEng:CoreInstance] Unsupported memory interface type used "
@@ -186,7 +187,8 @@ void CoreInstance::createL1DataMemory(const MemInterfaceType type) {
   return;
 }
 
-void CoreInstance::setL1DataMemory(std::shared_ptr<MemoryInterface> memRef) {
+void CoreInstance::setL1DataMemory(
+    std::shared_ptr<memory::MemoryInterface> memRef) {
   assert(setDataMemory_ &&
          "setL1DataMemory(...) called but the interface was created by the "
          "CoreInstance class.");
@@ -291,7 +293,7 @@ std::shared_ptr<Core> CoreInstance::getCore() const {
   return core_;
 }
 
-std::shared_ptr<MemoryInterface> CoreInstance::getDataMemory() const {
+std::shared_ptr<memory::MemoryInterface> CoreInstance::getDataMemory() const {
   if (setDataMemory_ && (dataMemory_ == nullptr)) {
     std::cerr << "[SimEng:CoreInstance] `External` data memory object not set."
               << std::endl;
@@ -300,7 +302,8 @@ std::shared_ptr<MemoryInterface> CoreInstance::getDataMemory() const {
   return dataMemory_;
 }
 
-std::shared_ptr<MemoryInterface> CoreInstance::getInstructionMemory() const {
+std::shared_ptr<memory::MemoryInterface> CoreInstance::getInstructionMemory()
+    const {
   if (setInstructionMemory_ && (instructionMemory_ == nullptr)) {
     std::cerr
         << "`[SimEng:CoreInstance] External` instruction memory object not set."

--- a/src/lib/RegisterFileSet.cc
+++ b/src/lib/RegisterFileSet.cc
@@ -4,17 +4,6 @@
 
 namespace simeng {
 
-std::ostream& operator<<(std::ostream& os, Register const& reg) {
-  return os << reg.tag;
-}
-
-bool Register::operator==(const Register& other) const {
-  return (other.type == type && other.tag == tag);
-}
-bool Register::operator!=(const Register& other) const {
-  return !(other == *this);
-}
-
 RegisterFileSet::RegisterFileSet(
     std::vector<RegisterFileStructure> registerFileStructures)
     : registerFiles(registerFileStructures.size()) {

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -212,7 +212,7 @@ int32_t Architecture::getSystemRegisterTag(uint16_t reg) const {
 
 std::shared_ptr<arch::ExceptionHandler> Architecture::handleException(
     const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
-    MemoryInterface& memory) const {
+    memory::MemoryInterface& memory) const {
   return std::make_shared<ExceptionHandler>(instruction, core, memory, linux_);
 }
 

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -15,7 +15,7 @@ namespace aarch64 {
 
 ExceptionHandler::ExceptionHandler(
     const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
-    MemoryInterface& memory, kernel::Linux& linux_)
+    memory::MemoryInterface& memory, kernel::Linux& linux_)
     : instruction_(*static_cast<Instruction*>(instruction.get())),
       core_(core),
       memory_(memory),
@@ -836,7 +836,7 @@ bool ExceptionHandler::readBufferThen(uint64_t ptr, uint64_t length,
   auto completedReads = memory_.getCompletedReads();
   auto response =
       std::find_if(completedReads.begin(), completedReads.end(),
-                   [&](const MemoryReadResult& response) {
+                   [&](const memory::MemoryReadResult& response) {
                      return response.requestId == instruction_.getSequenceId();
                    });
   if (response == completedReads.end()) {

--- a/src/lib/arch/aarch64/Instruction.cc
+++ b/src/lib/arch/aarch64/Instruction.cc
@@ -113,26 +113,27 @@ bool Instruction::isLoad() const { return isLoad_; }
 bool Instruction::isBranch() const { return isBranch_; }
 
 void Instruction::setMemoryAddresses(
-    const std::vector<MemoryAccessTarget>& addresses) {
+    const std::vector<memory::MemoryAccessTarget>& addresses) {
   memoryData_.resize(addresses.size());
   memoryAddresses_ = addresses;
   dataPending_ = addresses.size();
 }
 
 void Instruction::setMemoryAddresses(
-    std::vector<MemoryAccessTarget>&& addresses) {
+    std::vector<memory::MemoryAccessTarget>&& addresses) {
   dataPending_ = addresses.size();
   memoryData_.resize(addresses.size());
   memoryAddresses_ = std::move(addresses);
 }
 
-void Instruction::setMemoryAddresses(MemoryAccessTarget address) {
+void Instruction::setMemoryAddresses(memory::MemoryAccessTarget address) {
   dataPending_ = 1;
   memoryData_.resize(1);
   memoryAddresses_.push_back(address);
 }
 
-span<const MemoryAccessTarget> Instruction::getGeneratedAddresses() const {
+span<const memory::MemoryAccessTarget> Instruction::getGeneratedAddresses()
+    const {
   return {memoryAddresses_.data(), memoryAddresses_.size()};
 }
 

--- a/src/lib/arch/aarch64/Instruction_address.cc
+++ b/src/lib/arch/aarch64/Instruction_address.cc
@@ -10,7 +10,7 @@ namespace aarch64 {
 
 void generateContiguousAddresses(
     uint64_t baseAddr, uint16_t numVecElems, uint8_t size,
-    std::vector<simeng::MemoryAccessTarget>& addresses) {
+    std::vector<simeng::memory::MemoryAccessTarget>& addresses) {
   for (uint16_t i = 0; i < numVecElems; i++) {
     addresses.push_back({baseAddr + (i * size), size});
   }
@@ -18,7 +18,8 @@ void generateContiguousAddresses(
 
 void generatePredicatedContiguousAddressBlocks(
     uint64_t baseAddr, uint16_t numVecElems, uint8_t elemSize, uint8_t predSize,
-    const uint64_t* pred, std::vector<simeng::MemoryAccessTarget>& addresses) {
+    const uint64_t* pred,
+    std::vector<simeng::memory::MemoryAccessTarget>& addresses) {
   bool recordingBlock = false;
   uint64_t currAddr = 0;
   uint16_t currSize = 0;
@@ -45,13 +46,13 @@ void generatePredicatedContiguousAddressBlocks(
   if (recordingBlock) addresses.push_back({currAddr, currSize});
 }
 
-span<const MemoryAccessTarget> Instruction::generateAddresses() {
+span<const memory::MemoryAccessTarget> Instruction::generateAddresses() {
   assert((isLoad() || isStoreAddress()) &&
          "generateAddresses called on non-load-or-store instruction");
   if (isMicroOp_) {
     switch (microOpcode_) {
       case MicroOpcode::LDR_ADDR: {
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<simeng::memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(
             sourceValues_[0].get<uint64_t>() + metadata_.operands[1].mem.disp,
             1, dataSize_, addresses);
@@ -60,7 +61,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         break;
       }
       case MicroOpcode::STR_ADDR: {
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<simeng::memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(
             sourceValues_[0].get<uint64_t>() + metadata_.operands[0].mem.disp,
             1, dataSize_, addresses);
@@ -351,7 +352,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
                                     // lsl #3]
         const uint64_t base = sourceValues_[1].get<uint64_t>();
         uint64_t offset = sourceValues_[2].get<uint64_t>();
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(2);
 
         uint64_t addr = base + (offset * 8);
@@ -370,7 +371,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[1].get<uint64_t>();
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[3].mem.disp);
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(2);
 
         uint64_t addr = base + (offset * partition_num * 8);
@@ -389,7 +390,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[1].get<uint64_t>();
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[4].mem.disp);
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(3);
 
         uint64_t addr = base + (offset * partition_num * 8);
@@ -409,7 +410,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[1].get<uint64_t>();
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[5].mem.disp);
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(4);
 
         uint64_t addr = base + (offset * partition_num * 8);
@@ -514,7 +515,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_LDRWpre:    // ldr wt, [xn, #imm]!
       case Opcode::AArch64_LDRXui:     // ldr xt, [xn, #imm]
       case Opcode::AArch64_LDRXpre: {  // ldr xt, [xn, #imm]!
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<simeng::memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(
             sourceValues_[0].get<uint64_t>() + metadata_.operands[1].mem.disp,
             1, dataSize_, addresses);
@@ -528,7 +529,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_LDRSpost:    // ldr st, [xn], #imm
       case Opcode::AArch64_LDRWpost:    // ldr wt, [xn], #imm
       case Opcode::AArch64_LDRXpost: {  // ldr xt, [xn], #imm
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(sourceValues_[0].get<uint64_t>(), 1,
                                     dataSize_, addresses);
         setMemoryAddresses(addresses);
@@ -654,7 +655,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_LDPWpre:    // ldp wt1, wt2, [xn, #imm!]
       case Opcode::AArch64_LDPXi:      // ldp xt1, xt2, [xn, #imm]
       case Opcode::AArch64_LDPXpre: {  // ldp xt1, xt2, [xn, #imm!]
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<simeng::memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(
             sourceValues_[0].get<uint64_t>() + metadata_.operands[2].mem.disp,
             2, dataSize_, addresses);
@@ -666,7 +667,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_LDPSpost:    // ldp st1, st2, [xn], #imm
       case Opcode::AArch64_LDPWpost:    // ldp wt1, wt2, [xn], #imm
       case Opcode::AArch64_LDPXpost: {  // ldp xt1, xt2, [xn], #imm
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(sourceValues_[0].get<uint64_t>(), 2,
                                     dataSize_, addresses);
         setMemoryAddresses(addresses);
@@ -821,7 +822,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[2].get<uint64_t>();
         const uint64_t offset = sourceValues_[3].get<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks(base + offset, partition_num,
@@ -837,7 +838,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[2].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
         uint64_t addr = base + (offset * partition_num);
 
@@ -853,7 +854,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[2].get<uint64_t>();
         const uint64_t* offset = sourceValues_[3].getAsVector<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
 
         for (int i = 0; i < partition_num; i++) {
           uint64_t shifted_active = 1ull << ((i % 8) * 8);
@@ -872,7 +873,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[2].get<uint64_t>();
         const uint64_t* offset = sourceValues_[3].getAsVector<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -893,7 +894,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[2].get<uint64_t>();
         const uint64_t* offset = sourceValues_[3].getAsVector<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -913,7 +914,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[2].get<uint64_t>();
         const uint64_t offset = sourceValues_[3].get<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks(
@@ -929,7 +930,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[2].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks(
@@ -947,7 +948,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[3].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num * 2);
 
         uint64_t addr = base + (offset * partition_num * 8);
@@ -970,7 +971,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         if (metadata_.operands[2].mem.index)
           m = sourceValues_[partition_num + 3].get<uint64_t>() << 3;
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks((n + m), partition_num, 8, 8,
@@ -991,7 +992,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         if (metadata_.operands[2].mem.index)
           m = sourceValues_[partition_num + 3].get<uint64_t>() << 2;
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks((n + m), partition_num, 4, 4,
@@ -1006,7 +1007,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[2].get<uint64_t>();
         const uint64_t offset = sourceValues_[3].get<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks(
@@ -1021,7 +1022,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[2].get<uint64_t>();
         const uint64_t offset = sourceValues_[3].get<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks(
@@ -1038,7 +1039,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[2].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         generatePredicatedContiguousAddressBlocks(
@@ -1055,7 +1056,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[2].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1076,7 +1077,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset = static_cast<int64_t>(
             static_cast<int32_t>(metadata_.operands[2].mem.disp));
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1096,7 +1097,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[1].get<uint64_t>();
         const uint64_t* offset = sourceValues_[2].getAsVector<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1117,7 +1118,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t base = sourceValues_[1].get<uint64_t>();
         const uint64_t* offset = sourceValues_[2].getAsVector<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1139,7 +1140,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[2].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1161,7 +1162,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[2].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1182,7 +1183,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t n = sourceValues_[1].get<uint64_t>();
         const uint64_t* m = sourceValues_[2].getAsVector<uint64_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1203,7 +1204,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const uint64_t n = sourceValues_[1].get<uint64_t>();
         const uint32_t* m = sourceValues_[2].getAsVector<uint32_t>();
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1224,7 +1225,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
         const int64_t offset =
             static_cast<int64_t>(metadata_.operands[2].mem.disp);
 
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(partition_num);
 
         for (int i = 0; i < partition_num; i++) {
@@ -1240,7 +1241,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_ST1Fourv2s_POST: {  // st1 {vt.2s, vt2.2s, vt3.2s,
                                                // vt4.2s}, [xn], <#imm|xm>
         const uint64_t base = sourceValues_[4].get<uint64_t>();
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(4);
 
         for (int i = 0; i < 4; i++) {
@@ -1267,7 +1268,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_ST1Fourv4s_POST: {  // st1 {vt.4s, vt2.4s, vt3.4s,
                                                // vt4.4s}, [xn], <#imm|xm>
         const uint64_t base = sourceValues_[4].get<uint64_t>();
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(4);
 
         for (int i = 0; i < 4; i++) {
@@ -1291,7 +1292,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_ST1Twov4s_POST: {  // st1 {vt.4s, vt2.4s}, [xn],
                                               // <#imm|xm>
         const uint64_t base = sourceValues_[2].get<uint64_t>();
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(2);
 
         for (int i = 0; i < 2; i++) {
@@ -1327,7 +1328,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_ST2Twov4s_POST: {  // st2 {vt1.4s, vt2.4s}, [xn],
                                               // #imm
         const uint64_t base = sourceValues_[2].get<uint64_t>();
-        std::vector<MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         addresses.reserve(2);
 
         for (int i = 0; i < 2; i++) {
@@ -1367,7 +1368,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_STPWpre:    // stp wt1, wt2, [xn, #imm]!
       case Opcode::AArch64_STPXi:      // stp xt1, xt2, [xn, #imm]
       case Opcode::AArch64_STPXpre: {  // stp xt1, xt2, [xn, #imm]!
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<simeng::memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(
             sourceValues_[2].get<uint64_t>() + metadata_.operands[2].mem.disp,
             2, dataSize_, addresses);
@@ -1379,7 +1380,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_STPSpost:    // stp st1, st2, [xn], #imm
       case Opcode::AArch64_STPWpost:    // stp wt1, wt2, [xn], #imm
       case Opcode::AArch64_STPXpost: {  // stp xt1, xt2, [xn], #imm
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(sourceValues_[2].get<uint64_t>(), 2,
                                     dataSize_, addresses);
         setMemoryAddresses(addresses);
@@ -1441,7 +1442,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_STRWpre:    // str wt, [xn, #imm]!
       case Opcode::AArch64_STRXui:     // str xt, [xn, #imm]
       case Opcode::AArch64_STRXpre: {  // str xt, [xn, #imm]!
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<simeng::memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(
             sourceValues_[1].get<uint64_t>() + metadata_.operands[1].mem.disp,
             1, dataSize_, addresses);
@@ -1455,7 +1456,7 @@ span<const MemoryAccessTarget> Instruction::generateAddresses() {
       case Opcode::AArch64_STRSpost:    // str st, [xn], #imm
       case Opcode::AArch64_STRWpost:    // str wt, [xn], #imm
       case Opcode::AArch64_STRXpost: {  // str xt, [xn], #imm
-        std::vector<simeng::MemoryAccessTarget> addresses;
+        std::vector<memory::MemoryAccessTarget> addresses;
         generateContiguousAddresses(sourceValues_[1].get<uint64_t>(), 1,
                                     dataSize_, addresses);
         setMemoryAddresses(addresses);

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -212,7 +212,7 @@ int32_t Architecture::getSystemRegisterTag(uint16_t reg) const {
 
 std::shared_ptr<arch::ExceptionHandler> Architecture::handleException(
     const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
-    MemoryInterface& memory) const {
+    memory::MemoryInterface& memory) const {
   return std::make_shared<ExceptionHandler>(instruction, core, memory, linux_);
 }
 

--- a/src/lib/arch/riscv/ExceptionHandler.cc
+++ b/src/lib/arch/riscv/ExceptionHandler.cc
@@ -13,7 +13,7 @@ namespace riscv {
 
 ExceptionHandler::ExceptionHandler(
     const std::shared_ptr<simeng::Instruction>& instruction, const Core& core,
-    MemoryInterface& memory, kernel::Linux& linux_)
+    memory::MemoryInterface& memory, kernel::Linux& linux_)
     : instruction_(*static_cast<Instruction*>(instruction.get())),
       core_(core),
       memory_(memory),
@@ -826,7 +826,7 @@ bool ExceptionHandler::readBufferThen(uint64_t ptr, uint64_t length,
   auto completedReads = memory_.getCompletedReads();
   auto response =
       std::find_if(completedReads.begin(), completedReads.end(),
-                   [&](const MemoryReadResult& response) {
+                   [&](const memory::MemoryReadResult& response) {
                      return response.requestId == instruction_.getSequenceId();
                    });
   if (response == completedReads.end()) {

--- a/src/lib/arch/riscv/Instruction.cc
+++ b/src/lib/arch/riscv/Instruction.cc
@@ -102,13 +102,14 @@ bool Instruction::isAtomic() const { return isAtomic_; }
 bool Instruction::isFloat() const { return isFloat_; }
 
 void Instruction::setMemoryAddresses(
-    const std::vector<MemoryAccessTarget>& addresses) {
+    const std::vector<memory::MemoryAccessTarget>& addresses) {
   memoryData_ = std::vector<RegisterValue>(addresses.size());
   memoryAddresses_ = addresses;
   dataPending_ = addresses.size();
 }
 
-span<const MemoryAccessTarget> Instruction::getGeneratedAddresses() const {
+span<const memory::MemoryAccessTarget> Instruction::getGeneratedAddresses()
+    const {
   return {memoryAddresses_.data(), memoryAddresses_.size()};
 }
 

--- a/src/lib/arch/riscv/Instruction_address.cc
+++ b/src/lib/arch/riscv/Instruction_address.cc
@@ -7,7 +7,7 @@ namespace simeng {
 namespace arch {
 namespace riscv {
 
-span<const MemoryAccessTarget> Instruction::generateAddresses() {
+span<const memory::MemoryAccessTarget> Instruction::generateAddresses() {
   assert((isLoad() || isStoreAddress()) &&
          "generateAddresses called on non-load-or-store instruction");
 

--- a/src/lib/memory/FixedLatencyMemoryInterface.cc
+++ b/src/lib/memory/FixedLatencyMemoryInterface.cc
@@ -1,8 +1,10 @@
-#include "simeng/FixedLatencyMemoryInterface.hh"
+#include "simeng/memory/FixedLatencyMemoryInterface.hh"
 
 #include <iostream>
 
 namespace simeng {
+
+namespace memory {
 
 FixedLatencyMemoryInterface::FixedLatencyMemoryInterface(char* memory,
                                                          size_t size,
@@ -78,4 +80,5 @@ bool FixedLatencyMemoryInterface::hasPendingRequests() const {
   return !pendingRequests_.empty();
 }
 
+}  // namespace memory
 }  // namespace simeng

--- a/src/lib/memory/FlatMemoryInterface.cc
+++ b/src/lib/memory/FlatMemoryInterface.cc
@@ -1,8 +1,10 @@
-#include "simeng/FlatMemoryInterface.hh"
+#include "simeng/memory/FlatMemoryInterface.hh"
 
 #include <iostream>
 
 namespace simeng {
+
+namespace memory {
 
 FlatMemoryInterface::FlatMemoryInterface(char* memory, size_t size)
     : memory_(memory), size_(size) {}
@@ -47,4 +49,5 @@ bool FlatMemoryInterface::hasPendingRequests() const { return false; }
 
 void FlatMemoryInterface::tick() {}
 
+}  // namespace memory
 }  // namespace simeng

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -9,9 +9,9 @@ namespace emulation {
 /** The number of bytes fetched each cycle. */
 const uint8_t FETCH_SIZE = 4;
 
-Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
-           uint64_t entryPoint, uint64_t programByteLength,
-           const arch::Architecture& isa)
+Core::Core(memory::MemoryInterface& instructionMemory,
+           memory::MemoryInterface& dataMemory, uint64_t entryPoint,
+           uint64_t programByteLength, const arch::Architecture& isa)
     : simeng::Core(dataMemory, isa, config::SimInfo::getArchRegStruct()),
       instructionMemory_(instructionMemory),
       architecturalRegisterFileSet_(registerFileSet_),

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -169,10 +169,6 @@ uint64_t Core::getInstructionsRetiredCount() const {
   return instructionsExecuted_;
 }
 
-uint64_t Core::getSystemTimer() const {
-  return ticks_ / (clockFrequency_ / 1e9);
-}
-
 std::map<std::string, std::string> Core::getStats() const {
   return {{"cycles", std::to_string(ticks_)},
           {"retired", std::to_string(instructionsExecuted_)},

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -158,6 +158,27 @@ void Core::tick() {
   isa_.updateSystemTimerRegisters(&registerFileSet_, ticks_);
 }
 
+bool Core::hasHalted() const { return hasHalted_; }
+
+const ArchitecturalRegisterFileSet& Core::getArchitecturalRegisterFileSet()
+    const {
+  return architecturalRegisterFileSet_;
+}
+
+uint64_t Core::getInstructionsRetiredCount() const {
+  return instructionsExecuted_;
+}
+
+uint64_t Core::getSystemTimer() const {
+  return ticks_ / (clockFrequency_ / 1e9);
+}
+
+std::map<std::string, std::string> Core::getStats() const {
+  return {{"cycles", std::to_string(ticks_)},
+          {"retired", std::to_string(instructionsExecuted_)},
+          {"branch.executed", std::to_string(branchesExecuted_)}};
+};
+
 void Core::execute(std::shared_ptr<Instruction>& uop) {
   uop->execute();
 
@@ -276,27 +297,6 @@ void Core::applyStateChange(const arch::ProcessStateChange& change) {
                              change.memoryAddressValues[i]);
   }
 }
-
-bool Core::hasHalted() const { return hasHalted_; }
-
-const ArchitecturalRegisterFileSet& Core::getArchitecturalRegisterFileSet()
-    const {
-  return architecturalRegisterFileSet_;
-}
-
-uint64_t Core::getInstructionsRetiredCount() const {
-  return instructionsExecuted_;
-}
-
-uint64_t Core::getSystemTimer() const {
-  return ticks_ / (clockFrequency_ / 1e9);
-}
-
-std::map<std::string, std::string> Core::getStats() const {
-  return {{"cycles", std::to_string(ticks_)},
-          {"retired", std::to_string(instructionsExecuted_)},
-          {"branch.executed", std::to_string(branchesExecuted_)}};
-};
 
 }  // namespace emulation
 }  // namespace models

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -258,46 +258,6 @@ void Core::processExceptionHandler() {
   microOps_.pop();
 }
 
-void Core::applyStateChange(const arch::ProcessStateChange& change) {
-  // Update registers in accordance with the ProcessStateChange type
-  switch (change.type) {
-    case arch::ChangeType::INCREMENT: {
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        registerFileSet_.set(
-            change.modifiedRegisters[i],
-            registerFileSet_.get(change.modifiedRegisters[i]).get<uint64_t>() +
-                change.modifiedRegisterValues[i].get<uint64_t>());
-      }
-      break;
-    }
-    case arch::ChangeType::DECREMENT: {
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        registerFileSet_.set(
-            change.modifiedRegisters[i],
-            registerFileSet_.get(change.modifiedRegisters[i]).get<uint64_t>() -
-                change.modifiedRegisterValues[i].get<uint64_t>());
-      }
-      break;
-    }
-    default: {  // arch::ChangeType::REPLACEMENT
-      // If type is ChangeType::REPLACEMENT, set new values
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        registerFileSet_.set(change.modifiedRegisters[i],
-                             change.modifiedRegisterValues[i]);
-      }
-      break;
-    }
-  }
-
-  // Update memory
-  // TODO: Analyse if ChangeType::INCREMENT or ChangeType::DECREMENT case is
-  // required for memory changes
-  for (size_t i = 0; i < change.memoryAddresses.size(); i++) {
-    dataMemory_.requestWrite(change.memoryAddresses[i],
-                             change.memoryAddressValues[i]);
-  }
-}
-
 }  // namespace emulation
 }  // namespace models
 }  // namespace simeng

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -6,21 +6,17 @@ namespace simeng {
 namespace models {
 namespace emulation {
 
-// TODO: Expose as config option
 /** The number of bytes fetched each cycle. */
-const uint16_t FETCH_SIZE = 4;
-const unsigned int clockFrequency = 2.5 * 1e9;
+const uint8_t FETCH_SIZE = 4;
 
 Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
            uint64_t entryPoint, uint64_t programByteLength,
            const arch::Architecture& isa)
-    : instructionMemory_(instructionMemory),
-      dataMemory_(dataMemory),
-      programByteLength_(programByteLength),
-      isa_(isa),
+    : simeng::Core(dataMemory, isa, config::SimInfo::getArchRegStruct()),
+      instructionMemory_(instructionMemory),
+      architecturalRegisterFileSet_(registerFileSet_),
       pc_(entryPoint),
-      registerFileSet_(config::SimInfo::getArchRegStruct()),
-      architecturalRegisterFileSet_(registerFileSet_) {
+      programByteLength_(programByteLength) {
   // Pre-load the first instruction
   instructionMemory_.requestRead({pc_, FETCH_SIZE});
 
@@ -293,7 +289,7 @@ uint64_t Core::getInstructionsRetiredCount() const {
 }
 
 uint64_t Core::getSystemTimer() const {
-  return ticks_ / (clockFrequency / 1e9);
+  return ticks_ / (clockFrequency_ / 1e9);
 }
 
 std::map<std::string, std::string> Core::getStats() const {

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -220,6 +220,19 @@ void Core::processExceptionHandler() {
   exceptionHandler_ = nullptr;
 }
 
+void Core::handleLoad(const std::shared_ptr<Instruction>& instruction) {
+  loadData(instruction);
+  if (instruction->exceptionEncountered()) {
+    raiseException(instruction);
+    return;
+  }
+
+  forwardOperands(instruction->getDestinationRegisters(),
+                  instruction->getResults());
+  // Manually add the instruction to the writeback input buffer
+  completionSlots_[0].getTailSlots()[0] = instruction;
+}
+
 void Core::loadData(const std::shared_ptr<Instruction>& instruction) {
   const auto& addresses = instruction->getGeneratedAddresses();
   for (const auto& target : addresses) {
@@ -344,19 +357,6 @@ void Core::applyStateChange(const arch::ProcessStateChange& change) {
     dataMemory_.requestWrite(change.memoryAddresses[i],
                              change.memoryAddressValues[i]);
   }
-}
-
-void Core::handleLoad(const std::shared_ptr<Instruction>& instruction) {
-  loadData(instruction);
-  if (instruction->exceptionEncountered()) {
-    raiseException(instruction);
-    return;
-  }
-
-  forwardOperands(instruction->getDestinationRegisters(),
-                  instruction->getResults());
-  // Manually add the instruction to the writeback input buffer
-  completionSlots_[0].getTailSlots()[0] = instruction;
 }
 
 }  // namespace inorder

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -9,9 +9,10 @@ namespace simeng {
 namespace models {
 namespace inorder {
 
-Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
-           uint64_t processMemorySize, uint64_t entryPoint,
-           const arch::Architecture& isa, BranchPredictor& branchPredictor)
+Core::Core(memory::MemoryInterface& instructionMemory,
+           memory::MemoryInterface& dataMemory, uint64_t processMemorySize,
+           uint64_t entryPoint, const arch::Architecture& isa,
+           BranchPredictor& branchPredictor)
     : simeng::Core(dataMemory, isa, config::SimInfo::getArchRegStruct()),
       architecturalRegisterFileSet_(registerFileSet_),
       fetchToDecodeBuffer_(1, {}),

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -142,11 +142,6 @@ uint64_t Core::getInstructionsRetiredCount() const {
   return writebackUnit_.getInstructionsWrittenCount();
 }
 
-uint64_t Core::getSystemTimer() const {
-  // TODO: This will need to be changed if we start supporting DVFS.
-  return ticks_ / (clockFrequency_ / 1e9);
-}
-
 std::map<std::string, std::string> Core::getStats() const {
   auto retired = writebackUnit_.getInstructionsWrittenCount();
   auto ipc = retired / static_cast<float>(ticks_);

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -319,46 +319,6 @@ void Core::readRegisters() {
   }
 }
 
-void Core::applyStateChange(const arch::ProcessStateChange& change) {
-  // Update registers in accordance with the ProcessStateChange type
-  switch (change.type) {
-    case arch::ChangeType::INCREMENT: {
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        registerFileSet_.set(
-            change.modifiedRegisters[i],
-            registerFileSet_.get(change.modifiedRegisters[i]).get<uint64_t>() +
-                change.modifiedRegisterValues[i].get<uint64_t>());
-      }
-      break;
-    }
-    case arch::ChangeType::DECREMENT: {
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        registerFileSet_.set(
-            change.modifiedRegisters[i],
-            registerFileSet_.get(change.modifiedRegisters[i]).get<uint64_t>() -
-                change.modifiedRegisterValues[i].get<uint64_t>());
-      }
-      break;
-    }
-    default: {  // arch::ChangeType::REPLACEMENT
-      // If type is ChangeType::REPLACEMENT, set new values
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        registerFileSet_.set(change.modifiedRegisters[i],
-                             change.modifiedRegisterValues[i]);
-      }
-      break;
-    }
-  }
-
-  // Update memory
-  // TODO: Analyse if ChangeType::INCREMENT or ChangeType::DECREMENT case is
-  // required for memory changes
-  for (size_t i = 0; i < change.memoryAddresses.size(); i++) {
-    dataMemory_.requestWrite(change.memoryAddresses[i],
-                             change.memoryAddressValues[i]);
-  }
-}
-
 }  // namespace inorder
 }  // namespace models
 }  // namespace simeng

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -6,8 +6,8 @@
 #include <sstream>
 #include <string>
 
-// Temporary; until config options are available
-#include "simeng/arch/aarch64/Instruction.hh"
+// // Temporary; until config options are available
+// #include "simeng/arch/aarch64/Instruction.hh"
 namespace simeng {
 namespace models {
 namespace outoforder {
@@ -17,14 +17,12 @@ Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
            uint64_t processMemorySize, uint64_t entryPoint,
            const arch::Architecture& isa, BranchPredictor& branchPredictor,
            pipeline::PortAllocator& portAllocator, ryml::ConstNodeRef config)
-    : isa_(isa),
+    : simeng::Core(dataMemory, isa, config::SimInfo::getPhysRegStruct()),
       physicalRegisterStructures_(config::SimInfo::getPhysRegStruct()),
       physicalRegisterQuantities_(config::SimInfo::getPhysRegQuantities()),
-      registerFileSet_(physicalRegisterStructures_),
       registerAliasTable_(config::SimInfo::getArchRegStruct(),
                           physicalRegisterQuantities_),
       mappedRegisterFileSet_(registerFileSet_, registerAliasTable_),
-      dataMemory_(dataMemory),
       fetchToDecodeBuffer_(config["Pipeline-Widths"]["FrontEnd"].as<uint16_t>(),
                            {}),
       decodeToRenameBuffer_(
@@ -76,7 +74,6 @@ Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
           completionSlots_, registerFileSet_,
           [this](auto insnId) { reorderBuffer_.commitMicroOps(insnId); }),
       portAllocator_(portAllocator),
-      clockFrequency_(config["Core"]["Clock-Frequency-GHz"].as<float>() * 1e9),
       commitWidth_(config["Pipeline-Widths"]["Commit"].as<uint16_t>()) {
   for (size_t i = 0; i < config["Execution-Units"].num_children(); i++) {
     // Create vector of blocking groups

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -6,13 +6,10 @@
 #include <sstream>
 #include <string>
 
-// // Temporary; until config options are available
-// #include "simeng/arch/aarch64/Instruction.hh"
 namespace simeng {
 namespace models {
 namespace outoforder {
 
-// TODO: System register count has to match number of supported system registers
 Core::Core(memory::MemoryInterface& instructionMemory,
            memory::MemoryInterface& dataMemory, uint64_t processMemorySize,
            uint64_t entryPoint, const arch::Architecture& isa,
@@ -204,11 +201,6 @@ const ArchitecturalRegisterFileSet& Core::getArchitecturalRegisterFileSet()
 
 uint64_t Core::getInstructionsRetiredCount() const {
   return reorderBuffer_.getInstructionsCommittedCount();
-}
-
-uint64_t Core::getSystemTimer() const {
-  // TODO: This will need to be changed if we start supporting DVFS.
-  return ticks_ / (clockFrequency_ / 1e9);
 }
 
 std::map<std::string, std::string> Core::getStats() const {

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -13,9 +13,10 @@ namespace models {
 namespace outoforder {
 
 // TODO: System register count has to match number of supported system registers
-Core::Core(MemoryInterface& instructionMemory, MemoryInterface& dataMemory,
-           uint64_t processMemorySize, uint64_t entryPoint,
-           const arch::Architecture& isa, BranchPredictor& branchPredictor,
+Core::Core(memory::MemoryInterface& instructionMemory,
+           memory::MemoryInterface& dataMemory, uint64_t processMemorySize,
+           uint64_t entryPoint, const arch::Architecture& isa,
+           BranchPredictor& branchPredictor,
            pipeline::PortAllocator& portAllocator, ryml::ConstNodeRef config)
     : simeng::Core(dataMemory, isa, config::SimInfo::getPhysRegStruct()),
       physicalRegisterStructures_(config::SimInfo::getPhysRegStruct()),

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -325,48 +325,6 @@ void Core::processExceptionHandler() {
   exceptionHandler_ = nullptr;
 }
 
-void Core::applyStateChange(const arch::ProcessStateChange& change) {
-  // Update registers in accordance with the ProcessStateChange type
-  switch (change.type) {
-    case arch::ChangeType::INCREMENT: {
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        mappedRegisterFileSet_.set(
-            change.modifiedRegisters[i],
-            mappedRegisterFileSet_.get(change.modifiedRegisters[i])
-                    .get<uint64_t>() +
-                change.modifiedRegisterValues[i].get<uint64_t>());
-      }
-      break;
-    }
-    case arch::ChangeType::DECREMENT: {
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        mappedRegisterFileSet_.set(
-            change.modifiedRegisters[i],
-            mappedRegisterFileSet_.get(change.modifiedRegisters[i])
-                    .get<uint64_t>() -
-                change.modifiedRegisterValues[i].get<uint64_t>());
-      }
-      break;
-    }
-    default: {  // arch::ChangeType::REPLACEMENT
-      // If type is ChangeType::REPLACEMENT, set new values
-      for (size_t i = 0; i < change.modifiedRegisters.size(); i++) {
-        mappedRegisterFileSet_.set(change.modifiedRegisters[i],
-                                   change.modifiedRegisterValues[i]);
-      }
-      break;
-    }
-  }
-
-  // Update memory
-  // TODO: Analyse if ChangeType::INCREMENT or ChangeType::DECREMENT case is
-  // required for memory changes
-  for (size_t i = 0; i < change.memoryAddresses.size(); i++) {
-    dataMemory_.requestWrite(change.memoryAddresses[i],
-                             change.memoryAddressValues[i]);
-  }
-}
-
 void Core::flushIfNeeded() {
   // Check for flush
   bool euFlush = false;

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -4,7 +4,7 @@ namespace simeng {
 namespace pipeline {
 
 FetchUnit::FetchUnit(PipelineBuffer<MacroOp>& output,
-                     MemoryInterface& instructionMemory,
+                     memory::MemoryInterface& instructionMemory,
                      uint64_t programByteLength, uint64_t entryPoint,
                      uint16_t blockSize, const arch::Architecture& isa,
                      BranchPredictor& branchPredictor)

--- a/src/lib/pipeline/LoadStoreQueue.cc
+++ b/src/lib/pipeline/LoadStoreQueue.cc
@@ -10,14 +10,15 @@ namespace simeng {
 namespace pipeline {
 
 /** Check whether requests `a` and `b` overlap. */
-bool requestsOverlap(MemoryAccessTarget a, MemoryAccessTarget b) {
+bool requestsOverlap(memory::MemoryAccessTarget a,
+                     memory::MemoryAccessTarget b) {
   // Check whether one region ends before the other begins, implying no overlap,
   // and negate
   return !(a.address + a.size <= b.address || b.address + b.size <= a.address);
 }
 
 LoadStoreQueue::LoadStoreQueue(
-    unsigned int maxCombinedSpace, MemoryInterface& memory,
+    unsigned int maxCombinedSpace, memory::MemoryInterface& memory,
     span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
     std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
     std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
@@ -39,7 +40,7 @@ LoadStoreQueue::LoadStoreQueue(
 
 LoadStoreQueue::LoadStoreQueue(
     unsigned int maxLoadQueueSpace, unsigned int maxStoreQueueSpace,
-    MemoryInterface& memory,
+    memory::MemoryInterface& memory,
     span<PipelineBuffer<std::shared_ptr<Instruction>>> completionSlots,
     std::function<void(span<Register>, span<RegisterValue>)> forwardOperands,
     std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
@@ -122,8 +123,8 @@ void LoadStoreQueue::startLoad(const std::shared_ptr<Instruction>& insn) {
                              .reqAddresses;
     // Store load addresses temporarily so that conflictions are
     // only registered once on most recent (program order) store
-    std::list<simeng::MemoryAccessTarget> temp_load_addr(ld_addresses.begin(),
-                                                         ld_addresses.end());
+    std::list<simeng::memory::MemoryAccessTarget> temp_load_addr(
+        ld_addresses.begin(), ld_addresses.end());
 
     // Detect reordering conflicts
     if (storeQueue_.size() > 0) {
@@ -437,7 +438,7 @@ void LoadStoreQueue::tick() {
         // request[Load|Store]Queue_ entry
         auto& addressQueue = itInsn->reqAddresses;
         while (addressQueue.size()) {
-          const simeng::MemoryAccessTarget req =
+          const simeng::memory::MemoryAccessTarget req =
               addressQueue.front();  // Speculatively increment count of this
                                      // request type
           reqCounts[isStore]++;

--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -70,7 +70,7 @@ void ReorderBuffer::commitMicroOps(uint64_t insnId) {
   return;
 }
 
-unsigned int ReorderBuffer::commit(unsigned int maxCommitSize) {
+unsigned int ReorderBuffer::commit(uint64_t maxCommitSize) {
   shouldFlush_ = false;
   size_t maxCommits =
       std::min(static_cast<size_t>(maxCommitSize), buffer_.size());

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -6,13 +6,14 @@
 
 #include "simeng/Core.hh"
 #include "simeng/CoreInstance.hh"
-#include "simeng/MemoryInterface.hh"
 #include "simeng/config/SimInfo.hh"
+#include "simeng/memory/MemoryInterface.hh"
 #include "simeng/version.hh"
 
 /** Tick the provided core model until it halts. */
-uint64_t simulate(simeng::Core& core, simeng::MemoryInterface& dataMemory,
-                  simeng::MemoryInterface& instructionMemory) {
+uint64_t simulate(simeng::Core& core,
+                  simeng::memory::MemoryInterface& dataMemory,
+                  simeng::memory::MemoryInterface& instructionMemory) {
   uint64_t iterations = 0;
 
   // Tick the core and memory interfaces until the program has halted
@@ -78,9 +79,9 @@ int main(int argc, char** argv) {
 
   // Get simulation objects needed to forward simulation
   std::shared_ptr<simeng::Core> core = coreInstance->getCore();
-  std::shared_ptr<simeng::MemoryInterface> dataMemory =
+  std::shared_ptr<simeng::memory::MemoryInterface> dataMemory =
       coreInstance->getDataMemory();
-  std::shared_ptr<simeng::MemoryInterface> instructionMemory =
+  std::shared_ptr<simeng::memory::MemoryInterface> instructionMemory =
       coreInstance->getInstructionMemory();
 
   // Output general simulation details

--- a/sst/SimEngMemInterface.cc
+++ b/sst/SimEngMemInterface.cc
@@ -11,7 +11,7 @@ using namespace SST::SSTSimEng;
 
 SimEngMemInterface::SimEngMemInterface(StandardMem* mem, uint64_t cl,
                                        uint64_t max_addr, bool debug)
-    : simeng::MemoryInterface() {
+    : simeng::memory::MemoryInterface() {
   this->sstMem_ = mem;
   this->cacheLineWidth_ = cl;
   this->maxAddrMemory_ = max_addr;
@@ -149,7 +149,7 @@ std::vector<StandardMem::Request*> SimEngMemInterface::splitAggregatedRequest(
   return requests;
 }
 
-void SimEngMemInterface::requestRead(const MemoryAccessTarget& target,
+void SimEngMemInterface::requestRead(const memory::MemoryAccessTarget& target,
                                      uint64_t requestId) {
   uint64_t addrStart = target.address;
   uint64_t size = unsigned(target.size);
@@ -183,7 +183,7 @@ void SimEngMemInterface::requestRead(const MemoryAccessTarget& target,
   }
 }
 
-void SimEngMemInterface::requestWrite(const MemoryAccessTarget& target,
+void SimEngMemInterface::requestWrite(const memory::MemoryAccessTarget& target,
                                       const RegisterValue& data) {
   uint64_t addrStart = target.address;
   uint64_t size = unsigned(target.size);
@@ -209,8 +209,9 @@ bool SimEngMemInterface::hasPendingRequests() const {
   return aggregationMap_.size() > 0;
 };
 
-const span<MemoryReadResult> SimEngMemInterface::getCompletedReads() const {
-  return {const_cast<MemoryReadResult*>(completedReadRequests_.data()),
+const span<memory::MemoryReadResult> SimEngMemInterface::getCompletedReads()
+    const {
+  return {const_cast<memory::MemoryReadResult*>(completedReadRequests_.data()),
           completedReadRequests_.size()};
 };
 

--- a/sst/include/SimEngCoreWrapper.hh
+++ b/sst/include/SimEngCoreWrapper.hh
@@ -19,7 +19,6 @@
 #include "SimEngMemInterface.hh"
 #include "simeng/Core.hh"
 #include "simeng/CoreInstance.hh"
-#include "simeng/MemoryInterface.hh"
 #include "simeng/SpecialFileDirGen.hh"
 #include "simeng/version.hh"
 
@@ -204,7 +203,7 @@ class SimEngCoreWrapper : public SST::Component {
   std::shared_ptr<char> processMemory_;
 
   /** Reference to SimEng instruction memory. */
-  std::shared_ptr<simeng::MemoryInterface> instructionMemory_;
+  std::shared_ptr<simeng::memory::MemoryInterface> instructionMemory_;
 
   /** Reference to SimEngMemInterface used for interfacing with SST. */
   std::shared_ptr<SimEngMemInterface> dataMemory_;

--- a/sst/include/SimEngMemInterface.hh
+++ b/sst/include/SimEngMemInterface.hh
@@ -16,7 +16,7 @@
 #include <type_traits>
 #include <vector>
 
-#include "simeng/MemoryInterface.hh"
+#include "simeng/memory/MemoryInterface.hh"
 #include "simeng/span.hh"
 
 using namespace simeng;
@@ -27,7 +27,7 @@ namespace SST {
 namespace SSTSimEng {
 
 /** A memory interface used by SimEng to communicate with SST's memory model. */
-class SimEngMemInterface : public MemoryInterface {
+class SimEngMemInterface : public memory::MemoryInterface {
  public:
   SimEngMemInterface(StandardMem* mem, uint64_t cl, uint64_t max_addr,
                      bool debug);
@@ -39,17 +39,18 @@ class SimEngMemInterface : public MemoryInterface {
    * Construct an AggregatedReadRequest and use it to generate
    * SST::StandardMem::Read request(s). These request(s) are then sent to SST.
    */
-  void requestRead(const MemoryAccessTarget& target, uint64_t requestId = 0);
+  void requestRead(const memory::MemoryAccessTarget& target,
+                   uint64_t requestId = 0);
 
   /**
    * Construct an AggregatedWriteRequest and use it to generate
    * SST::StandardMem::Write request(s). These request(s) are then sent to SST.
    */
-  void requestWrite(const MemoryAccessTarget& target,
+  void requestWrite(const memory::MemoryAccessTarget& target,
                     const RegisterValue& data);
 
   /** Retrieve all completed read requests. */
-  const span<MemoryReadResult> getCompletedReads() const;
+  const span<memory::MemoryReadResult> getCompletedReads() const;
 
   /** Clear the completed reads. */
   void clearCompletedReads();
@@ -103,11 +104,12 @@ class SimEngMemInterface : public MemoryInterface {
    * struct for AggregateWriteRequest and AggregateReadRequest.
    */
   struct SimEngMemoryRequest {
-    /** MemoryAccessTarget from SimEng memory instruction. */
-    const MemoryAccessTarget target;
+    /** memory::MemoryAccessTarget from SimEng memory instruction. */
+    const memory::MemoryAccessTarget target;
 
-    SimEngMemoryRequest() : target(MemoryAccessTarget()){};
-    SimEngMemoryRequest(const MemoryAccessTarget& target) : target(target){};
+    SimEngMemoryRequest() : target(memory::MemoryAccessTarget()){};
+    SimEngMemoryRequest(const memory::MemoryAccessTarget& target)
+        : target(target){};
   };
 
   /**
@@ -122,7 +124,7 @@ class SimEngMemInterface : public MemoryInterface {
     const RegisterValue data;
 
     AggregateWriteRequest() : SimEngMemoryRequest(), data(RegisterValue()){};
-    AggregateWriteRequest(const MemoryAccessTarget& target,
+    AggregateWriteRequest(const memory::MemoryAccessTarget& target,
                           const RegisterValue& data)
         : SimEngMemoryRequest(target), data(data){};
   };
@@ -148,7 +150,8 @@ class SimEngMemInterface : public MemoryInterface {
     int aggregateCount_ = 0;
 
     AggregateReadRequest() : SimEngMemoryRequest(), id_(0){};
-    AggregateReadRequest(const MemoryAccessTarget& target, const uint64_t id)
+    AggregateReadRequest(const memory::MemoryAccessTarget& target,
+                         const uint64_t id)
         : SimEngMemoryRequest(target), id_(id) {}
   };
 
@@ -170,7 +173,7 @@ class SimEngMemInterface : public MemoryInterface {
   uint64_t maxAddrMemory_;
 
   /** A vector containing all completed read requests. */
-  std::vector<MemoryReadResult> completedReadRequests_;
+  std::vector<memory::MemoryReadResult> completedReadRequests_;
 
   /**
    * This map is used to store unique ids of SST::StandardMem::Read requests and

--- a/test/regression/RegressionTest.cc
+++ b/test/regression/RegressionTest.cc
@@ -2,13 +2,13 @@
 
 #include <string>
 
-#include "simeng/FixedLatencyMemoryInterface.hh"
-#include "simeng/FlatMemoryInterface.hh"
 #include "simeng/GenericPredictor.hh"
 #include "simeng/PerceptronPredictor.hh"
 #include "simeng/config/SimInfo.hh"
 #include "simeng/kernel/Linux.hh"
 #include "simeng/kernel/LinuxProcess.hh"
+#include "simeng/memory/FixedLatencyMemoryInterface.hh"
+#include "simeng/memory/FlatMemoryInterface.hh"
 #include "simeng/models/emulation/Core.hh"
 #include "simeng/models/inorder/Core.hh"
 #include "simeng/models/outoforder/Core.hh"
@@ -63,17 +63,18 @@ void RegressionTest::run(const char* source, const char* triple,
   // Create memory interfaces for instruction and data access.
   // For each memory interface, a dereferenced shared_ptr to the
   // processImage is passed as argument.
-  simeng::FlatMemoryInterface instructionMemory(processMemory_,
-                                                processMemorySize_);
+  simeng::memory::FlatMemoryInterface instructionMemory(processMemory_,
+                                                        processMemorySize_);
 
-  std::unique_ptr<simeng::FlatMemoryInterface> flatDataMemory =
-      std::make_unique<simeng::FlatMemoryInterface>(processMemory_,
-                                                    processMemorySize_);
+  std::unique_ptr<simeng::memory::FlatMemoryInterface> flatDataMemory =
+      std::make_unique<simeng::memory::FlatMemoryInterface>(processMemory_,
+                                                            processMemorySize_);
 
-  std::unique_ptr<simeng::FixedLatencyMemoryInterface> fixedLatencyDataMemory =
-      std::make_unique<simeng::FixedLatencyMemoryInterface>(
-          processMemory_, processMemorySize_, 4);
-  std::unique_ptr<simeng::MemoryInterface> dataMemory;
+  std::unique_ptr<simeng::memory::FixedLatencyMemoryInterface>
+      fixedLatencyDataMemory =
+          std::make_unique<simeng::memory::FixedLatencyMemoryInterface>(
+              processMemory_, processMemorySize_, 4);
+  std::unique_ptr<simeng::memory::MemoryInterface> dataMemory;
 
   // Create the OS kernel and the process
   simeng::kernel::Linux kernel(

--- a/test/unit/FixedLatencyMemoryInterfaceTest.cc
+++ b/test/unit/FixedLatencyMemoryInterfaceTest.cc
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "simeng/FixedLatencyMemoryInterface.hh"
+#include "simeng/memory/FixedLatencyMemoryInterface.hh"
 
 namespace {
 
@@ -16,14 +16,14 @@ class FixedLatencyMemoryInterfaceTest
 
   simeng::RegisterValue value = {0xDEADBEEF, 4};
   simeng::RegisterValue value_oversized = {0xDEADBEEFDEADBEEF, 8};
-  simeng::MemoryAccessTarget target = {0, 4};
-  simeng::MemoryAccessTarget target_OutOfBound1 = {1000, 4};
-  simeng::MemoryAccessTarget target_OutOfBound2 = {0, 8};
+  simeng::memory::MemoryAccessTarget target = {0, 4};
+  simeng::memory::MemoryAccessTarget target_OutOfBound1 = {1000, 4};
+  simeng::memory::MemoryAccessTarget target_OutOfBound2 = {0, 8};
 
   const std::string writeOverflowStr =
       "Attempted to write beyond memory limit.";
 
-  simeng::FixedLatencyMemoryInterface memory;
+  simeng::memory::FixedLatencyMemoryInterface memory;
 };
 
 // Test that we can read data and it completes after n cycles.

--- a/test/unit/FlatMemoryInterfaceTest.cc
+++ b/test/unit/FlatMemoryInterfaceTest.cc
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "simeng/FlatMemoryInterface.hh"
+#include "simeng/memory/FlatMemoryInterface.hh"
 
 namespace {
 
@@ -14,14 +14,14 @@ class FlatMemoryInterfaceTest : public testing::Test {
 
   simeng::RegisterValue value = {0xDEADBEEF, 4};
   simeng::RegisterValue value_oversized = {0xDEADBEEFDEADBEEF, 8};
-  simeng::MemoryAccessTarget target = {0, 4};
-  simeng::MemoryAccessTarget target_OutOfBound1 = {1000, 4};
-  simeng::MemoryAccessTarget target_OutOfBound2 = {0, 8};
+  simeng::memory::MemoryAccessTarget target = {0, 4};
+  simeng::memory::MemoryAccessTarget target_OutOfBound1 = {1000, 4};
+  simeng::memory::MemoryAccessTarget target_OutOfBound2 = {0, 8};
 
   const std::string writeOverflowStr =
       "Attempted to write beyond memory limit.";
 
-  simeng::FlatMemoryInterface memory;
+  simeng::memory::FlatMemoryInterface memory;
 };
 
 // Test that we can read data and it completes after zero cycles.

--- a/test/unit/MockArchitecture.hh
+++ b/test/unit/MockArchitecture.hh
@@ -17,7 +17,7 @@ class MockArchitecture : public arch::Architecture {
   MOCK_CONST_METHOD3(handleException,
                      std::shared_ptr<arch::ExceptionHandler>(
                          const std::shared_ptr<Instruction>& instruction,
-                         const Core& core, MemoryInterface& memory));
+                         const Core& core, memory::MemoryInterface& memory));
   MOCK_CONST_METHOD0(getInitialState, arch::ProcessStateChange());
   MOCK_CONST_METHOD0(getMaxInstructionSize, uint8_t());
   MOCK_CONST_METHOD2(updateSystemTimerRegisters,

--- a/test/unit/MockCore.hh
+++ b/test/unit/MockCore.hh
@@ -8,7 +8,7 @@ namespace simeng {
 /** Mock implementation of the `Core` interface. */
 class MockCore : public Core {
  public:
-  MockCore(MemoryInterface& dataMemory, const arch::Architecture& isa,
+  MockCore(memory::MemoryInterface& dataMemory, const arch::Architecture& isa,
            const std::vector<RegisterFileStructure>& regFileStructure)
       : Core(dataMemory, isa, regFileStructure) {}
   MOCK_METHOD0(tick, void());

--- a/test/unit/MockCore.hh
+++ b/test/unit/MockCore.hh
@@ -8,6 +8,9 @@ namespace simeng {
 /** Mock implementation of the `Core` interface. */
 class MockCore : public Core {
  public:
+  MockCore(MemoryInterface& dataMemory, const arch::Architecture& isa,
+           const std::vector<RegisterFileStructure>& regFileStructure)
+      : Core(dataMemory, isa, regFileStructure) {}
   MOCK_METHOD0(tick, void());
   MOCK_CONST_METHOD0(hasHalted, bool());
   MOCK_CONST_METHOD0(getArchitecturalRegisterFileSet,

--- a/test/unit/MockInstruction.hh
+++ b/test/unit/MockInstruction.hh
@@ -18,9 +18,10 @@ class MockInstruction : public Instruction {
   MOCK_CONST_METHOD0(canExecute, bool());
   MOCK_METHOD0(execute, void());
   MOCK_CONST_METHOD0(getResults, const span<RegisterValue>());
-  MOCK_METHOD0(generateAddresses, span<const MemoryAccessTarget>());
+  MOCK_METHOD0(generateAddresses, span<const memory::MemoryAccessTarget>());
   MOCK_METHOD2(supplyData, void(uint64_t address, const RegisterValue& data));
-  MOCK_CONST_METHOD0(getGeneratedAddresses, span<const MemoryAccessTarget>());
+  MOCK_CONST_METHOD0(getGeneratedAddresses,
+                     span<const memory::MemoryAccessTarget>());
   MOCK_CONST_METHOD0(hasAllData, bool());
   MOCK_CONST_METHOD0(getData, span<const RegisterValue>());
 

--- a/test/unit/MockMemoryInterface.hh
+++ b/test/unit/MockMemoryInterface.hh
@@ -1,20 +1,20 @@
 #pragma once
 
 #include "gmock/gmock.h"
-#include "simeng/MemoryInterface.hh"
+#include "simeng/memory/MemoryInterface.hh"
 
 namespace simeng {
 
-/** Mock implementation of MemoryInterface */
-class MockMemoryInterface : public MemoryInterface {
+/** Mock implementation of memory::MemoryInterface */
+class MockMemoryInterface : public memory::MemoryInterface {
  public:
-  MOCK_METHOD2(requestRead,
-               void(const MemoryAccessTarget& target, uint64_t requestId));
+  MOCK_METHOD2(requestRead, void(const memory::MemoryAccessTarget& target,
+                                 uint64_t requestId));
 
-  MOCK_METHOD2(requestWrite, void(const MemoryAccessTarget& target,
+  MOCK_METHOD2(requestWrite, void(const memory::MemoryAccessTarget& target,
                                   const RegisterValue& data));
 
-  MOCK_CONST_METHOD0(getCompletedReads, const span<MemoryReadResult>());
+  MOCK_CONST_METHOD0(getCompletedReads, const span<memory::MemoryReadResult>());
 
   MOCK_METHOD0(clearCompletedReads, void());
 

--- a/test/unit/aarch64/ArchitectureTest.cc
+++ b/test/unit/aarch64/ArchitectureTest.cc
@@ -147,7 +147,7 @@ TEST_F(AArch64ArchitectureTest, handleException) {
   std::unique_ptr<CoreInstance> coreInstance =
       std::make_unique<CoreInstance>(executablePath, executableArgs);
   const Core& core = *coreInstance->getCore();
-  MemoryInterface& memInt = *coreInstance->getDataMemory();
+  memory::MemoryInterface& memInt = *coreInstance->getDataMemory();
   auto exceptionHandler = arch->handleException(insn[0], core, memInt);
 
   bool tickRes = exceptionHandler->tick();

--- a/test/unit/aarch64/ExceptionHandlerTest.cc
+++ b/test/unit/aarch64/ExceptionHandlerTest.cc
@@ -23,18 +23,20 @@ class AArch64ExceptionHandlerTest : public ::testing::Test {
                    .as<std::string>()),
         arch(kernel),
         physRegFileSet(config::SimInfo::getArchRegStruct()),
-        archRegFileSet(physRegFileSet) {}
+        archRegFileSet(physRegFileSet),
+        core(memory, arch, config::SimInfo::getArchRegStruct()) {}
 
  protected:
   ConfigInit configInit = ConfigInit(config::ISA::AArch64, "");
 
-  MockCore core;
   MockMemoryInterface memory;
   kernel::Linux kernel;
   Architecture arch;
 
   RegisterFileSet physRegFileSet;
   ArchitecturalRegisterFileSet archRegFileSet;
+
+  MockCore core;
 
   // fdivr z1.s, p0/m, z1.s, z0.s --- Just need a valid instruction to hijack
   const std::array<uint8_t, 4> validInstrBytes = {0x01, 0x80, 0x8c, 0x65};

--- a/test/unit/pipeline/LoadStoreQueueTest.cc
+++ b/test/unit/pipeline/LoadStoreQueueTest.cc
@@ -123,8 +123,8 @@ class LoadStoreQueueTest : public ::testing::TestWithParam<bool> {
   std::vector<pipeline::PipelineBuffer<std::shared_ptr<Instruction>>>
       completionSlots;
 
-  std::vector<MemoryAccessTarget> addresses;
-  span<const MemoryAccessTarget> addressesSpan;
+  std::vector<memory::MemoryAccessTarget> addresses;
+  span<const memory::MemoryAccessTarget> addressesSpan;
 
   std::vector<RegisterValue> data;
   span<const RegisterValue> dataSpan;
@@ -218,8 +218,8 @@ TEST_P(LoadStoreQueueTest, AddStore) {
 TEST_P(LoadStoreQueueTest, PurgeFlushedLoad) {
   auto queue = getQueue();
   auto initialLoadSpace = queue.getLoadQueueSpace();
-  MemoryReadResult completedRead = {addresses[0], data[0], 1};
-  span<MemoryReadResult> completedReads = {&completedRead, 1};
+  memory::MemoryReadResult completedRead = {addresses[0], data[0], 1};
+  span<memory::MemoryReadResult> completedReads = {&completedRead, 1};
 
   // Set load instruction attributes
   loadUop->setSequenceId(0);
@@ -281,8 +281,8 @@ TEST_P(LoadStoreQueueTest, Load) {
   loadUop->setSequenceId(1);
   auto queue = getQueue();
 
-  MemoryReadResult completedRead = {addresses[0], data[0], 1};
-  span<MemoryReadResult> completedReads = {&completedRead, 1};
+  memory::MemoryReadResult completedRead = {addresses[0], data[0], 1};
+  span<memory::MemoryReadResult> completedReads = {&completedRead, 1};
 
   // Set load instruction attributes
   EXPECT_CALL(*loadUop, getGeneratedAddresses())
@@ -324,7 +324,7 @@ TEST_P(LoadStoreQueueTest, LoadWithNoAddresses) {
   loadUop->setSequenceId(1);
   auto queue = getQueue();
 
-  span<const MemoryAccessTarget> emptyAddressesSpan = {};
+  span<const memory::MemoryAccessTarget> emptyAddressesSpan = {};
 
   EXPECT_CALL(*loadUop, getGeneratedAddresses())
       .Times(AtLeast(1))
@@ -397,8 +397,8 @@ TEST_P(LoadStoreQueueTest, LoadStore) {
   auto initialLoadSpace = queue.getLoadQueueSpace();
   auto initialStoreSpace = queue.getStoreQueueSpace();
 
-  MemoryReadResult completedRead = {addresses[0], data[0], 1};
-  span<MemoryReadResult> completedReads = {&completedRead, 1};
+  memory::MemoryReadResult completedRead = {addresses[0], data[0], 1};
+  span<memory::MemoryReadResult> completedReads = {&completedRead, 1};
 
   // Set load-store instruction attributes
   loadStoreUop->setSequenceId(1);
@@ -467,8 +467,8 @@ TEST_P(LoadStoreQueueTest, NonExclusiveBandwidthRestriction) {
   loadUop2->setSequenceId(2);
   loadUop2->setInstructionId(2);
 
-  std::vector<MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
-  span<const MemoryAccessTarget> multipleAddressesSpan = {
+  std::vector<memory::MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
+  span<const memory::MemoryAccessTarget> multipleAddressesSpan = {
       multipleAddresses.data(), multipleAddresses.size()};
   std::vector<RegisterValue> storeData = {static_cast<uint8_t>(0x01),
                                           static_cast<uint8_t>(0x10)};
@@ -523,8 +523,8 @@ TEST_P(LoadStoreQueueTest, ExclusiveBandwidthRestriction) {
   loadUop2->setSequenceId(2);
   loadUop2->setInstructionId(2);
 
-  std::vector<MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
-  span<const MemoryAccessTarget> multipleAddressesSpan = {
+  std::vector<memory::MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
+  span<const memory::MemoryAccessTarget> multipleAddressesSpan = {
       multipleAddresses.data(), multipleAddresses.size()};
   std::vector<RegisterValue> storeData = {static_cast<uint8_t>(0x01),
                                           static_cast<uint8_t>(0x10)};
@@ -585,8 +585,8 @@ TEST_P(LoadStoreQueueTest, NonExclusiveRequestsRestriction) {
   loadUop2->setSequenceId(2);
   loadUop2->setInstructionId(2);
 
-  std::vector<MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
-  span<const MemoryAccessTarget> multipleAddressesSpan = {
+  std::vector<memory::MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
+  span<const memory::MemoryAccessTarget> multipleAddressesSpan = {
       multipleAddresses.data(), multipleAddresses.size()};
   std::vector<RegisterValue> storeData = {static_cast<uint8_t>(0x01),
                                           static_cast<uint8_t>(0x10)};
@@ -638,8 +638,8 @@ TEST_P(LoadStoreQueueTest, ExclusiveRequestsRestriction) {
   loadUop2->setSequenceId(2);
   loadUop2->setInstructionId(2);
 
-  std::vector<MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
-  span<const MemoryAccessTarget> multipleAddressesSpan = {
+  std::vector<memory::MemoryAccessTarget> multipleAddresses = {{1, 2}, {2, 2}};
+  span<const memory::MemoryAccessTarget> multipleAddressesSpan = {
       multipleAddresses.data(), multipleAddresses.size()};
   std::vector<RegisterValue> storeData = {static_cast<uint8_t>(0x01),
                                           static_cast<uint8_t>(0x10)};
@@ -722,19 +722,19 @@ TEST_P(LoadStoreQueueTest, ViolationOverlap) {
   auto queue = getQueue();
 
   // The store will write the byte `0x01` at addresses 0 and 1
-  std::vector<MemoryAccessTarget> storeAddresses = {{0, 2}};
+  std::vector<memory::MemoryAccessTarget> storeAddresses = {{0, 2}};
   std::vector<RegisterValue> storeData = {static_cast<uint16_t>(0x0101)};
 
-  span<const MemoryAccessTarget> storeAddressesSpan = {storeAddresses.data(),
-                                                       storeAddresses.size()};
+  span<const memory::MemoryAccessTarget> storeAddressesSpan = {
+      storeAddresses.data(), storeAddresses.size()};
   span<const RegisterValue> storeDataSpan = {storeData.data(),
                                              storeData.size()};
 
   // The load will read two bytes, at addresses 1 and 2; this will overlap with
   // the written data at address 1
-  std::vector<MemoryAccessTarget> loadAddresses = {{1, 2}};
-  span<const MemoryAccessTarget> loadAddressesSpan = {loadAddresses.data(),
-                                                      loadAddresses.size()};
+  std::vector<memory::MemoryAccessTarget> loadAddresses = {{1, 2}};
+  span<const memory::MemoryAccessTarget> loadAddressesSpan = {
+      loadAddresses.data(), loadAddresses.size()};
 
   EXPECT_CALL(*storeUop, getGeneratedAddresses())
       .Times(AtLeast(1))
@@ -759,9 +759,9 @@ TEST_P(LoadStoreQueueTest, NoViolation) {
   auto queue = getQueue();
 
   // A different address to the one being stored to
-  std::vector<MemoryAccessTarget> loadAddresses = {{1, 1}};
-  span<const MemoryAccessTarget> loadAddressesSpan = {loadAddresses.data(),
-                                                      loadAddresses.size()};
+  std::vector<memory::MemoryAccessTarget> loadAddresses = {{1, 1}};
+  span<const memory::MemoryAccessTarget> loadAddressesSpan = {
+      loadAddresses.data(), loadAddresses.size()};
 
   EXPECT_CALL(*loadUop, getGeneratedAddresses())
       .Times(AtLeast(1))
@@ -786,9 +786,9 @@ TEST_P(LoadStoreQueueTest, FlushDuringConfliction) {
   loadUop2->setFlushed();
 
   // Set store addresses and data
-  std::vector<MemoryAccessTarget> storeAddresses = {{1, 1}, {2, 1}};
-  span<const MemoryAccessTarget> storeAddressesSpan = {storeAddresses.data(),
-                                                       storeAddresses.size()};
+  std::vector<memory::MemoryAccessTarget> storeAddresses = {{1, 1}, {2, 1}};
+  span<const memory::MemoryAccessTarget> storeAddressesSpan = {
+      storeAddresses.data(), storeAddresses.size()};
   std::vector<RegisterValue> storeData = {static_cast<uint8_t>(0x01),
                                           static_cast<uint8_t>(0x10)};
   span<const RegisterValue> storeDataSpan = {storeData.data(),
@@ -801,17 +801,17 @@ TEST_P(LoadStoreQueueTest, FlushDuringConfliction) {
       .WillRepeatedly(Return(storeDataSpan));
 
   // Set load address which overlaps on first store address
-  std::vector<MemoryAccessTarget> loadAddresses = {{1, 1}};
-  span<const MemoryAccessTarget> loadAddressesSpan = {loadAddresses.data(),
-                                                      loadAddresses.size()};
+  std::vector<memory::MemoryAccessTarget> loadAddresses = {{1, 1}};
+  span<const memory::MemoryAccessTarget> loadAddressesSpan = {
+      loadAddresses.data(), loadAddresses.size()};
   EXPECT_CALL(*loadUop, getGeneratedAddresses())
       .Times(AtLeast(1))
       .WillRepeatedly(Return(loadAddressesSpan));
 
   // Set load address which overlaps on second store address
-  std::vector<MemoryAccessTarget> loadAddresses2 = {{2, 1}};
-  span<const MemoryAccessTarget> loadAddressesSpan2 = {loadAddresses2.data(),
-                                                       loadAddresses2.size()};
+  std::vector<memory::MemoryAccessTarget> loadAddresses2 = {{2, 1}};
+  span<const memory::MemoryAccessTarget> loadAddressesSpan2 = {
+      loadAddresses2.data(), loadAddresses2.size()};
   EXPECT_CALL(*loadUop2, getGeneratedAddresses())
       .Times(AtLeast(1))
       .WillRepeatedly(Return(loadAddressesSpan2));
@@ -852,9 +852,9 @@ TEST_P(LoadStoreQueueTest, SupplyDataToConfliction) {
   loadUop->setSequenceId(1);
   loadUop->setInstructionId(1);
 
-  std::vector<MemoryAccessTarget> storeAddresses = {{1, 1}, {2, 1}};
-  span<const MemoryAccessTarget> storeAddressesSpan = {storeAddresses.data(),
-                                                       storeAddresses.size()};
+  std::vector<memory::MemoryAccessTarget> storeAddresses = {{1, 1}, {2, 1}};
+  span<const memory::MemoryAccessTarget> storeAddressesSpan = {
+      storeAddresses.data(), storeAddresses.size()};
   std::vector<RegisterValue> storeData = {static_cast<uint8_t>(0x01),
                                           static_cast<uint8_t>(0x10)};
   span<const RegisterValue> storeDataSpan = {storeData.data(),
@@ -868,9 +868,10 @@ TEST_P(LoadStoreQueueTest, SupplyDataToConfliction) {
 
   // Set load addresses which exactly and partially overlaps on first and second
   // store addresses respectively
-  std::vector<MemoryAccessTarget> loadAddresses = {{1, 1}, {2, 2}, {3, 1}};
-  span<const MemoryAccessTarget> loadAddressesSpan = {loadAddresses.data(),
-                                                      loadAddresses.size()};
+  std::vector<memory::MemoryAccessTarget> loadAddresses = {
+      {1, 1}, {2, 2}, {3, 1}};
+  span<const memory::MemoryAccessTarget> loadAddressesSpan = {
+      loadAddresses.data(), loadAddresses.size()};
   EXPECT_CALL(*loadUop, getGeneratedAddresses())
       .Times(AtLeast(1))
       .WillRepeatedly(Return(loadAddressesSpan));

--- a/test/unit/pipeline/ReorderBufferTest.cc
+++ b/test/unit/pipeline/ReorderBufferTest.cc
@@ -167,9 +167,9 @@ TEST_F(ReorderBufferTest, CommitLoad) {
 
 // Tests that the reorder buffer correctly triggers a store upon commit
 TEST_F(ReorderBufferTest, CommitStore) {
-  std::vector<MemoryAccessTarget> addresses = {{0, 1}};
-  span<const MemoryAccessTarget> addressesSpan = {addresses.data(),
-                                                  addresses.size()};
+  std::vector<memory::MemoryAccessTarget> addresses = {{0, 1}};
+  span<const memory::MemoryAccessTarget> addressesSpan = {addresses.data(),
+                                                          addresses.size()};
 
   std::vector<RegisterValue> data = {static_cast<uint8_t>(1)};
   span<const RegisterValue> dataSpan = {data.data(), data.size()};
@@ -298,8 +298,8 @@ TEST_F(ReorderBufferTest, violatingLoad) {
   const uint64_t ldSize = 4;
 
   // Init Store
-  const MemoryAccessTarget strTarget = {strAddr, strSize};
-  span<const MemoryAccessTarget> strTargetSpan = {&strTarget, 1};
+  const memory::MemoryAccessTarget strTarget = {strAddr, strSize};
+  span<const memory::MemoryAccessTarget> strTargetSpan = {&strTarget, 1};
   ON_CALL(*uop, getGeneratedAddresses()).WillByDefault(Return(strTargetSpan));
   ON_CALL(*uop, isStoreAddress()).WillByDefault(Return(true));
   ON_CALL(*uop, isStoreData()).WillByDefault(Return(true));
@@ -308,8 +308,8 @@ TEST_F(ReorderBufferTest, violatingLoad) {
   lsq.addStore(uopPtr);
   reorderBuffer.reserve(uopPtr);
   // Init load
-  const MemoryAccessTarget ldTarget = {ldAddr, ldSize};
-  span<const MemoryAccessTarget> ldTargetSpan = {&ldTarget, 1};
+  const memory::MemoryAccessTarget ldTarget = {ldAddr, ldSize};
+  span<const memory::MemoryAccessTarget> ldTargetSpan = {&ldTarget, 1};
   ON_CALL(*uop2, getGeneratedAddresses()).WillByDefault(Return(ldTargetSpan));
   ON_CALL(*uop2, isLoad()).WillByDefault(Return(true));
   uopPtr2->setSequenceId(1);

--- a/test/unit/riscv/ArchitectureTest.cc
+++ b/test/unit/riscv/ArchitectureTest.cc
@@ -121,7 +121,7 @@ TEST_F(RiscVArchitectureTest, handleException) {
   std::unique_ptr<CoreInstance> coreInstance =
       std::make_unique<CoreInstance>(executablePath, executableArgs);
   const Core& core = *coreInstance->getCore();
-  MemoryInterface& memInt = *coreInstance->getDataMemory();
+  memory::MemoryInterface& memInt = *coreInstance->getDataMemory();
   auto exceptionHandler = arch->handleException(insn[0], core, memInt);
 
   bool tickRes = exceptionHandler->tick();

--- a/test/unit/riscv/ExceptionHandlerTest.cc
+++ b/test/unit/riscv/ExceptionHandlerTest.cc
@@ -87,12 +87,13 @@ TEST_F(RiscVExceptionHandlerTest, testSyscall) {
   EXPECT_EQ(result.stateChange.modifiedRegisters, modRegs);
   std::vector<RegisterValue> modRegVals = {{0ull, 8}};
   EXPECT_EQ(result.stateChange.modifiedRegisterValues, modRegVals);
-  std::vector<MemoryAccessTarget> modMemTargets = {{1234, 6},
-                                                   {1234 + 65, 13},
-                                                   {1234 + (65 * 2), 42},
-                                                   {1234 + (65 * 3), 35},
-                                                   {1234 + (65 * 4), 8},
-                                                   {1234 + (65 * 5), 7}};
+  std::vector<memory::MemoryAccessTarget> modMemTargets = {
+      {1234, 6},
+      {1234 + 65, 13},
+      {1234 + (65 * 2), 42},
+      {1234 + (65 * 3), 35},
+      {1234 + (65 * 4), 8},
+      {1234 + (65 * 5), 7}};
   EXPECT_EQ(result.stateChange.memoryAddresses, modMemTargets);
   std::vector<RegisterValue> modMemVals = {
       RegisterValue("Linux"),
@@ -120,18 +121,20 @@ TEST_F(RiscVExceptionHandlerTest, readStringThen) {
   uint64_t addr = 1024;
   int maxLen = kernel::Linux::LINUX_PATH_MAX;
 
-  MemoryAccessTarget target1 = {addr, 1};
-  MemoryReadResult res1 = {target1, RegisterValue(0xAB, 1), 1};
-  span<MemoryReadResult> res1Span = span<MemoryReadResult>(&res1, 1);
+  memory::MemoryAccessTarget target1 = {addr, 1};
+  memory::MemoryReadResult res1 = {target1, RegisterValue(0xAB, 1), 1};
+  span<memory::MemoryReadResult> res1Span =
+      span<memory::MemoryReadResult>(&res1, 1);
 
-  MemoryAccessTarget target2 = {addr + 1, 1};
-  MemoryReadResult res2 = {target2, RegisterValue(static_cast<int>('\0'), 1),
-                           1};
-  span<MemoryReadResult> res2Span = span<MemoryReadResult>(&res2, 1);
+  memory::MemoryAccessTarget target2 = {addr + 1, 1};
+  memory::MemoryReadResult res2 = {target2,
+                                   RegisterValue(static_cast<int>('\0'), 1), 1};
+  span<memory::MemoryReadResult> res2Span =
+      span<memory::MemoryReadResult>(&res2, 1);
 
   // On first call to readStringThen, expect return of false and retVal to still
   // be 0, and buffer to be filled with `q`
-  MemoryAccessTarget tar = {addr, 1};
+  memory::MemoryAccessTarget tar = {addr, 1};
   EXPECT_CALL(memory, requestRead(tar, 0)).Times(1);
   bool outcome =
       handler.readStringThen(buffer, addr, maxLen, [&retVal](auto length) {
@@ -147,7 +150,7 @@ TEST_F(RiscVExceptionHandlerTest, readStringThen) {
   // ResumeHandling (called on tick()) should now be set to `readStringThen()`
   // so call this for our second pass.
   ON_CALL(memory, getCompletedReads())
-      .WillByDefault(Return(span<MemoryReadResult>()));
+      .WillByDefault(Return(span<memory::MemoryReadResult>()));
   EXPECT_CALL(memory, getCompletedReads()).Times(1);
   outcome = handler.tick();
   // No memory reads completed yet so again expect to return false and no change
@@ -239,13 +242,14 @@ TEST_F(RiscVExceptionHandlerTest, readStringThen_maxLenReached) {
   uint64_t addr = 1024;
   int maxLen = 1;
 
-  MemoryAccessTarget target1 = {addr, 1};
-  MemoryReadResult res1 = {target1, RegisterValue(0xAB, 1), 1};
-  span<MemoryReadResult> res1Span = span<MemoryReadResult>(&res1, 1);
+  memory::MemoryAccessTarget target1 = {addr, 1};
+  memory::MemoryReadResult res1 = {target1, RegisterValue(0xAB, 1), 1};
+  span<memory::MemoryReadResult> res1Span =
+      span<memory::MemoryReadResult>(&res1, 1);
 
   // On first call to readStringThen, expect return of false and retVal to still
   // be 0, and buffer to be filled with `q`
-  MemoryAccessTarget tar = {addr, 1};
+  memory::MemoryAccessTarget tar = {addr, 1};
   EXPECT_CALL(memory, requestRead(tar, 0)).Times(1);
   bool outcome =
       handler.readStringThen(buffer, addr, maxLen, [&retVal](auto length) {
@@ -261,7 +265,7 @@ TEST_F(RiscVExceptionHandlerTest, readStringThen_maxLenReached) {
   // ResumeHandling (called on tick()) should now be set to `readStringThen()`
   // so call this for our second pass.
   ON_CALL(memory, getCompletedReads())
-      .WillByDefault(Return(span<MemoryReadResult>()));
+      .WillByDefault(Return(span<memory::MemoryReadResult>()));
   EXPECT_CALL(memory, getCompletedReads()).Times(1);
   outcome = handler.tick();
   // No memory reads completed yet so again expect to return false and no change
@@ -307,12 +311,13 @@ TEST_F(RiscVExceptionHandlerTest, readBufferThen) {
   std::vector<char> dataVec2(length, 'q');
   // Initialise the two required targets (128-bytes per read request in
   // readBufferThen())
-  MemoryAccessTarget tar1 = {ptr, 128};
-  MemoryAccessTarget tar2 = {ptr + 128, static_cast<uint16_t>(length - 128)};
+  memory::MemoryAccessTarget tar1 = {ptr, 128};
+  memory::MemoryAccessTarget tar2 = {ptr + 128,
+                                     static_cast<uint16_t>(length - 128)};
   // Initialise "responses" from the MockMemory
-  MemoryReadResult res1 = {tar1, RegisterValue(dataVec.data() + ptr, 128),
-                           uopPtr->getSequenceId()};
-  MemoryReadResult res2 = {
+  memory::MemoryReadResult res1 = {
+      tar1, RegisterValue(dataVec.data() + ptr, 128), uopPtr->getSequenceId()};
+  memory::MemoryReadResult res2 = {
       tar2, RegisterValue(dataVec.data() + ptr + 128, length - 128),
       uopPtr->getSequenceId()};
 
@@ -333,7 +338,7 @@ TEST_F(RiscVExceptionHandlerTest, readBufferThen) {
 
   // Can now call tick() - on call, emulate no reads completed
   ON_CALL(memory, getCompletedReads())
-      .WillByDefault(Return(span<MemoryReadResult>()));
+      .WillByDefault(Return(span<memory::MemoryReadResult>()));
   EXPECT_CALL(memory, getCompletedReads()).Times(1);
   outcome = handler.tick();
   EXPECT_FALSE(outcome);
@@ -343,12 +348,12 @@ TEST_F(RiscVExceptionHandlerTest, readBufferThen) {
   // Call tick() again, simulating completed read + new read requested as still
   // data to fetch
   ON_CALL(memory, getCompletedReads())
-      .WillByDefault(Return(span<MemoryReadResult>(&res1, 1)));
+      .WillByDefault(Return(span<memory::MemoryReadResult>(&res1, 1)));
   // Make sure clearCompletedReads() alters functionality of getCompletedReads()
   ON_CALL(memory, clearCompletedReads())
       .WillByDefault(::testing::InvokeWithoutArgs([&]() {
         ON_CALL(memory, getCompletedReads())
-            .WillByDefault(Return(span<MemoryReadResult>()));
+            .WillByDefault(Return(span<memory::MemoryReadResult>()));
       }));
   EXPECT_CALL(memory, getCompletedReads()).Times(2);
   EXPECT_CALL(memory, clearCompletedReads()).Times(1);
@@ -364,7 +369,7 @@ TEST_F(RiscVExceptionHandlerTest, readBufferThen) {
   // One final call to tick() to get last bits of data from memory and call
   // then()
   ON_CALL(memory, getCompletedReads())
-      .WillByDefault(Return(span<MemoryReadResult>(&res2, 1)));
+      .WillByDefault(Return(span<memory::MemoryReadResult>(&res2, 1)));
   EXPECT_CALL(memory, getCompletedReads()).Times(1);
   EXPECT_CALL(memory, clearCompletedReads()).Times(1);
   outcome = handler.tick();

--- a/test/unit/riscv/ExceptionHandlerTest.cc
+++ b/test/unit/riscv/ExceptionHandlerTest.cc
@@ -23,18 +23,20 @@ class RiscVExceptionHandlerTest : public ::testing::Test {
                    .as<std::string>()),
         arch(kernel),
         physRegFileSet(config::SimInfo::getArchRegStruct()),
-        archRegFileSet(physRegFileSet) {}
+        archRegFileSet(physRegFileSet),
+        core(memory, arch, config::SimInfo::getArchRegStruct()) {}
 
  protected:
   ConfigInit configInit = ConfigInit(config::ISA::RV64, "");
 
-  MockCore core;
   MockMemoryInterface memory;
   kernel::Linux kernel;
   Architecture arch;
 
   RegisterFileSet physRegFileSet;
   ArchitecturalRegisterFileSet archRegFileSet;
+
+  MockCore core;
 
   // addi	sp, ra, 2000 --- Just need a valid instruction to hijack
   std::array<uint8_t, 4> validInstrBytes = {0x13, 0x81, 0x00, 0x7d};


### PR DESCRIPTION
Cleans up the Core classes by moving common member variables into the base class and ensuring the code aligns with the rest of the project.

Closes #356 
Fixes #386 