### PR TITLE
Corrected RISC-V shift word instructions

### DIFF
--- a/src/lib/arch/riscv/Instruction_execute.cc
+++ b/src/lib/arch/riscv/Instruction_execute.cc
@@ -243,14 +243,14 @@ void Instruction::execute() {
     case Opcode::RISCV_SLLW: {  // SLLW rd,rs1,rs2
       const int32_t rs1 = sourceValues_[0].get<int32_t>();
       const int32_t rs2 =
-          sourceValues_[1].get<int32_t>() & 63;  // Only use lowest 6 bits
+          sourceValues_[1].get<int32_t>() & 31;  // Only use lowest 5 bits
       int64_t out = signExtendW(static_cast<int32_t>(rs1 << rs2));
       results_[0] = RegisterValue(out, 8);
       break;
     }
     case Opcode::RISCV_SLLIW: {  // SLLIW rd,rs1,shamt
       const int32_t rs1 = sourceValues_[0].get<uint32_t>();
-      const int32_t shamt = sourceImm_ & 63;  // Only use lowest 6 bits
+      const int32_t shamt = sourceImm_ & 31;  // Only use lowest 5 bits
       uint64_t out = signExtendW(static_cast<uint32_t>(rs1 << shamt));
       results_[0] = RegisterValue(out, 8);
       break;
@@ -273,14 +273,14 @@ void Instruction::execute() {
     case Opcode::RISCV_SRLW: {  // SRLW rd,rs1,rs2
       const uint32_t rs1 = sourceValues_[0].get<uint32_t>();
       const uint32_t rs2 =
-          sourceValues_[1].get<uint32_t>() & 63;  // Only use lowest 6 bits
+          sourceValues_[1].get<uint32_t>() & 31;  // Only use lowest 5 bits
       uint64_t out = signExtendW(static_cast<uint64_t>(rs1 >> rs2));
       results_[0] = RegisterValue(out, 8);
       break;
     }
     case Opcode::RISCV_SRLIW: {  // SRLIW rd,rs1,shamt
       const uint32_t rs1 = sourceValues_[0].get<uint32_t>();
-      const uint32_t shamt = sourceImm_ & 63;  // Only use lowest 6 bits
+      const uint32_t shamt = sourceImm_ & 31;  // Only use lowest 5 bits
       uint64_t out = signExtendW(static_cast<uint32_t>(rs1 >> shamt));
       results_[0] = RegisterValue(out, 8);
       break;
@@ -303,14 +303,14 @@ void Instruction::execute() {
     case Opcode::RISCV_SRAW: {  // SRAW rd,rs1,rs2
       const int32_t rs1 = sourceValues_[0].get<int32_t>();
       const int32_t rs2 =
-          sourceValues_[1].get<int32_t>() & 63;  // Only use lowest 6 bits
+          sourceValues_[1].get<int32_t>() & 31;  // Only use lowest 5 bits
       int64_t out = static_cast<int32_t>(rs1 >> rs2);
       results_[0] = RegisterValue(out, 8);
       break;
     }
     case Opcode::RISCV_SRAIW: {  // SRAIW rd,rs1,shamt
       const int32_t rs1 = sourceValues_[0].get<int32_t>();
-      const int32_t shamt = sourceImm_ & 63;  // Only use lowest 6 bits
+      const int32_t shamt = sourceImm_ & 31;  // Only use lowest 5 bits
       int64_t out = static_cast<int32_t>(rs1 >> shamt);
       results_[0] = RegisterValue(out, 8);
       break;


### PR DESCRIPTION
I spotted that the RISC-V instructions for shifting words have a minor inaccuracy. In the 64-bit variants, we take the lowest 6 bits (up to 63) for the `shamt` (shift-amount). In the word (32 bit) variants, we should only be taking the lowest 5 bits (up to 31) for `shamt`, as there are only 31 bit positions to shift before you've looped back.

Functionally, this inaccuracy caused no issues due to the cyclic nature of shifts. If you are to shift a 32 bit number by `shamt=34`, this is equivalent to `shamt=2`. Due to this, all tests previously passed and still do pass. For the sake of being spec accurate, this change should be made to limit the shifts of words to 31. No test can be written to cover this due to them being functionally identical.

I've verified for each instruction that this is correct compared to the RISC-V unprivileged spec, SAIL, and the spike implementation of these instructions.

From the spec:

> In RV64I, only the low 6 bits of rs2 are considered for the shift amount.
> SLLW, SRLW, and SRAW are RV64I-only instructions that are analogously defined but operate
> on 32-bit values and produce signed 32-bit results. The shift amount is given by rs2[4:0].