### PR TITLE
Fix Warnings

### DIFF
--- a/src/include/simeng/CoreInstance.hh
+++ b/src/include/simeng/CoreInstance.hh
@@ -23,7 +23,8 @@
 
 // Program used when no executable is provided; counts down from
 // 1024*1024, with an independent `orr` at the start of each branch.
-static uint32_t hex_[] = {
+// TODO unsure of why this is producing a warning when it is used
+[[maybe_unused]] static uint32_t hex_[] = {
     0x320C03E0,  // orr w0, wzr, #1048576
     0x320003E1,  // orr w0, wzr, #1
     0x71000400,  // subs w0, w0, #1

--- a/src/include/simeng/arch/aarch64/ArchInfo.hh
+++ b/src/include/simeng/arch/aarch64/ArchInfo.hh
@@ -38,8 +38,9 @@ class ArchInfo : public simeng::arch::ArchInfo {
     uint16_t condCount = regConfig["Conditional-Count"].as<uint16_t>();
     uint16_t matCount = regConfig["Matrix-Count"].as<uint16_t>();
     // Matrix-Count multiplied by (SVL/8) as internal representation of
-    // ZA is a block of row-vector-registers. Therefore we need to
+    // ZA is a block of row-vector-registers. Therefore, we need to
     // convert physical counts from whole-ZA to rows-in-ZA.
+    // TODO giving may be uninitialised but unsure why
     matCount *= zaSize_;
     physRegStruct_ = {{8, gpCount},
                       {256, fpCount},

--- a/src/include/simeng/arch/aarch64/helpers/float.hh
+++ b/src/include/simeng/arch/aarch64/helpers/float.hh
@@ -157,6 +157,8 @@ RegisterValue scvtf_FixedPoint(
  * Returns single value of type D. */
 template <typename D, typename N>
 D fcvtzu_integer(srcValContainer& sourceValues) {
+  static_assert((std::is_same<float, N>() || std::is_same<double, N>()) &&
+                "N not of valid type float or double");
   N input = sourceValues[0].get<N>();
   D result = static_cast<D>(0);
 
@@ -165,7 +167,7 @@ D fcvtzu_integer(srcValContainer& sourceValues) {
     if (std::isinf(input)) {
       // Account for Infinity
       result = std::numeric_limits<D>::max();
-    } else if (input > std::numeric_limits<D>::max()) {
+    } else if (input >= (N)std::numeric_limits<D>::max()) {
       // Account for the source value being larger than the
       // destination register can support
       result = std::numeric_limits<D>::max();

--- a/src/include/simeng/arch/aarch64/helpers/neon.hh
+++ b/src/include/simeng/arch/aarch64/helpers/neon.hh
@@ -146,7 +146,7 @@ RegisterValue vecCountPerByte(srcValContainer& sourceValues) {
   const uint8_t* n = sourceValues[0].getAsVector<uint8_t>();
   T out[16 / sizeof(T)] = {0};
   for (int i = 0; i < I; i++) {
-    for (int j = 0; j < (sizeof(T) * 8); j++) {
+    for (size_t j = 0; j < (sizeof(T) * 8); j++) {
       // Move queried bit to LSB and extract via an AND operator
       out[i] += ((n[i] >> j) & 1);
     }
@@ -187,10 +187,10 @@ RegisterValue vecExtVecs_index(
   const uint64_t index = static_cast<uint64_t>(metadata.operands[3].imm);
   T out[16 / sizeof(T)] = {0};
 
-  for (int i = index; i < I; i++) {
+  for (uint64_t i = index; i < I; i++) {
     out[i - index] = n[i];
   }
-  for (int i = 0; i < index; i++) {
+  for (uint64_t i = 0; i < index; i++) {
     out[I - index + i] = m[i];
   }
   return {out, 256};
@@ -825,7 +825,7 @@ RegisterValue vecTbl(
   const uint8_t n_table_regs = metadata.operandCount - 2;
 
   // Create table from vectors. All table sourceValues must be of 16b format.
-  int tableSize = 16 * n_table_regs;
+  int16_t tableSize = 16 * n_table_regs;
   uint8_t table[tableSize];
   for (int i = 0; i < n_table_regs; i++) {
     const int8_t* currentVector = sourceValues[i].getAsVector<int8_t>();
@@ -836,7 +836,7 @@ RegisterValue vecTbl(
 
   int8_t out[16 / sizeof(int8_t)] = {0};
   for (int i = 0; i < I; i++) {
-    unsigned int index = Vm[i];
+    int8_t index = Vm[i];
 
     // If an index is out of range for the table, the result for that lookup
     // is 0

--- a/src/include/simeng/config/ExpectationNode.hh
+++ b/src/include/simeng/config/ExpectationNode.hh
@@ -235,7 +235,7 @@ class ExpectationNode {
     }
 
     definedSet_ = true;
-    for (const T s : set) {
+    for (const T& s : set) {
       DataTypeVariant dtv = s;
       expectedSet_.push_back(dtv);
     }
@@ -311,6 +311,11 @@ class ExpectationNode {
           }
           return {true, "Success"};
         }
+        default:
+          std::cerr << "[SimEng:validateConfigNode] Unexpected ExpectedType"
+                    << std::endl;
+
+          exit(-1);
       }
     }
   }
@@ -460,7 +465,7 @@ class ExpectationNode {
         }
       }
       if (!foundInSet) {
-        // Construct a human readable output denoted expected set failure
+        // Construct a human-readable output denoted expected set failure
         retStr << nodeVal << " not in set {";
         for (size_t i = 0; i < expectedSet_.size(); i++) {
           retStr << getByType<T>(expectedSet_[i]);
@@ -475,7 +480,7 @@ class ExpectationNode {
       // Check for value between bounds
       if (getByType<T>(expectedBounds_.first) > nodeVal ||
           getByType<T>(expectedBounds_.second) < nodeVal) {
-        // Construct a human readable output denoted expected bounds failure
+        // Construct a human-readable output denoted expected bounds failure
         retStr << nodeVal << " not in the bounds {"
                << getByType<T>(expectedBounds_.first) << " to "
                << getByType<T>(expectedBounds_.second) << "}";
@@ -542,7 +547,9 @@ class ExpectationNode {
 
   /** The value bounds the associated config option is expected to lie between.
    */
-  std::pair<DataTypeVariant, DataTypeVariant> expectedBounds_;
+  // TODO needs initialisation in case validation called before setting. Unsure
+  // whether this is a good solution
+  std::pair<DataTypeVariant, DataTypeVariant> expectedBounds_ = {0, 0};
 
   /** The instances of ExpectationNodes held within this node. Considered to be
    * the children of this node. */

--- a/src/include/simeng/config/yaml/ryml.hh
+++ b/src/include/simeng/config/yaml/ryml.hh
@@ -20764,7 +20764,7 @@ public:
     template<class T>
     T as() const 
     {
-        T val;
+        T val{};
         tree__->cref(id__) >> val;
         return val;
     }

--- a/src/include/simeng/kernel/Linux.hh
+++ b/src/include/simeng/kernel/Linux.hh
@@ -89,7 +89,8 @@ struct LinuxProcessState {
   /** The clear_child_tid value. */
   uint64_t clearChildTid = 0;
 
-  /** The virtual file descriptor mapping table. */
+  /** The virtual file descriptor mapping table. Maps virtual file descriptors
+   * to host file descriptors */
   std::vector<int64_t> fileDescriptorTable;
   /** Set of deallocated virtual file descriptors available for reuse. */
   std::set<int64_t> freeFileDescriptors;
@@ -204,7 +205,7 @@ class Linux {
                 off_t offset);
 
   /** openat syscall: open/create a file. */
-  int64_t openat(int64_t dirfd, const std::string& path, int64_t flags,
+  int64_t openat(int64_t vdfd, const std::string& filename, int64_t flags,
                  uint16_t mode);
 
   /** readlinkat syscall: read value of a symbolic link. */
@@ -240,9 +241,10 @@ class Linux {
   static const size_t LINUX_PATH_MAX = 4096;
 
  private:
-  /** Resturn correct Dirfd depending on given pathname abd dirfd given to
-   * syscall. */
-  uint64_t getDirFd(int64_t dfd, std::string pathname);
+  /** Return the host directory file descriptor depending on given pathname and
+   * virtual dfd given to syscall. If vdfd is AT_FDCWD then AT_FDCWD is returned
+   */
+  int64_t getHostDFD(int64_t vdfd, std::string pathname);
 
   /** If the given filepath points to a special file, the filepath is replaced
    * to point to the SimEng equivalent. */

--- a/src/include/simeng/pipeline/ReorderBuffer.hh
+++ b/src/include/simeng/pipeline/ReorderBuffer.hh
@@ -44,7 +44,7 @@ class ReorderBuffer {
   /** Constructs a reorder buffer of maximum size `maxSize`, supplying a
    * reference to the register alias table. */
   ReorderBuffer(
-      unsigned int maxSize, RegisterAliasTable& rat, LoadStoreQueue& lsq,
+      uint64_t maxSize, RegisterAliasTable& rat, LoadStoreQueue& lsq,
       std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
       std::function<void(uint64_t branchAddress)> sendLoopBoundary,
       BranchPredictor& predictor, uint16_t loopBufSize,
@@ -93,7 +93,7 @@ class ReorderBuffer {
   LoadStoreQueue& lsq_;
 
   /** The maximum size of the ROB. */
-  unsigned int maxSize_;
+  uint64_t maxSize_;
 
   /** A function to call upon exception generation. */
   std::function<void(std::shared_ptr<Instruction>)> raiseException_;

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -66,4 +66,5 @@ install(TARGETS libsimeng DESTINATION lib)
 get_target_property(SIMENG_COMPILE_OPTIONS libsimeng COMPILE_OPTIONS)
 get_target_property(SIMENG_COMPILE_DEFINITIONS libsimeng COMPILE_DEFINITIONS)
 get_target_property(SIMENG_VERSION libsimeng VERSION)
+# TODO can this be moved to build folder? Cmake may not do full rebuild when compiling after a change, therefor version.hh and cmake options may differ e.g. BUILD_TYPE
 configure_file(${PROJECT_SOURCE_DIR}/src/include/simeng/version.hh.in ${PROJECT_SOURCE_DIR}/src/include/simeng/version.hh)

--- a/src/lib/CoreInstance.cc
+++ b/src/lib/CoreInstance.cc
@@ -105,6 +105,7 @@ void CoreInstance::createProcess(std::string executablePath,
       exit(1);
     }
   } else {
+    // TODO remove once default binary in use
     // Create a process image from the set of instructions held in hex_
     process_ = std::make_unique<kernel::LinuxProcess>(
         span<char>(reinterpret_cast<char*>(hex_), sizeof(hex_)), config_);

--- a/src/lib/PerceptronPredictor.cc
+++ b/src/lib/PerceptronPredictor.cc
@@ -12,7 +12,7 @@ PerceptronPredictor::PerceptronPredictor(ryml::ConstNodeRef config)
   btb_.resize(btbSize);
   // Initialise perceptron values with 0 for the global history weights, and 1
   // for the bias weight; and initialise the target with 0 (i.e., unknown)
-  for (int i = 0; i < btbSize; i++) {
+  for (uint32_t i = 0; i < btbSize; i++) {
     btb_[i].first.assign(globalHistoryLength_, 0);
     btb_[i].first.push_back(1);
     btb_[i].second = 0;
@@ -96,10 +96,11 @@ void PerceptronPredictor::update(uint64_t address, bool taken,
 
   // Update the perceptron if the prediction was wrong, or the dot product's
   // magnitude was not greater than the training threshold
-  if ((directionPrediction != taken) || (abs(Pout) < trainingThreshold_)) {
+  if ((directionPrediction != taken) ||
+      ((uint64_t)abs(Pout) < trainingThreshold_)) {
     int8_t t = (taken) ? 1 : -1;
 
-    for (int i = 0; i < globalHistoryLength_; i++) {
+    for (uint64_t i = 0; i < globalHistoryLength_; i++) {
       int8_t xi =
           ((prevGlobalHistory & (1 << ((globalHistoryLength_ - 1) - i))) == 0)
               ? -1
@@ -148,7 +149,7 @@ void PerceptronPredictor::flush(uint64_t address) {
 int64_t PerceptronPredictor::getDotProduct(
     const std::vector<int8_t>& perceptron, uint64_t history) {
   int64_t Pout = perceptron[globalHistoryLength_];
-  for (int i = 0; i < globalHistoryLength_; i++) {
+  for (uint64_t i = 0; i < globalHistoryLength_; i++) {
     // Get branch direction for ith entry in the history
     bool historyTaken =
         ((history & (1 << ((globalHistoryLength_ - 1) - i))) != 0);

--- a/src/lib/SpecialFileDirGen.cc
+++ b/src/lib/SpecialFileDirGen.cc
@@ -23,6 +23,7 @@ void SpecialFileDirGen::RemoveExistingSFDir() {
   const std::string exist_input = "[ ! -d " + specialFilesDir_ + " ]";
   if (system(exist_input.c_str())) {
     const std::string rm_input = "rm -r " + specialFilesDir_;
+    // TODO handle result, applied to all "system" calls
     system(rm_input.c_str());
   }
   return;
@@ -45,7 +46,7 @@ void SpecialFileDirGen::GenerateSFDir() {
 
   // Create '/proc/cpuinfo' file.
   std::ofstream cpuinfo_File(proc_dir + "cpuinfo");
-  for (int i = 0; i < coreCount_ * socketCount_ * smt_; i++) {
+  for (uint64_t i = 0; i < coreCount_ * socketCount_ * smt_; i++) {
     cpuinfo_File << "processor\t: " + std::to_string(i) + "\nBogoMIPS\t: " +
                         std::to_string(bogoMIPS_).erase(
                             std::to_string(bogoMIPS_).length() - 4) +
@@ -63,7 +64,7 @@ void SpecialFileDirGen::GenerateSFDir() {
   // Create '/proc/stat' file.
   std::ofstream stat_File(proc_dir + "stat");
   stat_File << "cpu  0 0 0 0 0 0 0 0 0 0\n";
-  for (int i = 0; i < coreCount_ * socketCount_ * smt_; i++) {
+  for (uint64_t i = 0; i < coreCount_ * socketCount_ * smt_; i++) {
     stat_File << "cpu" + std::to_string(i) + " 0 0 0 0 0 0 0 0 0 0\n";
   }
   stat_File << "intr 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
@@ -88,7 +89,7 @@ void SpecialFileDirGen::GenerateSFDir() {
   online_File.close();
 
   // Create sub directory for each CPU core and required files.
-  for (int i = 0; i < coreCount_ * socketCount_ * smt_; i++) {
+  for (uint64_t i = 0; i < coreCount_ * socketCount_ * smt_; i++) {
     system(("mkdir " + cpu_base_dir + std::to_string(i) + "/").c_str());
     system(
         ("mkdir " + cpu_base_dir + std::to_string(i) + "/topology/").c_str());
@@ -98,12 +99,12 @@ void SpecialFileDirGen::GenerateSFDir() {
   // physical_package_id}' files
   uint64_t cores_per_package = coreCount_ / packageCount_;
   uint64_t current_package_id = 0;
-  for (int s = 0; s < socketCount_; s++) {
-    for (int c = 0; c < coreCount_; c++) {
+  for (uint64_t s = 0; s < socketCount_; s++) {
+    for (uint64_t c = 0; c < coreCount_; c++) {
       if (c % cores_per_package == 0 && c != 0) {
         current_package_id += 1;
       }
-      for (int t = 0; t < smt_; t++) {
+      for (uint64_t t = 0; t < smt_; t++) {
         // core_id File generation
         std::ofstream core_id_file(
             cpu_base_dir +

--- a/src/lib/arch/aarch64/Architecture.cc
+++ b/src/lib/arch/aarch64/Architecture.cc
@@ -65,7 +65,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
         if (groupInheritance_.find(groups.front()) != groupInheritance_.end()) {
           std::vector<uint16_t> inheritedGroups =
               groupInheritance_.at(groups.front());
-          for (int k = 0; k < inheritedGroups.size(); k++) {
+          for (size_t k = 0; k < inheritedGroups.size(); k++) {
             // Determine if this group has inherited latency values from a
             // smaller distance
             if (inheritanceDistance[inheritedGroups[k]] > distance) {
@@ -111,7 +111,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
               groupInheritance_.end()) {
             std::vector<uint16_t> inheritedGroups =
                 groupInheritance_.at(groups.front());
-            for (int k = 0; k < inheritedGroups.size(); k++) {
+            for (size_t k = 0; k < inheritedGroups.size(); k++) {
               groupExecutionInfo_[inheritedGroups[k]].ports.push_back(newPort);
               groups.push(inheritedGroups[k]);
             }

--- a/src/lib/arch/aarch64/ExceptionHandler.cc
+++ b/src/lib/arch/aarch64/ExceptionHandler.cc
@@ -146,15 +146,17 @@ bool ExceptionHandler::init() {
         uint64_t bufPtr = registerFileSet.get(R1).get<uint64_t>();
         uint64_t count = registerFileSet.get(R2).get<uint64_t>();
         return readBufferThen(bufPtr, count, [=]() {
-          int64_t totalRead = linux_.read(fd, dataBuffer_.data(), count);
+          int64_t totRead = linux_.read(fd, dataBuffer_.data(), count);
           ProcessStateChange stateChange = {
-              ChangeType::REPLACEMENT, {R0}, {totalRead}};
+              ChangeType::REPLACEMENT, {R0}, {totRead}};
           // Check for failure
-          if (totalRead < 0) {
+          if (totRead < 0) {
             return concludeSyscall(stateChange);
           }
 
-          int64_t bytesRemaining = totalRead;
+          uint64_t totalRead = (uint64_t)totRead;
+
+          uint64_t bytesRemaining = totalRead;
           // Get pointer and size of the buffer
           uint64_t iDst = bufPtr;
           uint64_t iLength = bytesRemaining;
@@ -221,17 +223,19 @@ bool ExceptionHandler::init() {
           }
 
           // Invoke the kernel
-          int64_t totalRead = linux_.readv(fd, iovec.data(), iovcnt);
+          int64_t totRead = linux_.readv(fd, iovec.data(), iovcnt);
           ProcessStateChange stateChange = {
-              ChangeType::REPLACEMENT, {R0}, {totalRead}};
+              ChangeType::REPLACEMENT, {R0}, {totRead}};
 
           // Check for failure
-          if (totalRead < 0) {
+          if (totRead < 0) {
             return concludeSyscall(stateChange);
           }
 
+          uint64_t totalRead = (uint64_t)totRead;
+
           // Build list of memory write operations
-          int64_t bytesRemaining = totalRead;
+          uint64_t bytesRemaining = totalRead;
           for (int64_t i = 0; i < iovcnt; i++) {
             // Get pointer and size of the buffer
             uint64_t iDst = iovdata[i * 2 + 0];

--- a/src/lib/arch/aarch64/Instruction_decode.cc
+++ b/src/lib/arch/aarch64/Instruction_decode.cc
@@ -239,7 +239,7 @@ void Instruction::decode() {
             destinationRegisters_.addSMEOperand(regs.size());
             sourceValues_.addSMEOperand(regs.size());
             results_.addSMEOperand(regs.size());
-            for (int i = 0; i < regs.size(); i++) {
+            for (size_t i = 0; i < regs.size(); i++) {
               destinationRegisters_[destinationRegisterCount_] = regs[i];
               destinationRegisterCount_++;
               // If WRITE, also need to add to source registers to maintain
@@ -266,7 +266,7 @@ void Instruction::decode() {
           // Update source operand structure sizes
           sourceRegisters_.addSMEOperand(regs.size());
           sourceValues_.addSMEOperand(regs.size());
-          for (int i = 0; i < regs.size(); i++) {
+          for (size_t i = 0; i < regs.size(); i++) {
             sourceRegisters_[sourceRegisterCount_] = regs[i];
             sourceRegisterCount_++;
             sourceOperandsPending_++;
@@ -312,7 +312,7 @@ void Instruction::decode() {
         results_.addSMEOperand(regs.size());
         sourceRegisters_.addSMEOperand(regs.size());
         sourceValues_.addSMEOperand(regs.size());
-        for (int i = 0; i < regs.size(); i++) {
+        for (size_t i = 0; i < regs.size(); i++) {
           // If READ access, we only need to add SME rows to source registers.
           // If WRITE access, then we need to add SME rows to destination
           // registers AND source registers. The latter is required to maintain

--- a/src/lib/arch/aarch64/Instruction_execute.cc
+++ b/src/lib/arch/aarch64/Instruction_execute.cc
@@ -2566,7 +2566,8 @@ void Instruction::execute() {
 
         // All Slice vectors are added to results[] so need to update the
         // correct one
-        for (int i = 0; i < partition_num; i++) {
+        // TODO updated based on == comparison
+        for (uint32_t i = 0; i < partition_num; i++) {
           if (i == sliceNum)
             results_[i] = {out, 256};
           else
@@ -2630,7 +2631,8 @@ void Instruction::execute() {
 
         // All Slice vectors are added to results[] so need to update the
         // correct one
-        for (int i = 0; i < partition_num; i++) {
+        // TODO updated based on == comparison
+        for (uint32_t i = 0; i < partition_num; i++) {
           if (i == sliceNum)
             results_[i] = {out, 256};
           else

--- a/src/lib/arch/aarch64/MicroDecoder.cc
+++ b/src/lib/arch/aarch64/MicroDecoder.cc
@@ -626,7 +626,7 @@ cs_detail MicroDecoder::createDefaultDetail(std::vector<OpType> opTypes) {
   cs_detail detail = default_detail;
   info.op_count = opTypes.size();
 
-  for (int op = 0; op < opTypes.size(); op++) {
+  for (size_t op = 0; op < opTypes.size(); op++) {
     info.operands[op] = default_op;
     switch (opTypes[op].type) {
       case arm64_op_type::ARM64_OP_REG: {

--- a/src/lib/arch/riscv/Architecture.cc
+++ b/src/lib/arch/riscv/Architecture.cc
@@ -84,7 +84,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
         if (groupInheritance_.find(groups.front()) != groupInheritance_.end()) {
           std::vector<uint16_t> inheritedGroups =
               groupInheritance_.at(groups.front());
-          for (int k = 0; k < inheritedGroups.size(); k++) {
+          for (size_t k = 0; k < inheritedGroups.size(); k++) {
             // Determine if this group has inherited latency values from a
             // smaller distance
             if (inheritanceDistance[inheritedGroups[k]] > distance) {
@@ -131,7 +131,7 @@ Architecture::Architecture(kernel::Linux& kernel, ryml::ConstNodeRef config)
               groupInheritance_.end()) {
             std::vector<uint16_t> inheritedGroups =
                 groupInheritance_.at(groups.front());
-            for (int k = 0; k < inheritedGroups.size(); k++) {
+            for (size_t k = 0; k < inheritedGroups.size(); k++) {
               groupExecutionInfo_[inheritedGroups[k]].ports.push_back(newPort);
               groups.push(inheritedGroups[k]);
             }

--- a/src/lib/arch/riscv/ExceptionHandler.cc
+++ b/src/lib/arch/riscv/ExceptionHandler.cc
@@ -338,6 +338,7 @@ bool ExceptionHandler::init() {
               delete[] filename;
               stateChange.memoryAddresses.push_back(
                   {statbufPtr, sizeof(statOut)});
+              // TODO implicit cast stat to register value
               stateChange.memoryAddressValues.push_back(statOut);
               return concludeSyscall(stateChange);
             });

--- a/src/lib/config/ModelConfig.cc
+++ b/src/lib/config/ModelConfig.cc
@@ -950,7 +950,7 @@ void ModelConfig::postValidation() {
           groupInheritance.end()) {
         std::vector<uint16_t> inheritedGroups =
             groupInheritance.at(blockingGroups.front());
-        for (int k = 0; k < inheritedGroups.size(); k++) {
+        for (size_t k = 0; k < inheritedGroups.size(); k++) {
           blockingGroups.push(inheritedGroups[k]);
           node["Blocking-Group-Nums"].append_child() << inheritedGroups[k];
         }
@@ -999,7 +999,7 @@ void ModelConfig::postValidation() {
     } else {
       node.append_child() << ryml::key("Port-Nums") |= ryml::SEQ;
     }
-    for (int i = 0; i < node["Ports"].num_children(); i++) {
+    for (size_t i = 0; i < node["Ports"].num_children(); i++) {
       std::string portname = node["Ports"][i].as<std::string>();
       std::vector<std::string>::iterator itr =
           std::find(portnames.begin(), portnames.end(), portname);
@@ -1225,7 +1225,7 @@ void ModelConfig::createGroupMapping() {
   // uint16_t starting from 0. Therefore, the index of each groupOptions_
   // entry is also its <isa>::InstructionGroups value (assuming groupOptions_
   // is ordered exactly as <isa>::InstructionGroups is).
-  for (int grp = 0; grp < groupOptions_.size(); grp++) {
+  for (size_t grp = 0; grp < groupOptions_.size(); grp++) {
     groupMapping_[groupOptions_[grp]] = grp;
   }
 }

--- a/src/lib/kernel/Linux.cc
+++ b/src/lib/kernel/Linux.cc
@@ -44,7 +44,9 @@ void Linux::createProcess(const LinuxProcess& process) {
 }
 
 int64_t Linux::getHostDFD(int64_t vdfd, std::string pathname) {
-  if (vdfd == AT_FDCWD) {
+  // -100 = AT_FCWD on linux. Pass back AT_FDCWD for host platform e.g. -2 for
+  // MAC
+  if (vdfd == -100) {
     // Early return if requesting current working directory
     return AT_FDCWD;
   }

--- a/src/lib/kernel/Linux.cc
+++ b/src/lib/kernel/Linux.cc
@@ -45,8 +45,13 @@ void Linux::createProcess(const LinuxProcess& process) {
 uint64_t Linux::getDirFd(int64_t dfd, std::string pathname) {
   // Resolve absolute path to target file
   char absolutePath[LINUX_PATH_MAX];
-  // TODO result ignored
-  realpath(pathname.c_str(), absolutePath);
+  char* output = realpath(pathname.c_str(), absolutePath);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:getDirFd] realpath failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
   int64_t dfd_temp = AT_FDCWD;
   // TODO unsure of where -100 comes from. Requires comment
@@ -532,8 +537,13 @@ int64_t Linux::readlinkat(int64_t dirfd, const std::string& pathname, char* buf,
   if (pathname == "/proc/self/exe") {
     // Resolve absolute path
     char absolutePath[LINUX_PATH_MAX];
-    // TODO result ignored
-    realpath(processState.path.c_str(), absolutePath);
+    char* output = realpath(processState.path.c_str(), absolutePath);
+    if (output == NULL) {
+      // Something went wrong
+      std::cerr << "[SimEng:getDirFd] realpath failed with errno = " << errno
+                << std::endl;
+      exit(EXIT_FAILURE);
+    }
 
     // Copy executable path to buffer
     std::strncpy(buf, absolutePath, bufsize);

--- a/src/lib/kernel/LinuxProcess.cc
+++ b/src/lib/kernel/LinuxProcess.cc
@@ -127,7 +127,7 @@ void LinuxProcess::createStack(char** processImage) {
   initialStackFrame.push_back(commandLine_.size());  // argc
   for (size_t i = 0; i < commandLine_.size(); i++) {
     char* argvi = commandLine_[i].data();
-    for (int j = 0; j < commandLine_[i].size(); j++) {
+    for (size_t j = 0; j < commandLine_[i].size(); j++) {
       stringBytes.push_back(argvi[j]);
     }
     stringBytes.push_back(0);
@@ -135,7 +135,7 @@ void LinuxProcess::createStack(char** processImage) {
   // Environment strings
   std::vector<std::string> envStrings = {"OMP_NUM_THREADS=1"};
   for (std::string& env : envStrings) {
-    for (int i = 0; i < env.size(); i++) {
+    for (size_t i = 0; i < env.size(); i++) {
       stringBytes.push_back(env.c_str()[i]);
     }
     // Null entry to separate strings
@@ -147,7 +147,7 @@ void LinuxProcess::createStack(char** processImage) {
   stackPointer_ -= alignToBoundary(stringBytes.size() + 1, 32);
   uint16_t ptrCount = 1;
   initialStackFrame.push_back(stackPointer_);  // argv[0] ptr
-  for (int i = 0; i < stringBytes.size(); i++) {
+  for (size_t i = 0; i < stringBytes.size(); i++) {
     if (ptrCount == commandLine_.size()) {
       // null terminator to separate argv and env strings
       initialStackFrame.push_back(0);

--- a/src/lib/kernel/LinuxProcess.cc
+++ b/src/lib/kernel/LinuxProcess.cc
@@ -62,11 +62,16 @@ LinuxProcess::LinuxProcess(const std::vector<std::string>& commandLine,
   processImage_ = std::shared_ptr<char>(unwrappedProcImgPtr, free);
 }
 
+// TODO can this be marked as only usable by test? or is it used by SST??
 LinuxProcess::LinuxProcess(span<char> instructions, ryml::ConstNodeRef config)
     : STACK_SIZE(config["Process-Image"]["Stack-Size"].as<uint64_t>()),
       HEAP_SIZE(config["Process-Image"]["Heap-Size"].as<uint64_t>()) {
   // Set program command string to a relative path of "Default"
-  commandLine_.push_back("Default\0");
+  // TODO need to determine consequences of setting this as absolute and
+  // relative to simeng source directory
+  commandLine_.push_back("./SimEngDefaultProgram\0");
+  //  std::cerr << "command line = " << commandLine_.back().c_str() <<
+  //  std::endl;
 
   isValid_ = true;
 

--- a/src/lib/pipeline/A64FXPortAllocator.cc
+++ b/src/lib/pipeline/A64FXPortAllocator.cc
@@ -20,8 +20,8 @@ uint16_t A64FXPortAllocator::allocate(const std::vector<uint16_t>& ports) {
   uint16_t rs = 0;
   uint16_t port = 0;
   // TODO both only used in assertion
-  bool foundRS = false;
-  bool foundPort = false;
+  [[maybe_unused]] bool foundRS = false;
+  [[maybe_unused]] bool foundPort = false;
 
   if (attribute == InstructionAttribute::RSX) {
     // Get difference between free entries of RSE{0|1} and RSA{0|1}
@@ -153,7 +153,7 @@ uint8_t A64FXPortAllocator::attributeMapping(
     const std::vector<uint16_t>& ports) {
   uint8_t attribute = 0;
   // TODO only used in assertion so produces warning in release mode
-  bool foundAttribute = false;
+  [[maybe_unused]] bool foundAttribute = false;
   if (ports == EXA_EXB_EAGA_EAGB) {  // EXA,EXB,EAGA,EAGB
     attribute = InstructionAttribute::RSX;
     foundAttribute = true;

--- a/src/lib/pipeline/A64FXPortAllocator.cc
+++ b/src/lib/pipeline/A64FXPortAllocator.cc
@@ -19,6 +19,7 @@ uint16_t A64FXPortAllocator::allocate(const std::vector<uint16_t>& ports) {
 
   uint16_t rs = 0;
   uint16_t port = 0;
+  // TODO both only used in assertion
   bool foundRS = false;
   bool foundPort = false;
 
@@ -34,7 +35,7 @@ uint16_t A64FXPortAllocator::allocate(const std::vector<uint16_t>& ports) {
     int thresholdC = 4;
 
     if (diffRSE >= thresholdA) {
-      if ((freeEntries_[0] - freeEntries_[1]) >= thresholdB) {
+      if (((int64_t)freeEntries_[0] - (int64_t)freeEntries_[1]) >= thresholdB) {
         rs = RSEm_;  // Table 1
       } else {
         rs = dispatchSlot_ % 2 == 0 ? RSEm_ : RSEf_;  // Table 2
@@ -151,6 +152,7 @@ void A64FXPortAllocator::deallocate(uint16_t port) { issued(port); };
 uint8_t A64FXPortAllocator::attributeMapping(
     const std::vector<uint16_t>& ports) {
   uint8_t attribute = 0;
+  // TODO only used in assertion so produces warning in release mode
   bool foundAttribute = false;
   if (ports == EXA_EXB_EAGA_EAGB) {  // EXA,EXB,EAGA,EAGB
     attribute = InstructionAttribute::RSX;

--- a/src/lib/pipeline/DispatchIssueUnit.cc
+++ b/src/lib/pipeline/DispatchIssueUnit.cc
@@ -42,7 +42,7 @@ DispatchIssueUnit::DispatchIssueUnit(
       uint16_t issue_port = reservation_station["Port-Nums"][j].as<uint16_t>();
       rs.ports[j].issuePort = issue_port;
       // Add port mapping entry, resizing vector if needed
-      if ((issue_port + 1) > portMapping_.size()) {
+      if ((size_t)(issue_port + 1) > portMapping_.size()) {
         portMapping_.resize((issue_port + 1));
       }
       portMapping_[issue_port] = {i, j};

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -40,9 +40,9 @@ void FetchUnit::tick() {
       auto& macroOp = outputSlots[slot];
       // TODO bytes read not used in release mode producing warning. Should
       // assertion become if?
-      auto bytesRead = isa_.predecode(&(loopBuffer_.front().encoding),
-                                      loopBuffer_.front().instructionSize,
-                                      loopBuffer_.front().address, macroOp);
+      [[maybe_unused]] auto bytesRead = isa_.predecode(
+          &(loopBuffer_.front().encoding), loopBuffer_.front().instructionSize,
+          loopBuffer_.front().address, macroOp);
       assert(bytesRead != 0 && "predecode failure for loop buffer entry");
 
       // Set prediction to recorded value during loop buffer filling

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -38,6 +38,8 @@ void FetchUnit::tick() {
     auto outputSlots = output_.getTailSlots();
     for (size_t slot = 0; slot < output_.getWidth(); slot++) {
       auto& macroOp = outputSlots[slot];
+      // TODO bytes read not used in release mode producing warning. Should
+      // assertion become if?
       auto bytesRead = isa_.predecode(&(loopBuffer_.front().encoding),
                                       loopBuffer_.front().instructionSize,
                                       loopBuffer_.front().address, macroOp);
@@ -56,6 +58,7 @@ void FetchUnit::tick() {
   }
 
   // Pointer to the instruction data to decode from
+  // TODO unsure of why buffer exists and fetchBuffer_ isn't used everywhere
   const uint8_t* buffer;
   uint16_t bufferOffset;
 
@@ -105,6 +108,10 @@ void FetchUnit::tick() {
       bufferedBytes_ += blockSize_ - bufferOffset;
       buffer = fetchBuffer_;
       // Decoding should start from the beginning of the fetchBuffer_.
+      bufferOffset = 0;
+    } else {
+      // There is already enough data in the fetch buffer, so use that
+      buffer = fetchBuffer_;
       bufferOffset = 0;
     }
   } else {

--- a/src/lib/pipeline/M1PortAllocator.cc
+++ b/src/lib/pipeline/M1PortAllocator.cc
@@ -21,7 +21,7 @@ uint16_t M1PortAllocator::allocate(const std::vector<uint16_t>& ports) {
 
   uint16_t bestRSQueueSize = 0xFFFF;
   // TODO unused in release mode as only used in assertion
-  bool foundRS = false;
+  [[maybe_unused]] bool foundRS = false;
 
   // Update the reference for number of free spaces in the reservation
   // stations

--- a/src/lib/pipeline/M1PortAllocator.cc
+++ b/src/lib/pipeline/M1PortAllocator.cc
@@ -20,9 +20,10 @@ uint16_t M1PortAllocator::allocate(const std::vector<uint16_t>& ports) {
   uint16_t bestWeight = 0xFFFF;
 
   uint16_t bestRSQueueSize = 0xFFFF;
+  // TODO unused in release mode as only used in assertion
   bool foundRS = false;
 
-  // Update the the reference for number of free spaces in the reservation
+  // Update the reference for number of free spaces in the reservation
   // stations
   std::vector<uint64_t> rsFreeSpaces;
   rsSizes_(rsFreeSpaces);

--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -8,7 +8,7 @@ namespace simeng {
 namespace pipeline {
 
 ReorderBuffer::ReorderBuffer(
-    unsigned int maxSize, RegisterAliasTable& rat, LoadStoreQueue& lsq,
+    uint64_t maxSize, RegisterAliasTable& rat, LoadStoreQueue& lsq,
     std::function<void(const std::shared_ptr<Instruction>&)> raiseException,
     std::function<void(uint64_t branchAddress)> sendLoopBoundary,
     BranchPredictor& predictor, uint16_t loopBufSize,
@@ -36,7 +36,8 @@ void ReorderBuffer::reserve(const std::shared_ptr<Instruction>& insn) {
 void ReorderBuffer::commitMicroOps(uint64_t insnId) {
   if (buffer_.size()) {
     size_t index = 0;
-    int firstOp = -1;
+    // Unsure if valid
+    size_t firstOp = -1;
     bool validForCommit = false;
 
     // Find first instance of uop belonging to macro-op instruction
@@ -47,7 +48,8 @@ void ReorderBuffer::commitMicroOps(uint64_t insnId) {
       }
     }
 
-    if (firstOp > -1) {
+    // TODO check validity
+    if (firstOp > (size_t)-1) {
       // If found, see if all uops are committable
       for (; index < buffer_.size(); index++) {
         if (buffer_[index]->getInstructionId() != insnId) break;
@@ -91,7 +93,7 @@ unsigned int ReorderBuffer::commit(uint64_t maxCommitSize) {
     }
 
     const auto& destinations = uop->getDestinationRegisters();
-    for (int i = 0; i < destinations.size(); i++) {
+    for (size_t i = 0; i < destinations.size(); i++) {
       rat_.commit(destinations[i]);
     }
 

--- a/src/lib/pipeline/ReorderBuffer.cc
+++ b/src/lib/pipeline/ReorderBuffer.cc
@@ -36,20 +36,21 @@ void ReorderBuffer::reserve(const std::shared_ptr<Instruction>& insn) {
 void ReorderBuffer::commitMicroOps(uint64_t insnId) {
   if (buffer_.size()) {
     size_t index = 0;
-    // Unsure if valid
-    size_t firstOp = -1;
+    // Could be size_t or uint64_t
+    uint64_t firstOp;
     bool validForCommit = false;
+    bool foundFirstInstance = false;
 
     // Find first instance of uop belonging to macro-op instruction
     for (; index < buffer_.size(); index++) {
       if (buffer_[index]->getInstructionId() == insnId) {
         firstOp = index;
+        foundFirstInstance = true;
         break;
       }
     }
 
-    // TODO check validity
-    if (firstOp > (size_t)-1) {
+    if (foundFirstInstance) {
       // If found, see if all uops are committable
       for (; index < buffer_.size(); index++) {
         if (buffer_[index]->getInstructionId() != insnId) break;

--- a/src/tools/simeng/CMakeLists.txt
+++ b/src/tools/simeng/CMakeLists.txt
@@ -10,3 +10,13 @@ target_include_directories(simeng PUBLIC ${PROJECT_SOURCE_DIR}/src/lib)
 target_link_libraries(simeng libsimeng)
 
 install(TARGETS simeng DESTINATION bin)
+
+# Copy default program to install directory. Referenced by main
+install(FILES ${PROJECT_SOURCE_DIR}/SimEngDefaultProgram DESTINATION bin)
+
+# Copy default program to binary directory in build folder (Needed when working with some IDEs as it uses the binary which is built here). Referenced by main
+add_custom_command(
+        TARGET simeng POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${PROJECT_SOURCE_DIR}/SimEngDefaultProgram
+        ${CMAKE_CURRENT_BINARY_DIR}/SimEngDefaultProgram)

--- a/src/tools/simeng/main.cc
+++ b/src/tools/simeng/main.cc
@@ -68,6 +68,7 @@ int main(int argc, char** argv) {
     // Without a config file, no executable can be supplied so pass default
     // (empty) values for executable information
     configFilePath = DEFAULT_STR;
+    executablePath = "./SimEngDefaultProgram";
   }
 
   coreInstance =

--- a/test/regression/aarch64/AArch64RegressionTest.hh
+++ b/test/regression/aarch64/AArch64RegressionTest.hh
@@ -4,7 +4,7 @@
 #include "simeng/arch/aarch64/Architecture.hh"
 #include "simeng/arch/aarch64/Instruction.hh"
 
-static const char* AARCH64_ADDITIONAL_CONFIG = R"YAML(
+[[maybe_unused]] static const char* AARCH64_ADDITIONAL_CONFIG = R"YAML(
 {
   Core:
     {
@@ -368,12 +368,12 @@ class AArch64RegressionTest : public RegressionTest {
    * number of elements defined by a number of bytes used. */
   template <typename T>
   std::array<T, (256 / sizeof(T))> fillNeon(std::vector<T> src,
-                                            int num_bytes) const {
+                                            uint num_bytes) const {
     // Create array to be returned and fill with a default value of 0
     std::array<T, (256 / sizeof(T))> generatedArray;
     generatedArray.fill(0);
     // Fill array by cycling through source elements
-    for (int i = 0; i < (num_bytes / sizeof(T)); i++) {
+    for (size_t i = 0; i < (num_bytes / sizeof(T)); i++) {
       generatedArray[i] = src[i % src.size()];
     }
     return generatedArray;
@@ -406,7 +406,7 @@ class AArch64RegressionTest : public RegressionTest {
     std::array<T, (256 / sizeof(T))> generatedArray;
     generatedArray.fill(0);
     // Fill array by adding an increasing offset value to the base value
-    for (int i = 0; i < (num_bytes / sizeof(T)); i++) {
+    for (size_t i = 0; i < (num_bytes / sizeof(T)); i++) {
       generatedArray[i] = base + (i * offset);
     }
     return generatedArray;

--- a/test/regression/aarch64/CMakeLists.txt
+++ b/test/regression/aarch64/CMakeLists.txt
@@ -37,3 +37,9 @@ target_compile_definitions(regression-aarch64 PRIVATE
   "SIMENG_AARCH64_TEST_ROOT=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 
 add_test(NAME regression-aarch64-test COMMAND regression-aarch64)
+
+add_custom_command(
+        TARGET regression-aarch64
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/SimEngDefaultProgram ${CMAKE_CURRENT_BINARY_DIR}/SimEngDefaultProgram
+)

--- a/test/regression/aarch64/Exception.cc
+++ b/test/regression/aarch64/Exception.cc
@@ -365,7 +365,7 @@ TEST_P(Exception, svcr) {
     msr svcr, x5
     msr svcr, x4
   )");
-  for (int i = 0; i < (SVL / 8); i++) {
+  for (uint64_t i = 0; i < (SVL / 8); i++) {
     CHECK_MAT_ROW(ARM64_REG_ZA, i, uint32_t, fillNeon<uint32_t>({0}, SVL / 8));
   }
 }

--- a/test/regression/aarch64/Exception.cc
+++ b/test/regression/aarch64/Exception.cc
@@ -292,7 +292,7 @@ TEST_P(Exception, svcr) {
     smstop
     smstart
   )");
-  for (int i = 0; i < (SVL / 8); i++) {
+  for (uint64_t i = 0; i < (SVL / 8); i++) {
     CHECK_MAT_ROW(ARM64_REG_ZA, i, uint32_t, fillNeon<uint32_t>({0}, SVL / 8));
   }
 

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -1111,7 +1111,7 @@ TEST_P(Syscall, uname) {
 
   data += 65;
   const char machine[] = "aarch64";
-  for (int i = 0; i < strlen(machine); i++) EXPECT_EQ(data[i], machine[i]);
+  for (size_t i = 0; i < strlen(machine); i++) EXPECT_EQ(data[i], machine[i]);
 }
 
 TEST_P(Syscall, getrusage) {

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -436,14 +436,14 @@ TEST_P(Syscall, file_read) {
   // Check result of readv operations
   const char refReadv[] = "ABCD\0UV\0EFGH\0\0\0\0MNOPQRST";
   char* dataReadv = processMemory_ + process_->getHeapStart();
-  for (int i = 0; i < strlen(refReadv); i++) {
+  for (size_t i = 0; i < strlen(refReadv); i++) {
     EXPECT_EQ(dataReadv[i], refReadv[i]) << "at index i=" << i << '\n';
   }
 
   // Check result of read operation
   const char refRead[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   char* dataRead = processMemory_ + process_->getInitialStackPointer() - 64;
-  for (int i = 0; i < strlen(refRead); i++) {
+  for (size_t i = 0; i < strlen(refRead); i++) {
     EXPECT_EQ(dataRead[i], refRead[i]) << "at index i=" << i << '\n';
   }
 }
@@ -610,7 +610,7 @@ TEST_P(Syscall, readlinkat) {
 
   EXPECT_EQ(getGeneralRegister<int64_t>(0), reference.size());
   char* data = processMemory_ + process_->getHeapStart() + 15;
-  for (int i = 0; i < reference.size(); i++) {
+  for (size_t i = 0; i < reference.size(); i++) {
     EXPECT_EQ(data[i], reference.c_str()[i]) << "at index i=" << i << '\n';
   }
 }
@@ -1094,20 +1094,20 @@ TEST_P(Syscall, uname) {
   // Check utsname struct in memory
   char* data = processMemory_ + process_->getHeapStart();
   const char sysname[] = "Linux";
-  for (int i = 0; i < strlen(sysname); i++) EXPECT_EQ(data[i], sysname[i]);
+  for (size_t i = 0; i < strlen(sysname); i++) EXPECT_EQ(data[i], sysname[i]);
 
   // Add 65 to data pointer for reserved length of each string field in Linux
   data += 65;
   const char nodename[] = "simeng.hpc.cs.bris.ac.uk";
-  for (int i = 0; i < strlen(nodename); i++) EXPECT_EQ(data[i], nodename[i]);
+  for (size_t i = 0; i < strlen(nodename); i++) EXPECT_EQ(data[i], nodename[i]);
 
   data += 65;
   const char release[] = "4.14.0";
-  for (int i = 0; i < strlen(release); i++) EXPECT_EQ(data[i], release[i]);
+  for (size_t i = 0; i < strlen(release); i++) EXPECT_EQ(data[i], release[i]);
 
   data += 65;
   const char version[] = "#1 SimEng Mon Apr 29 16:28:37 UTC 2019";
-  for (int i = 0; i < strlen(version); i++) EXPECT_EQ(data[i], version[i]);
+  for (size_t i = 0; i < strlen(version); i++) EXPECT_EQ(data[i], version[i]);
 
   data += 65;
   const char machine[] = "aarch64";

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -608,26 +608,27 @@ TEST_P(Syscall, readlinkat) {
     exit(EXIT_FAILURE);
   }
 
-  std::string reference = std::string(cwd) + std::string("/Default");
+  std::string reference = cwd + std::string("/SimEngDefaultProgram");
+
   // Copy path to heap
   initialHeapData_.resize(strlen(path) + reference.size() + 1);
   memcpy(initialHeapData_.data(), path, strlen(path) + 1);
 
   RUN_AARCH64(R"(
-    # Get heap address
-    mov x0, 0
-    mov x8, 214
-    svc #0
-    mov x20, x0
+     # Get heap address
+     mov x0, 0
+     mov x8, 214
+     svc #0
+     mov x20, x0
 
-    # readlinkat(dirfd=0, pathname=x20, buf=x20+15, bufsize=1024)
-    mov x0, #0
-    mov x1, x20
-    add x2, x20, #15
-    mov x3, #1024
-    mov x8, #78
-    svc #0
-  )");
+     # readlinkat(dirfd=0, pathname=x20, buf=x20+15, bufsize=1024)
+     mov x0, #0
+     mov x1, x20
+     add x2, x20, #15
+     mov x3, #1024
+     mov x8, #78
+     svc #0
+   )");
 
   EXPECT_EQ(getGeneralRegister<int64_t>(0), reference.size());
   char* data = processMemory_ + process_->getHeapStart() + 15;

--- a/test/regression/aarch64/Syscall.cc
+++ b/test/regression/aarch64/Syscall.cc
@@ -187,7 +187,15 @@ TEST_P(Syscall, faccessat) {
   unlink(filepath);
 
   char abs_filepath[LINUX_PATH_MAX];
-  realpath(SIMENG_AARCH64_TEST_ROOT "/data/input.txt", abs_filepath);
+  char* output =
+      realpath(SIMENG_AARCH64_TEST_ROOT "/data/input.txt", abs_filepath);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] realpath failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
   initialHeapData_.resize(strlen(abs_filepath) + 1);
   // Copy abs_filepath to heap
   memcpy(initialHeapData_.data(), abs_filepath, strlen(abs_filepath) + 1);
@@ -213,7 +221,13 @@ TEST_P(Syscall, faccessat) {
   // Check syscall works using dirfd instead of AT_FDCWD
   const char file[] = "input.txt\0";
   char dirPath[LINUX_PATH_MAX];
-  realpath(SIMENG_AARCH64_TEST_ROOT "/data/\0", dirPath);
+  output = realpath(SIMENG_AARCH64_TEST_ROOT "/data/\0", dirPath);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] realpath failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
   initialHeapData_.resize(strlen(dirPath) + strlen(file) + 2);
   // Copy dirPath to heap
@@ -583,10 +597,17 @@ TEST_P(Syscall, filenotfound) {
 // Test that readlinkat works for supported cases
 TEST_P(Syscall, readlinkat) {
   const char path[] = "/proc/self/exe";
-  // Get current directory and append the default program's comannd line
+  // Get current directory and append the default program's command line
   // argument 0 value
   char cwd[LINUX_PATH_MAX];
-  getcwd(cwd, LINUX_PATH_MAX);
+  char* output = getcwd(cwd, LINUX_PATH_MAX);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] getcwd failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
   std::string reference = std::string(cwd) + std::string("/Default");
   // Copy path to heap
   initialHeapData_.resize(strlen(path) + reference.size() + 1);
@@ -719,7 +740,13 @@ TEST_P(Syscall, newfstatat) {
   // Check syscall works using dirfd instead of AT_FDCWD
   const char file[] = "input.txt\0";
   char dirPath[LINUX_PATH_MAX];
-  realpath(SIMENG_AARCH64_TEST_ROOT "/data/\0", dirPath);
+  char* output = realpath(SIMENG_AARCH64_TEST_ROOT "/data/\0", dirPath);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] realpath failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
   initialHeapData_.resize(128 + strlen(dirPath) + strlen(file) + 2);
   // Copy dirPath to heap

--- a/test/regression/aarch64/instructions/sme.cc
+++ b/test/regression/aarch64/instructions/sme.cc
@@ -98,7 +98,7 @@ TEST_P(InstSme, fmopa) {
 
     fmopa za2.d, p0/m, p2/m, z3.d, z4.d
   )");
-  for (int i = 0; i < (SVL / 64); i++) {
+  for (uint64_t i = 0; i < (SVL / 64); i++) {
     CHECK_MAT_ROW(ARM64_REG_ZAD0, i, double,
                   fillNeon<double>({10.0}, (SVL / 8)));
     CHECK_MAT_ROW(ARM64_REG_ZAD2, i, double,
@@ -299,7 +299,7 @@ TEST_P(InstSme, st1d) {
     st1d {za0h.d[w12, 0]}, p0, [sp, x1, lsl #3]
     st1d {za1h.d[w12, 1]}, p0, [x4]
   )");
-  for (int i = 0; i < (SVL / 64); i++) {
+  for (uint64_t i = 0; i < (SVL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 8)),
               src[i % 2]);
@@ -329,7 +329,7 @@ TEST_P(InstSme, st1d) {
     ld1d {za1h.d[w13, 1]}, p1/z, [x0, x3, lsl #3]
     st1d {za1h.d[w13, 1]}, p1, [x5, x3, lsl #3]
   )");
-  for (int i = 0; i < (SVL / 128); i++) {
+  for (uint64_t i = 0; i < (SVL / 128); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(800 + (i * 8)), src[i % 2]);
     EXPECT_EQ(getMemoryValue<uint64_t>(800 + 16 + (i * 8)), src[i % 2]);
   }
@@ -360,7 +360,7 @@ TEST_P(InstSme, st1d) {
     st1d {za0v.d[w12, 0]}, p0, [sp, x1, lsl #3]
     st1d {za1v.d[w12, 1]}, p0, [x4]
   )");
-  for (int i = 0; i < (SVL / 64); i++) {
+  for (uint64_t i = 0; i < (SVL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 8)),
               src_vert[i % 2]);
@@ -390,7 +390,7 @@ TEST_P(InstSme, st1d) {
     ld1d {za1v.d[w13, 1]}, p1/z, [x0, x3, lsl #3]
     st1d {za1v.d[w13, 1]}, p1, [x5, x3, lsl #3]
   )");
-  for (int i = 0; i < (SVL / 128); i++) {
+  for (uint64_t i = 0; i < (SVL / 128); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(800 + (i * 8)), src_vert[i % 2]);
     EXPECT_EQ(getMemoryValue<uint64_t>(800 + 16 + (i * 8)), src_vert[i % 2]);
   }
@@ -423,7 +423,7 @@ TEST_P(InstSme, st1w) {
     st1w {za0h.s[w12, 0]}, p0, [sp, x1, lsl #2]
     st1w {za1h.s[w12, 1]}, p0, [x4]
   )");
-  for (int i = 0; i < (SVL / 32); i++) {
+  for (uint64_t i = 0; i < (SVL / 32); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 4)),
               src[i % 4]);
@@ -452,7 +452,7 @@ TEST_P(InstSme, st1w) {
     ld1w {za1h.s[w12, 2]}, p1/z, [x0, x3, lsl #2]
     st1w {za1h.s[w12, 2]}, p1, [x5, x3, lsl #2]
   )");
-  for (int i = 0; i < (SVL / 64); i++) {
+  for (uint64_t i = 0; i < (SVL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>(800 + (i * 4)), src[i % 4]);
     EXPECT_EQ(getMemoryValue<uint32_t>(800 + 16 + (i * 4)), src[i % 4]);
   }
@@ -484,7 +484,7 @@ TEST_P(InstSme, st1w) {
     st1w {za0v.s[w12, 0]}, p0, [sp, x1, lsl #2]
     st1w {za1v.s[w12, 1]}, p0, [x4]
   )");
-  for (int i = 0; i < (SVL / 32); i++) {
+  for (uint64_t i = 0; i < (SVL / 32); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 4)),
               src_vert[i % 4]);
@@ -513,7 +513,7 @@ TEST_P(InstSme, st1w) {
     ld1w {za1v.s[w12, 2]}, p1/z, [x0, x3, lsl #2]
     st1w {za1v.s[w12, 2]}, p1, [x5, x3, lsl #2]
   )");
-  for (int i = 0; i < (SVL / 64); i++) {
+  for (uint64_t i = 0; i < (SVL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>(800 + (i * 4)), src_vert[i % 4]);
     EXPECT_EQ(getMemoryValue<uint32_t>(800 + 16 + (i * 4)), src_vert[i % 4]);
   }
@@ -525,7 +525,7 @@ TEST_P(InstSme, zero) {
 
     zero {za}
   )");
-  for (int i = 0; i < (SVL / 8); i++) {
+  for (uint64_t i = 0; i < (SVL / 8); i++) {
     CHECK_MAT_ROW(ARM64_REG_ZA, i, uint64_t, fillNeon<uint64_t>({0}, SVL / 8));
   }
 
@@ -561,7 +561,7 @@ TEST_P(InstSme, zero) {
 
     zero {za0.s, za2.s}
   )");
-  for (int i = 0; i < (SVL / 32); i++) {
+  for (uint64_t i = 0; i < (SVL / 32); i++) {
     CHECK_MAT_ROW(ARM64_REG_ZAS0, i, uint32_t,
                   fillNeon<uint32_t>({0}, SVL / 8));
     CHECK_MAT_ROW(ARM64_REG_ZAS2, i, uint32_t,

--- a/test/regression/aarch64/instructions/sme.cc
+++ b/test/regression/aarch64/instructions/sme.cc
@@ -70,7 +70,7 @@ TEST_P(InstSme, fmopa) {
 
     fmopa za2.s, p0/m, p2/m, z3.s, z4.s
   )");
-  for (int i = 0; i < (SVL / 32); i++) {
+  for (uint64_t i = 0; i < (SVL / 32); i++) {
     CHECK_MAT_ROW(ARM64_REG_ZAS0, i, float,
                   fillNeon<float>({10.0f}, (SVL / 8)));
     CHECK_MAT_ROW(ARM64_REG_ZAS2, i, float,

--- a/test/regression/aarch64/instructions/sve.cc
+++ b/test/regression/aarch64/instructions/sve.cc
@@ -1883,7 +1883,7 @@ TEST_P(InstSve, eor) {
   CHECK_PREDICATE(2, uint64_t, res_p2);
   CHECK_PREDICATE(3, uint64_t, {0, 0, 0, 0});
   auto res_p4 = fillPred(VL / 8, {0}, 1);
-  for (int i = 0; i < (VL / 8); i++) {
+  for (uint64_t i = 0; i < (VL / 8); i++) {
     uint64_t shifted_active = 1ull << (i % 64);
     res_p4[i / 64] |=
         (p1[i / 64] & shifted_active) == shifted_active ? 0 : shifted_active;
@@ -1954,7 +1954,7 @@ TEST_P(InstSve, eor) {
   )");
   auto res_0 = fillNeon<uint8_t>({0}, VL / 8);
   int val = 8;
-  for (int i = 0; i < (VL / 8); i++) {
+  for (uint64_t i = 0; i < (VL / 8); i++) {
     res_0[i] = val ^ 15;
     val += 2;
   }
@@ -1963,7 +1963,7 @@ TEST_P(InstSve, eor) {
 
   auto res_3 = fillNeon<uint16_t>({0}, VL / 8);
   val = 8;
-  for (int i = 0; i < (VL / 16); i++) {
+  for (uint64_t i = 0; i < (VL / 16); i++) {
     res_3[i] = val ^ 15;
     val += 2;
   }
@@ -1972,7 +1972,7 @@ TEST_P(InstSve, eor) {
 
   auto res_6 = fillNeon<uint32_t>({0}, VL / 8);
   val = 8;
-  for (int i = 0; i < (VL / 32); i++) {
+  for (uint64_t i = 0; i < (VL / 32); i++) {
     res_6[i] = val ^ 15;
     val += 2;
   }
@@ -1981,7 +1981,7 @@ TEST_P(InstSve, eor) {
 
   auto res_9 = fillNeon<uint64_t>({0}, VL / 8);
   val = 8;
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     res_9[i] = val ^ 15;
     val += 2;
   }
@@ -2802,7 +2802,7 @@ TEST_P(InstSve, fadda) {
   )");
   float fresultA = 2.75f;
   float fresultB = 2.75f;
-  for (int i = 0; i < VL / 64; i++) {
+  for (uint64_t i = 0; i < VL / 64; i++) {
     fresultA += fsrc[i % 8];
     fresultB += fsrc[(i + VL / 64) % 8];
   }
@@ -2841,7 +2841,7 @@ TEST_P(InstSve, fadda) {
   )");
   double resultA = 2.75;
   double resultB = 2.75;
-  for (int i = 0; i < VL / 128; i++) {
+  for (uint64_t i = 0; i < VL / 128; i++) {
     resultA += dsrc[i % 8];
     resultB += dsrc[(i + VL / 128) % 8];
   }
@@ -6196,16 +6196,16 @@ TEST_P(InstSve, st1b) {
     st1b {z1.b}, p1, [sp, #4, mul vl]
   )");
 
-  for (int i = 0; i < (VL / 8); i++) {
+  for (uint64_t i = 0; i < (VL / 8); i++) {
     EXPECT_EQ(
         getMemoryValue<uint8_t>(process_->getInitialStackPointer() - 4095 + i),
         src[i % 16]);
   }
-  for (int i = 0; i < (VL / 16); i++) {
+  for (uint64_t i = 0; i < (VL / 16); i++) {
     EXPECT_EQ(getMemoryValue<uint8_t>(4 * (VL / 16) + i), src[i % 16]);
   }
   uint64_t base = process_->getInitialStackPointer() - 8190 + 4 * (VL / 8);
-  for (int i = 0; i < (VL / 16); i++) {
+  for (uint64_t i = 0; i < (VL / 16); i++) {
     EXPECT_EQ(getMemoryValue<uint8_t>(base + i), src[i % 16]);
   }
 }
@@ -6362,19 +6362,19 @@ TEST_P(InstSve, st1d) {
     st1d {z1.d}, p1, [x2, x3, lsl #3]
   )");
 
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 8)),
               src[i % 4]);
   }
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(65792 + (i * 8)), src[i % 4]);
   }
   std::rotate(src.begin(), src.begin() + 2, src.end());
-  for (int i = 0; i < (VL / 128); i++) {
+  for (uint64_t i = 0; i < (VL / 128); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>((VL / 128) + 16 + (i * 8)), src[i % 4]);
   }
-  for (int i = 0; i < (VL / 128); i++) {
+  for (uint64_t i = 0; i < (VL / 128); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>((VL / 128) + (VL / 2) + (i * 8)),
               src[i % 4]);
   }
@@ -6402,7 +6402,7 @@ TEST_P(InstSve, st2d) {
     st2d {z2.d, z3.d}, p1, [x6, #4, mul vl]
   )");
 
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(process_->getInitialStackPointer() -
                                        4095 + (2 * i * 8)),
               3);
@@ -6412,7 +6412,7 @@ TEST_P(InstSve, st2d) {
   }
 
   int index = 4 * (VL / 64) * 8;
-  for (int i = 0; i < (VL / 128); i++) {
+  for (uint64_t i = 0; i < (VL / 128); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(300 + index + (2 * i * 8)), 5);
     EXPECT_EQ(getMemoryValue<uint64_t>(300 + index + (2 * i * 8) + 8), 6);
   }
@@ -6507,12 +6507,12 @@ TEST_P(InstSve, st1w) {
     st1w {z2.s}, p0, [x4]
   )");
 
-  for (int i = 0; i < (VL / 32); i++) {
+  for (uint64_t i = 0; i < (VL / 32); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 4)),
               src[i % 4]);
   }
-  for (int i = 0; i < (VL / 32); i++) {
+  for (uint64_t i = 0; i < (VL / 32); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>((VL / 8) + (i * 4)), src[i % 4]);
   }
 
@@ -6535,11 +6535,11 @@ TEST_P(InstSve, st1w) {
     st1w {z1.s}, p1, [x2, x3, lsl #2]
   )");
 
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>((VL / 64) + (VL / 2) + (i * 4)),
               src[i % 4]);
   }
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>((VL / 64) + 16 + (i * 4)), src[i % 4]);
   }
 
@@ -6583,7 +6583,7 @@ TEST_P(InstSve, st1w) {
   std::array<uint32_t, (256 / sizeof(uint32_t))> srcC =
       fillNeonCombined<uint32_t>(
           {0xDEADBEEF, 0x12345678, 0x98765432, 0xABCDEF01}, {0ul}, VL / 16);
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 4)),
               srcC[i]);
@@ -6593,7 +6593,7 @@ TEST_P(InstSve, st1w) {
       fillNeonCombined<uint32_t>(
           {0xDEADBEEF, 0x12345678, 0x98765432, 0xABCDEF01},
           {0xDEADBEEF, 0x12345678, 0x98765432, 0xABCDEF01}, VL / 16);
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint32_t>(64 + (3 + i) * 4), srcD[i]);
   }
 }
@@ -6614,7 +6614,7 @@ TEST_P(InstSve, str_predicate) {
     ldr p0, [x0, #0, mul vl]
     str p0, [sp, #0, mul vl]
   )");
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(
         getMemoryValue<uint8_t>(process_->getInitialStackPointer() - 4095 + i),
         0xFF);
@@ -6632,7 +6632,7 @@ TEST_P(InstSve, str_predicate) {
     ldr p0, [x0, #0, mul vl]
     str p0, [sp, #1, mul vl]
   )");
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint8_t>(process_->getInitialStackPointer() -
                                       (4095 - (VL / 64)) + i),
               0xDE);
@@ -6650,7 +6650,7 @@ TEST_P(InstSve, str_predicate) {
     ldr p0, [x0, #0, mul vl]
     str p0, [sp, #2, mul vl]
   )");
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint8_t>(process_->getInitialStackPointer() -
                                       (4095 - (VL / 64) * 2) + i),
               0x12);
@@ -6668,7 +6668,7 @@ TEST_P(InstSve, str_predicate) {
     ldr p0, [x0, #0, mul vl]
     str p0, [sp, #3, mul vl]
   )");
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint8_t>(process_->getInitialStackPointer() -
                                       (4095 - (VL / 64) * 3) + i),
               0x98);
@@ -6697,12 +6697,12 @@ TEST_P(InstSve, str_vector) {
     str z0, [sp, #0, mul vl]
     str z1, [x1, #4, mul vl]
   )");
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>(process_->getInitialStackPointer() -
                                        4095 + (i * 8)),
               src[i % 8]);
   }
-  for (int i = 0; i < (VL / 64); i++) {
+  for (uint64_t i = 0; i < (VL / 64); i++) {
     EXPECT_EQ(getMemoryValue<uint64_t>((VL / 8) + (VL / 2) + (i * 8)),
               src[i % 8]);
   }
@@ -6800,7 +6800,7 @@ TEST_P(InstSve, trn1) {
   std::vector<uint8_t> result8;
   int i1 = 0;
   int i2 = 10;
-  for (int i = 0; i < VL / 16; i++) {
+  for (uint64_t i = 0; i < VL / 16; i++) {
     result8.push_back(i1);
     result8.push_back(i2);
     i1 += 2;
@@ -6818,7 +6818,7 @@ TEST_P(InstSve, trn1) {
   std::vector<uint16_t> result16;
   i1 = 0;
   i2 = 10;
-  for (int i = 0; i < VL / 32; i++) {
+  for (uint64_t i = 0; i < VL / 32; i++) {
     result16.push_back(i1);
     result16.push_back(i2);
     i1 += 2;
@@ -6836,7 +6836,7 @@ TEST_P(InstSve, trn1) {
   std::vector<uint32_t> result32;
   i1 = 0;
   i2 = 10;
-  for (int i = 0; i < VL / 64; i++) {
+  for (uint64_t i = 0; i < VL / 64; i++) {
     result32.push_back(i1);
     result32.push_back(i2);
     i1 += 2;
@@ -6854,7 +6854,7 @@ TEST_P(InstSve, trn1) {
   std::vector<uint64_t> result64;
   i1 = 0;
   i2 = 10;
-  for (int i = 0; i < VL / 128; i++) {
+  for (uint64_t i = 0; i < VL / 128; i++) {
     result64.push_back(i1);
     result64.push_back(i2);
     i1 += 2;
@@ -6874,7 +6874,7 @@ TEST_P(InstSve, trn2) {
   std::vector<uint8_t> result8;
   int i1 = 1;
   int i2 = 11;
-  for (int i = 0; i < VL / 16; i++) {
+  for (uint64_t i = 0; i < VL / 16; i++) {
     result8.push_back(i1);
     result8.push_back(i2);
     i1 += 2;
@@ -6892,7 +6892,7 @@ TEST_P(InstSve, trn2) {
   std::vector<uint16_t> result16;
   i1 = 1;
   i2 = 11;
-  for (int i = 0; i < VL / 32; i++) {
+  for (uint64_t i = 0; i < VL / 32; i++) {
     result16.push_back(i1);
     result16.push_back(i2);
     i1 += 2;
@@ -6910,7 +6910,7 @@ TEST_P(InstSve, trn2) {
   std::vector<uint32_t> result32;
   i1 = 1;
   i2 = 11;
-  for (int i = 0; i < VL / 64; i++) {
+  for (uint64_t i = 0; i < VL / 64; i++) {
     result32.push_back(i1);
     result32.push_back(i2);
     i1 += 2;
@@ -6928,7 +6928,7 @@ TEST_P(InstSve, trn2) {
   std::vector<uint64_t> result64;
   i1 = 1;
   i2 = 11;
-  for (int i = 0; i < VL / 128; i++) {
+  for (uint64_t i = 0; i < VL / 128; i++) {
     result64.push_back(i1);
     result64.push_back(i2);
     i1 += 2;

--- a/test/regression/aarch64/instructions/sve.cc
+++ b/test/regression/aarch64/instructions/sve.cc
@@ -3800,8 +3800,9 @@ TEST_P(InstSve, fmla_indexed) {
   )");
   std::vector<float> resultsA;
   std::vector<float> resultsB;
-  float itemA;
-  float itemB;
+  // Redundant initialisation to prevent warnings
+  float itemA = 5.0f + (5.0f * static_cast<float>(1));
+  float itemB = 5.0f + (5.0f * static_cast<float>(2));
   for (size_t i = 0; i < (VL / 32); i++) {
     if (i % 4 == 0) {
       itemA = 5.0f + (5.0f * static_cast<float>(i + 1));
@@ -3829,8 +3830,9 @@ TEST_P(InstSve, fmla_indexed) {
   )");
   std::vector<double> resultsC;
   std::vector<double> resultsD;
-  double itemC;
-  double itemD;
+  // Redundant initialisation to prevent warnings
+  double itemC = 5.0 + (5.0 * static_cast<double>(0));
+  double itemD = 5.0 + (5.0 * static_cast<double>(1));
   for (size_t i = 0; i < (VL / 64); i++) {
     if (i % 2 == 0) {
       itemC = 5.0 + (5.0 * static_cast<double>(i));

--- a/test/regression/riscv/CMakeLists.txt
+++ b/test/regression/riscv/CMakeLists.txt
@@ -31,3 +31,9 @@ target_compile_definitions(regression-riscv PRIVATE
   "SIMENG_RISCV_TEST_ROOT=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 
 add_test(NAME regression-riscv-test COMMAND regression-riscv)
+
+add_custom_command(
+        TARGET regression-riscv
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/SimEngDefaultProgram ${CMAKE_CURRENT_BINARY_DIR}/SimEngDefaultProgram
+)

--- a/test/regression/riscv/RISCVRegressionTest.hh
+++ b/test/regression/riscv/RISCVRegressionTest.hh
@@ -4,7 +4,7 @@
 #include "simeng/arch/riscv/Architecture.hh"
 #include "simeng/arch/riscv/Instruction.hh"
 
-static const char* RISCV_ADDITIONAL_CONFIG = R"YAML(
+[[maybe_unused]] static const char* RISCV_ADDITIONAL_CONFIG = R"YAML(
 {
   Core:
     {

--- a/test/regression/riscv/Syscall.cc
+++ b/test/regression/riscv/Syscall.cc
@@ -620,7 +620,7 @@ TEST_P(Syscall, readlinkat) {
 
   EXPECT_EQ(getGeneralRegister<int64_t>(10), reference.size());
   char* data = processMemory_ + process_->getHeapStart() + 15;
-  for (int i = 0; i < reference.size(); i++) {
+  for (size_t i = 0; i < reference.size(); i++) {
     EXPECT_EQ(data[i], reference.c_str()[i]) << "at index i=" << i << '\n';
   }
 }
@@ -1119,28 +1119,28 @@ TEST_P(Syscall, uname) {
   // Check utsname struct in memory
   char* data = processMemory_ + process_->getHeapStart();
   const char sysname[] = "Linux";
-  for (int i = 0; i < strlen(sysname); i++) EXPECT_EQ(data[i], sysname[i]);
+  for (size_t i = 0; i < strlen(sysname); i++) EXPECT_EQ(data[i], sysname[i]);
 
   // Add 65 to data pointer for reserved length of each string field in Linux
   data += 65;
   const char nodename[] = "fedora-riscv";
-  for (int i = 0; i < strlen(nodename); i++) EXPECT_EQ(data[i], nodename[i]);
+  for (size_t i = 0; i < strlen(nodename); i++) EXPECT_EQ(data[i], nodename[i]);
 
   data += 65;
   const char release[] = "5.5.0-0.rc5.git0.1.1.riscv64.fc32.riscv64";
-  for (int i = 0; i < strlen(release); i++) EXPECT_EQ(data[i], release[i]);
+  for (size_t i = 0; i < strlen(release); i++) EXPECT_EQ(data[i], release[i]);
 
   data += 65;
   const char version[] = "#1 SMP Mon Jan 6 17:31:22 UTC 2020";
-  for (int i = 0; i < strlen(version); i++) EXPECT_EQ(data[i], version[i]);
+  for (size_t i = 0; i < strlen(version); i++) EXPECT_EQ(data[i], version[i]);
 
   data += 65;
   const char machine[] = "riscv64";
-  for (int i = 0; i < strlen(machine); i++) EXPECT_EQ(data[i], machine[i]);
+  for (size_t i = 0; i < strlen(machine); i++) EXPECT_EQ(data[i], machine[i]);
 
   data += 65;
   const char domainname[] = "(none)";
-  for (int i = 0; i < strlen(domainname); i++)
+  for (size_t i = 0; i < strlen(domainname); i++)
     EXPECT_EQ(data[i], domainname[i]);
 }
 

--- a/test/regression/riscv/Syscall.cc
+++ b/test/regression/riscv/Syscall.cc
@@ -621,7 +621,8 @@ TEST_P(Syscall, readlinkat) {
     exit(EXIT_FAILURE);
   }
 
-  std::string reference = std::string(cwd) + std::string("/Default");
+  std::string reference =
+      std::string(cwd) + std::string("/SimEngDefaultProgram");
   // Copy path to heap
   initialHeapData_.resize(strlen(path) + reference.size() + 1);
   memcpy(initialHeapData_.data(), path, strlen(path) + 1);

--- a/test/regression/riscv/Syscall.cc
+++ b/test/regression/riscv/Syscall.cc
@@ -186,7 +186,16 @@ TEST_P(Syscall, faccessat) {
   unlink(filepath);
 
   char abs_filepath[LINUX_PATH_MAX];
-  realpath(SIMENG_RISCV_TEST_ROOT "/data/input.txt", abs_filepath);
+
+  char* output =
+      realpath(SIMENG_RISCV_TEST_ROOT "/data/input.txt", abs_filepath);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] realpath failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
   initialHeapData_.resize(strlen(abs_filepath) + 1);
   // Copy abs_filepath to heap
   memcpy(initialHeapData_.data(), abs_filepath, strlen(abs_filepath) + 1);
@@ -212,7 +221,14 @@ TEST_P(Syscall, faccessat) {
   // Check syscall works using dirfd instead of AT_FDCWD
   const char file[] = "input.txt\0";
   char dirPath[LINUX_PATH_MAX];
-  realpath(SIMENG_RISCV_TEST_ROOT "/data/\0", dirPath);
+
+  output = realpath(SIMENG_RISCV_TEST_ROOT "/data/\0", dirPath);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] realpath failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
   initialHeapData_.resize(strlen(dirPath) + strlen(file) + 2);
   // Copy dirPath to heap
@@ -596,7 +612,15 @@ TEST_P(Syscall, readlinkat) {
   // Get current directory and append the default program's comannd line
   // argument 0 value
   char cwd[LINUX_PATH_MAX];
-  getcwd(cwd, LINUX_PATH_MAX);
+
+  char* output = getcwd(cwd, LINUX_PATH_MAX);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] getcwd failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
   std::string reference = std::string(cwd) + std::string("/Default");
   // Copy path to heap
   initialHeapData_.resize(strlen(path) + reference.size() + 1);
@@ -729,7 +753,14 @@ TEST_P(Syscall, newfstatat) {
   // Check syscall works using dirfd instead of AT_FDCWD
   const char file[] = "input.txt\0";
   char dirPath[LINUX_PATH_MAX];
-  realpath(SIMENG_RISCV_TEST_ROOT "/data/\0", dirPath);
+
+  char* output = realpath(SIMENG_RISCV_TEST_ROOT "/data/\0", dirPath);
+  if (output == NULL) {
+    // Something went wrong
+    std::cerr << "[SimEng:syscall] realpath failed with errno = " << errno
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
   initialHeapData_.resize(128 + strlen(dirPath) + strlen(file) + 2);
   // Copy dirPath to heap

--- a/test/regression/riscv/instructions/compressed.cc
+++ b/test/regression/riscv/instructions/compressed.cc
@@ -626,7 +626,7 @@ TEST_P(InstCompressed, nop) {
   )");
   EXPECT_EQ(getGeneralRegister<uint64_t>(0), 0);
   EXPECT_EQ(getGeneralRegister<uint64_t>(1), 0);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(2), 199840);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(2), 199808);
   EXPECT_EQ(getGeneralRegister<uint64_t>(3), 0);
   EXPECT_EQ(getGeneralRegister<uint64_t>(4), 0);
   EXPECT_EQ(getGeneralRegister<uint64_t>(5), 0);
@@ -672,7 +672,7 @@ TEST_P(InstCompressed, nop) {
   // Ensure state hasn't changed except the number of ticks
   EXPECT_EQ(getGeneralRegister<uint64_t>(0), 0);
   EXPECT_EQ(getGeneralRegister<uint64_t>(1), 0);
-  EXPECT_EQ(getGeneralRegister<uint64_t>(2), 199840);
+  EXPECT_EQ(getGeneralRegister<uint64_t>(2), 199808);
   EXPECT_EQ(getGeneralRegister<uint64_t>(3), 0);
   EXPECT_EQ(getGeneralRegister<uint64_t>(4), 0);
   EXPECT_EQ(getGeneralRegister<uint64_t>(5), 0);

--- a/test/unit/OSTest.cc
+++ b/test/unit/OSTest.cc
@@ -67,7 +67,7 @@ TEST_F(OSTest, processElf_stackPointer) {
 
 TEST_F(OSTest, processHex_stackPointer) {
   os.createProcess(proc_hex);
-  EXPECT_EQ(os.getInitialStackPointer(), 1074790240);
+  EXPECT_EQ(os.getInitialStackPointer(), 1074790208);
   EXPECT_EQ(os.getInitialStackPointer(), proc_hex.getInitialStackPointer());
 }
 

--- a/test/unit/ProcessTest.cc
+++ b/test/unit/ProcessTest.cc
@@ -50,7 +50,7 @@ TEST_F(ProcessTest, createProcess_hex) {
   kernel::LinuxProcess proc = kernel::LinuxProcess(
       span(reinterpret_cast<char*>(demoHex), sizeof(demoHex)));
   EXPECT_TRUE(proc.isValid());
-  EXPECT_EQ(proc.getPath(), "Default\0");
+  EXPECT_EQ(proc.getPath(), "./SimEngDefaultProgram\0");
 }
 
 // Tests get{Heap, Stack, Mmap}Start() functions

--- a/test/unit/SpecialFileDirGenTest.cc
+++ b/test/unit/SpecialFileDirGenTest.cc
@@ -73,7 +73,7 @@ class SpecialFileDirGenTest : public testing::Test {
 // (i.e. the one defined in the YAML string above)
 TEST_F(SpecialFileDirGenTest, genAndDelete) {
   // Make sure files currently do not exist
-  for (int i = 0; i < allFiles_names_Lines.size(); i++) {
+  for (size_t i = 0; i < allFiles_names_Lines.size(); i++) {
     EXPECT_FALSE(
         std::ifstream(TEST_SPEC_FILE_DIR + std::get<0>(allFiles_names_Lines[i]))
             .good());
@@ -83,7 +83,7 @@ TEST_F(SpecialFileDirGenTest, genAndDelete) {
   specFile.GenerateSFDir();
 
   // Validate files exist and are correct
-  for (int i = 0; i < allFiles_names_Lines.size(); i++) {
+  for (size_t i = 0; i < allFiles_names_Lines.size(); i++) {
     EXPECT_TRUE(
         std::ifstream(TEST_SPEC_FILE_DIR + std::get<0>(allFiles_names_Lines[i]))
             .good());
@@ -92,7 +92,7 @@ TEST_F(SpecialFileDirGenTest, genAndDelete) {
     const std::vector<std::string>& knownLines =
         std::get<1>(allFiles_names_Lines[i]);
     std::string line;
-    int numOfLines = 0;
+    size_t numOfLines = 0;
     while (std::getline(file, line)) {
       if (numOfLines > knownLines.size()) {
         break;
@@ -107,7 +107,7 @@ TEST_F(SpecialFileDirGenTest, genAndDelete) {
   specFile.RemoveExistingSFDir();
 
   // Make sure files don't exist
-  for (int i = 0; i < allFiles_names_Lines.size(); i++) {
+  for (size_t i = 0; i < allFiles_names_Lines.size(); i++) {
     EXPECT_FALSE(
         std::ifstream(TEST_SPEC_FILE_DIR + std::get<0>(allFiles_names_Lines[i]))
             .good());

--- a/test/unit/aarch64/ExceptionHandlerTest.cc
+++ b/test/unit/aarch64/ExceptionHandlerTest.cc
@@ -363,7 +363,7 @@ TEST_F(AArch64ExceptionHandlerTest, readBufferThen) {
   EXPECT_FALSE(outcome);
   EXPECT_EQ(retVal, 0);
   EXPECT_EQ(handler.dataBuffer_.size(), 128);
-  for (int i = 0; i < handler.dataBuffer_.size(); i++) {
+  for (size_t i = 0; i < handler.dataBuffer_.size(); i++) {
     EXPECT_EQ(handler.dataBuffer_[i], 'q');
   }
 
@@ -377,7 +377,7 @@ TEST_F(AArch64ExceptionHandlerTest, readBufferThen) {
   EXPECT_TRUE(outcome);
   EXPECT_EQ(retVal, 10);
   EXPECT_EQ(handler.dataBuffer_.size(), length);
-  for (int i = 0; i < length; i++) {
+  for (uint64_t i = 0; i < length; i++) {
     EXPECT_EQ(handler.dataBuffer_[i], static_cast<unsigned char>('q'));
   }
 }

--- a/test/unit/aarch64/InstructionTest.cc
+++ b/test/unit/aarch64/InstructionTest.cc
@@ -114,7 +114,7 @@ TEST_F(AArch64InstructionTest, validInsn) {
   EXPECT_EQ(insn.getBranchType(), BranchType::Unknown);
   EXPECT_EQ(insn.getData().size(), 0);
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
   EXPECT_EQ(insn.getException(), InstructionException::None);
@@ -133,7 +133,7 @@ TEST_F(AArch64InstructionTest, validInsn) {
   // Operands vector resized at decode
   EXPECT_EQ(insn.getSourceOperands().size(), 3);
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
     EXPECT_FALSE(insn.isOperandReady(i));
   }
@@ -177,7 +177,7 @@ TEST_F(AArch64InstructionTest, invalidInsn_1) {
   EXPECT_EQ(insn.getBranchType(), BranchType::Unknown);
   EXPECT_EQ(insn.getData().size(), 0);
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
   EXPECT_EQ(insn.getException(), InstructionException::EncodingUnallocated);
@@ -197,7 +197,7 @@ TEST_F(AArch64InstructionTest, invalidInsn_1) {
   // Operands vector resized at decode
   EXPECT_EQ(insn.getSourceOperands().size(), 0);
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
     EXPECT_FALSE(insn.isOperandReady(i));
   }
@@ -243,7 +243,7 @@ TEST_F(AArch64InstructionTest, invalidInsn_2) {
   EXPECT_EQ(insn.getBranchType(), BranchType::Unknown);
   EXPECT_EQ(insn.getData().size(), 0);
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
   EXPECT_EQ(insn.getException(), InstructionException::HypervisorCall);
@@ -263,7 +263,7 @@ TEST_F(AArch64InstructionTest, invalidInsn_2) {
   // Operands vector resized at decode
   EXPECT_EQ(insn.getSourceOperands().size(), 0);
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
     EXPECT_FALSE(insn.isOperandReady(i));
   }
@@ -297,11 +297,11 @@ TEST_F(AArch64InstructionTest, renameRegs) {
                                    {RegisterType::VECTOR, 0}};
   // Ensure registers decoded correctly
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
   }
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
 
@@ -314,11 +314,11 @@ TEST_F(AArch64InstructionTest, renameRegs) {
   insn.renameSource(1, srcRegs_new[1]);
   // Ensure renaming functionality works as expected
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs_new.size());
-  for (int i = 0; i < srcRegs_new.size(); i++) {
+  for (size_t i = 0; i < srcRegs_new.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs_new[i]);
   }
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs_new.size());
-  for (int i = 0; i < destRegs_new.size(); i++) {
+  for (size_t i = 0; i < destRegs_new.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs_new[i]);
   }
 }
@@ -386,11 +386,11 @@ TEST_F(AArch64InstructionTest, supplyData) {
 
   // Check source and destination registers extracted correctly
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
   }
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
 
@@ -405,7 +405,7 @@ TEST_F(AArch64InstructionTest, supplyData) {
   insn.generateAddresses();
   auto generatedAddresses = insn.getGeneratedAddresses();
   EXPECT_EQ(generatedAddresses.size(), 2);
-  for (int i = 0; i < generatedAddresses.size(); i++) {
+  for (size_t i = 0; i < generatedAddresses.size(); i++) {
     EXPECT_EQ(generatedAddresses[i].address, 0x480 + (i * 0x8));
     EXPECT_EQ(generatedAddresses[i].size, 8);
   }
@@ -414,12 +414,12 @@ TEST_F(AArch64InstructionTest, supplyData) {
   EXPECT_FALSE(insn.hasAllData());
   std::vector<RegisterValue> data = {{123, 8}, {456, 8}};
   EXPECT_EQ(generatedAddresses.size(), data.size());
-  for (int i = 0; i < generatedAddresses.size(); i++) {
+  for (size_t i = 0; i < generatedAddresses.size(); i++) {
     insn.supplyData(generatedAddresses[i].address, data[i]);
   }
   // Ensure data was supplied correctly
   auto retrievedData = insn.getData();
-  for (int i = 0; i < retrievedData.size(); i++) {
+  for (size_t i = 0; i < retrievedData.size(); i++) {
     EXPECT_EQ(retrievedData[i], data[i]);
   }
   EXPECT_TRUE(insn.hasAllData());
@@ -449,7 +449,7 @@ TEST_F(AArch64InstructionTest, supplyData_dataAbort) {
   insn.generateAddresses();
   auto generatedAddresses = insn.getGeneratedAddresses();
   EXPECT_EQ(generatedAddresses.size(), 2);
-  for (int i = 0; i < generatedAddresses.size(); i++) {
+  for (size_t i = 0; i < generatedAddresses.size(); i++) {
     EXPECT_EQ(generatedAddresses[i].address, 0x480 + (i * 0x8));
     EXPECT_EQ(generatedAddresses[i].size, 8);
   }

--- a/test/unit/pipeline/DispatchIssueUnitTest.cc
+++ b/test/unit/pipeline/DispatchIssueUnitTest.cc
@@ -213,7 +213,7 @@ TEST_F(PipelineDispatchIssueUnitTest, singleInstr_exception) {
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes, refRsSizes);
   // Ensure all output ports are empty
-  for (int i = 0; i < output.size(); i++) {
+  for (size_t i = 0; i < output.size(); i++) {
     EXPECT_EQ(output[i].getTailSlots()[0], nullptr);
   }
   // Ensure frontend stall recorded
@@ -230,7 +230,7 @@ TEST_F(PipelineDispatchIssueUnitTest, singleInstr_rsFull) {
 
   // Artificially fill Reservation station with index 2
   std::vector<std::shared_ptr<MockInstruction>> insns(refRsSizes[RS_EAGA]);
-  for (int i = 0; i < insns.size(); i++) {
+  for (size_t i = 0; i < insns.size(); i++) {
     // Initialise instruction
     insns[i] = std::make_shared<MockInstruction>();
     // All expected calls to instruction during tick()
@@ -251,7 +251,7 @@ TEST_F(PipelineDispatchIssueUnitTest, singleInstr_rsFull) {
   std::vector<uint64_t> rsSizes;
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes.size(), refRsSizes.size());
-  for (int i = 0; i < refRsSizes.size(); i++) {
+  for (size_t i = 0; i < refRsSizes.size(); i++) {
     if (i != RS_EAGA) {
       EXPECT_EQ(rsSizes[i], refRsSizes[i]);
     } else {
@@ -277,7 +277,7 @@ TEST_F(PipelineDispatchIssueUnitTest, singleInstr_rsFull) {
   rsSizes.clear();
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes.size(), refRsSizes.size());
-  for (int i = 0; i < refRsSizes.size(); i++) {
+  for (size_t i = 0; i < refRsSizes.size(); i++) {
     if (i != RS_EAGA) {
       EXPECT_EQ(rsSizes[i], refRsSizes[i]);
     } else {
@@ -316,7 +316,7 @@ TEST_F(PipelineDispatchIssueUnitTest, singleInstr_portStall) {
   std::vector<uint64_t> rsSizes;
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes.size(), refRsSizes.size());
-  for (int i = 0; i < refRsSizes.size(); i++) {
+  for (size_t i = 0; i < refRsSizes.size(); i++) {
     if (i != RS_EAGA) {
       EXPECT_EQ(rsSizes[i], refRsSizes[i]);
     } else {
@@ -338,7 +338,7 @@ TEST_F(PipelineDispatchIssueUnitTest, singleInstr_portStall) {
   rsSizes.clear();
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes.size(), refRsSizes.size());
-  for (int i = 0; i < refRsSizes.size(); i++) {
+  for (size_t i = 0; i < refRsSizes.size(); i++) {
     if (i != RS_EAGA) {
       EXPECT_EQ(rsSizes[i], refRsSizes[i]);
     } else {
@@ -346,7 +346,7 @@ TEST_F(PipelineDispatchIssueUnitTest, singleInstr_portStall) {
     }
   }
   // Ensure all output ports are empty
-  for (int i = 0; i < output.size(); i++) {
+  for (size_t i = 0; i < output.size(); i++) {
     EXPECT_EQ(output[i].getTailSlots()[0], nullptr);
   }
   // Ensure portBusyStall and backend stall recorded in issue()
@@ -406,7 +406,7 @@ TEST_F(PipelineDispatchIssueUnitTest, createdependency_raw) {
   std::vector<uint64_t> rsSizes;
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes.size(), refRsSizes.size());
-  for (int i = 0; i < refRsSizes.size(); i++) {
+  for (size_t i = 0; i < refRsSizes.size(); i++) {
     if (i != RS_EAGA) {
       EXPECT_EQ(rsSizes[i], refRsSizes[i]);
     } else {
@@ -414,7 +414,7 @@ TEST_F(PipelineDispatchIssueUnitTest, createdependency_raw) {
     }
   }
   // Ensure all output ports are empty
-  for (int i = 0; i < output.size(); i++) {
+  for (size_t i = 0; i < output.size(); i++) {
     EXPECT_EQ(output[i].getTailSlots()[0], nullptr);
   }
   // Ensure backend stall recorded in issue()
@@ -437,7 +437,7 @@ TEST_F(PipelineDispatchIssueUnitTest, createdependency_raw) {
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes, refRsSizes);
   // Ensure all output ports are empty except EAGA
-  for (int i = 0; i < output.size(); i++) {
+  for (size_t i = 0; i < output.size(); i++) {
     if (i != EAGA)
       EXPECT_EQ(output[i].getTailSlots()[0], nullptr);
     else
@@ -498,7 +498,7 @@ TEST_F(PipelineDispatchIssueUnitTest, purgeFlushed) {
   std::vector<uint64_t> rsSizes;
   diUnit.getRSSizes(rsSizes);
   EXPECT_EQ(rsSizes.size(), refRsSizes.size());
-  for (int i = 0; i < refRsSizes.size(); i++) {
+  for (size_t i = 0; i < refRsSizes.size(); i++) {
     if (i != RS_EAGA) {
       EXPECT_EQ(rsSizes[i], refRsSizes[i]);
     } else {
@@ -506,7 +506,7 @@ TEST_F(PipelineDispatchIssueUnitTest, purgeFlushed) {
     }
   }
   // Ensure all output ports are empty
-  for (int i = 0; i < output.size(); i++) {
+  for (size_t i = 0; i < output.size(); i++) {
     EXPECT_EQ(output[i].getTailSlots()[0], nullptr);
   }
   // Ensure no stalls recorded
@@ -529,7 +529,7 @@ TEST_F(PipelineDispatchIssueUnitTest, purgeFlushed) {
   // Perform issue to see if `uop` is still present
   diUnit.issue();
   // Ensure all output ports are empty
-  for (int i = 0; i < output.size(); i++) {
+  for (size_t i = 0; i < output.size(); i++) {
     EXPECT_EQ(output[i].getTailSlots()[0], nullptr);
   }
   // Ensure frontend stall recorded in issue()
@@ -549,7 +549,7 @@ TEST_F(PipelineDispatchIssueUnitTest, purgeFlushed) {
 
   diUnit.issue();
   // Ensure all output ports are empty
-  for (int i = 0; i < output.size(); i++) {
+  for (size_t i = 0; i < output.size(); i++) {
     EXPECT_EQ(output[i].getTailSlots()[0], nullptr);
   }
   // Ensure frontend stall recorded in issue()

--- a/test/unit/pipeline/RenameUnitTest.cc
+++ b/test/unit/pipeline/RenameUnitTest.cc
@@ -44,8 +44,8 @@ class RenameUnitTest : public testing::Test {
   const Register r1 = {1, 2};
   const Register r2 = {2, 4};
 
-  const unsigned int robSize = 8;
-  const unsigned int lsqQueueSize = 10;
+  const uint64_t robSize = 8;
+  const uint64_t lsqQueueSize = 10;
 
   PipelineBuffer<std::shared_ptr<Instruction>> input;
   PipelineBuffer<std::shared_ptr<Instruction>> output;
@@ -196,7 +196,7 @@ TEST_F(RenameUnitTest, noFreeRegs) {
 // Tests that when ROB is full, no renaming occurs
 TEST_F(RenameUnitTest, fullROB) {
   // Pre-fill ROB
-  for (int i = 0; i < robSize; i++) {
+  for (uint64_t i = 0; i < robSize; i++) {
     rob.reserve(uopPtr);
   }
   EXPECT_EQ(rob.getFreeSpace(), 0);
@@ -264,7 +264,7 @@ TEST_F(RenameUnitTest, loadUop) {
 // Test a LOAD instruction is handled correctly when Load queue is full
 TEST_F(RenameUnitTest, loadUopQueueFull) {
   // pre-fill Load Queue
-  for (int i = 0; i < lsqQueueSize; i++) {
+  for (uint64_t i = 0; i < lsqQueueSize; i++) {
     lsq.addLoad(uopPtr);
   }
   EXPECT_EQ(lsq.getLoadQueueSpace(), 0);
@@ -350,7 +350,7 @@ TEST_F(RenameUnitTest, storeUop) {
 // Test a STORE instruction is handled correctly when Store queue is full
 TEST_F(RenameUnitTest, storeUopQueueFull) {
   // pre-fill Load Queue
-  for (int i = 0; i < lsqQueueSize; i++) {
+  for (uint64_t i = 0; i < lsqQueueSize; i++) {
     lsq.addStore(uopPtr);
   }
   EXPECT_EQ(lsq.getStoreQueueSpace(), 0);

--- a/test/unit/riscv/ExceptionHandlerTest.cc
+++ b/test/unit/riscv/ExceptionHandlerTest.cc
@@ -362,7 +362,7 @@ TEST_F(RiscVExceptionHandlerTest, readBufferThen) {
   EXPECT_FALSE(outcome);
   EXPECT_EQ(retVal, 0);
   EXPECT_EQ(handler.dataBuffer_.size(), 128);
-  for (int i = 0; i < handler.dataBuffer_.size(); i++) {
+  for (size_t i = 0; i < handler.dataBuffer_.size(); i++) {
     EXPECT_EQ(handler.dataBuffer_[i], 'q');
   }
 
@@ -376,7 +376,7 @@ TEST_F(RiscVExceptionHandlerTest, readBufferThen) {
   EXPECT_TRUE(outcome);
   EXPECT_EQ(retVal, 10);
   EXPECT_EQ(handler.dataBuffer_.size(), length);
-  for (int i = 0; i < length; i++) {
+  for (size_t i = 0; i < length; i++) {
     EXPECT_EQ(handler.dataBuffer_[i], static_cast<unsigned char>('q'));
   }
 }

--- a/test/unit/riscv/InstructionTest.cc
+++ b/test/unit/riscv/InstructionTest.cc
@@ -112,7 +112,7 @@ TEST_F(RiscVInstructionTest, validInsn) {
   EXPECT_EQ(insn.getBranchType(), BranchType::Unknown);
   EXPECT_EQ(insn.getData().size(), 0);
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
   EXPECT_EQ(insn.getException(), InstructionException::None);
@@ -129,7 +129,7 @@ TEST_F(RiscVInstructionTest, validInsn) {
   EXPECT_EQ(insn.getSequenceId(), 12);
   EXPECT_EQ(insn.getSourceOperands().size(), 2);
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
     EXPECT_FALSE(insn.isOperandReady(i));
   }
@@ -173,7 +173,7 @@ TEST_F(RiscVInstructionTest, invalidInsn_1) {
   EXPECT_EQ(insn.getBranchType(), BranchType::Unknown);
   EXPECT_EQ(insn.getData().size(), 0);
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
   EXPECT_EQ(insn.getException(), InstructionException::EncodingUnallocated);
@@ -191,7 +191,7 @@ TEST_F(RiscVInstructionTest, invalidInsn_1) {
   EXPECT_EQ(insn.getSequenceId(), 14);
   EXPECT_EQ(insn.getSourceOperands().size(), 0);
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
     EXPECT_FALSE(insn.isOperandReady(i));
   }
@@ -237,7 +237,7 @@ TEST_F(RiscVInstructionTest, invalidInsn_2) {
   EXPECT_EQ(insn.getBranchType(), BranchType::Unknown);
   EXPECT_EQ(insn.getData().size(), 0);
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
   EXPECT_EQ(insn.getException(), InstructionException::HypervisorCall);
@@ -255,7 +255,7 @@ TEST_F(RiscVInstructionTest, invalidInsn_2) {
   EXPECT_EQ(insn.getSequenceId(), 16);
   EXPECT_EQ(insn.getSourceOperands().size(), 0);
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
     EXPECT_FALSE(insn.isOperandReady(i));
   }
@@ -288,11 +288,11 @@ TEST_F(RiscVInstructionTest, renameRegs) {
                                    {RegisterType::GENERAL, 10}};
   // Ensure registers decoded correctly
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
   }
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
 
@@ -304,11 +304,11 @@ TEST_F(RiscVInstructionTest, renameRegs) {
   insn.renameSource(1, srcRegs_new[1]);
   // Ensure renaming functionality works as expected
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs_new.size());
-  for (int i = 0; i < srcRegs_new.size(); i++) {
+  for (size_t i = 0; i < srcRegs_new.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs_new[i]);
   }
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs_new.size());
-  for (int i = 0; i < destRegs_new.size(); i++) {
+  for (size_t i = 0; i < destRegs_new.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs_new[i]);
   }
 }
@@ -367,11 +367,11 @@ TEST_F(RiscVInstructionTest, supplyData) {
 
   // Check source and destination registers extracted correctly
   EXPECT_EQ(insn.getSourceRegisters().size(), srcRegs.size());
-  for (int i = 0; i < srcRegs.size(); i++) {
+  for (size_t i = 0; i < srcRegs.size(); i++) {
     EXPECT_EQ(insn.getSourceRegisters()[i], srcRegs[i]);
   }
   EXPECT_EQ(insn.getDestinationRegisters().size(), destRegs.size());
-  for (int i = 0; i < destRegs.size(); i++) {
+  for (size_t i = 0; i < destRegs.size(); i++) {
     EXPECT_EQ(insn.getDestinationRegisters()[i], destRegs[i]);
   }
 
@@ -396,7 +396,7 @@ TEST_F(RiscVInstructionTest, supplyData) {
   insn.supplyData(generatedAddresses[0].address, data[0]);
   // Ensure data was supplied correctly
   auto retrievedData = insn.getData();
-  for (int i = 0; i < retrievedData.size(); i++) {
+  for (size_t i = 0; i < retrievedData.size(); i++) {
     EXPECT_EQ(retrievedData[i], data[i]);
   }
   EXPECT_TRUE(insn.hasAllData());


### PR DESCRIPTION
This PR aims to fix all compiler warning.

A default binary is added to allow for proper execution of the readlinkat test as well as to give some output when run with no input.