### PR TITLE
Ensure Emulation core executes each micro-op to completion in 1 cycle

### DIFF
--- a/.jenkins/build_test_run.sh
+++ b/.jenkins/build_test_run.sh
@@ -63,7 +63,7 @@ run () {
     cat run
     echo ""
     compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "6708" "retired instructions"
-    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "7955" "simulated cycles"
+    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "6736" "simulated cycles"
     echo ""
 
     ./bin/simeng "$SIMENG_TOP"/configs/tx2.yaml > run

--- a/.jenkins/build_test_run.sh
+++ b/.jenkins/build_test_run.sh
@@ -63,7 +63,7 @@ run () {
     cat run
     echo ""
     compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "6721" "retired instructions"
-    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "6736" "simulated cycles"
+    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "6721" "simulated cycles"
     echo ""
 
     ./bin/simeng "$SIMENG_TOP"/configs/tx2.yaml > run

--- a/.jenkins/build_test_run.sh
+++ b/.jenkins/build_test_run.sh
@@ -62,7 +62,7 @@ run () {
     echo "Simulation without configuration file argument:"
     cat run
     echo ""
-    compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "6708" "retired instructions"
+    compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "6721" "retired instructions"
     compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "6736" "simulated cycles"
     echo ""
 

--- a/src/include/simeng/models/emulation/Core.hh
+++ b/src/include/simeng/models/emulation/Core.hh
@@ -59,9 +59,6 @@ class Core : public simeng::Core {
   /** A reusable macro-op vector to fill with uops. */
   MacroOp macroOp_;
 
-  /** An internal buffer for storing one or more uops. */
-  std::queue<std::shared_ptr<Instruction>> microOps_;
-
   /** The previously generated addresses. */
   std::vector<simeng::memory::MemoryAccessTarget> previousAddresses_;
 

--- a/src/include/simeng/models/emulation/Core.hh
+++ b/src/include/simeng/models/emulation/Core.hh
@@ -71,9 +71,6 @@ class Core : public simeng::Core {
   /** The length of the available instruction memory. */
   uint64_t programByteLength_ = 0;
 
-  /** Is the core waiting on a data read? */
-  uint64_t pendingReads_ = 0;
-
   /** The number of instructions executed. */
   uint64_t instructionsExecuted_ = 0;
 

--- a/src/lib/arch/aarch64/Instruction_decode.cc
+++ b/src/lib/arch/aarch64/Instruction_decode.cc
@@ -487,12 +487,14 @@ void Instruction::decode() {
     // LDADD* are considered to be both a load and a store
     if (metadata_.id >= ARM64_INS_LDADD && metadata_.id <= ARM64_INS_LDADDLH) {
       setInstructionType(InsnType::isLoad);
+      setInstructionType(InsnType::isStoreData);
     }
 
     // CASAL* are considered to be both a load and a store
     if (metadata_.opcode == Opcode::AArch64_CASALW ||
         metadata_.opcode == Opcode::AArch64_CASALX) {
       setInstructionType(InsnType::isLoad);
+      setInstructionType(InsnType::isStoreData);
     }
 
     if (isInstruction(InsnType::isStoreData)) {

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -83,7 +83,7 @@ void Core::tick() {
       }
     }
 
-    // Execute
+    // Execute & Write-back
     if (uop->isLoad()) {
       auto addresses = uop->generateAddresses();
       previousAddresses_.clear();
@@ -139,6 +139,7 @@ void Core::tick() {
     execute(uop);
     macroOp_.erase(macroOp_.begin());
   }
+  // Commit
   instructionsExecuted_++;
   // Fetch memory for next cycle
   instructionMemory_.requestRead({pc_, FETCH_SIZE});

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -172,18 +172,11 @@ void Core::execute(std::shared_ptr<Instruction>& uop) {
   }
 
   // Writeback
-  auto results = uop->getResults();
-  auto destinations = uop->getDestinationRegisters();
-  if (uop->isStoreData()) {
-    for (size_t i = 0; i < results.size(); i++) {
-      auto reg = destinations[i];
-      registerFileSet_.set(reg, results[i]);
-    }
-  } else {
-    for (size_t i = 0; i < results.size(); i++) {
-      auto reg = destinations[i];
-      registerFileSet_.set(reg, results[i]);
-    }
+  const auto& results = uop->getResults();
+  const auto& destinations = uop->getDestinationRegisters();
+  for (size_t i = 0; i < results.size(); i++) {
+    auto reg = destinations[i];
+    registerFileSet_.set(reg, results[i]);
   }
 }
 

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -97,7 +97,7 @@ void Core::tick() {
       return;
     }
     if (addresses.size() > 0) {
-      // Memory reads required; request them.
+      // Memory reads required; request them
       for (auto const& target : addresses) {
         dataMemory_.requestRead(target);
         // Save addresses for use by instructions that perform a LD and STR
@@ -105,7 +105,7 @@ void Core::tick() {
         previousAddresses_.push_back(target);
       }
       // Emulation core can only be used with a Flat memory interface, so data
-      // is ready immediately.
+      // is ready immediately
       const auto& completedReads = dataMemory_.getCompletedReads();
       assert(completedReads.size() == addresses.size() &&
              "Number of completed reads does not match the number of requested "

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -106,6 +106,9 @@ void Core::tick() {
       }
       // Emulation core can only be used with a Flat memory interface, so data
       // is ready immediately
+      assert((config::SimInfo::getConfig()["L1-Data-Memory"]["Interface-Type"]
+                  .as<std::string>() == "Flat") &&
+             "Emulation core is only compatable with a Flat Memory Interface.");
       const auto& completedReads = dataMemory_.getCompletedReads();
       assert(completedReads.size() == addresses.size() &&
              "Number of completed reads does not match the number of requested "
@@ -226,6 +229,11 @@ void Core::processExceptionHandler() {
 
   // Clear the handler
   exceptionHandler_ = nullptr;
+
+  // For an exception to reach this part of the code, it must be something akin
+  // to a system call, which itself should be counted as an instruction
+  // finishing execution.
+  instructionsExecuted_++;
 
   // Fetch memory for next cycle
   instructionMemory_.requestRead({pc_, FETCH_SIZE});

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -130,7 +130,6 @@ void Core::tick() {
     execute(uop);
     macroOp_.erase(macroOp_.begin());
   }
-  // Commit
   instructionsExecuted_++;
   // Fetch memory for next cycle
   instructionMemory_.requestRead({pc_, FETCH_SIZE});
@@ -189,12 +188,8 @@ void Core::processExceptionHandler() {
   assert(exceptionHandler_ != nullptr &&
          "Attempted to process an exception handler that wasn't present");
 
-  while (true) {
-    bool success = exceptionHandler_->tick();
-    if (success) {
-      // No more ticks needed to complete exception
-      break;
-    }
+  // Tick until true is returned, signifying completion
+  while (exceptionHandler_->tick() == false) {
   }
 
   const auto& result = exceptionHandler_->getResult();

--- a/src/lib/models/emulation/Core.cc
+++ b/src/lib/models/emulation/Core.cc
@@ -69,9 +69,6 @@ void Core::tick() {
       handleException(uop);
       // If fatal, return
       if (hasHalted_) return;
-      // Else, move onto next micro-op
-      macroOp_.erase(macroOp_.begin());
-      continue;
     }
 
     // Issue
@@ -91,9 +88,6 @@ void Core::tick() {
         handleException(uop);
         // If fatal, return
         if (hasHalted_) return;
-        // Else, move onto next micro-op
-        macroOp_.erase(macroOp_.begin());
-        continue;
       }
       if (addresses.size() > 0) {
         // Memory reads required; request them
@@ -122,9 +116,6 @@ void Core::tick() {
         handleException(uop);
         // If fatal, return
         if (hasHalted_) return;
-        // Else, move onto next micro-op
-        macroOp_.erase(macroOp_.begin());
-        continue;
       }
       // Store addresses for use by next store data operation in `execute()`
       for (auto const& target : addresses) {

--- a/src/lib/models/inorder/Core.cc
+++ b/src/lib/models/inorder/Core.cc
@@ -39,9 +39,10 @@ Core::Core(memory::MemoryInterface& instructionMemory,
 }
 
 void Core::tick() {
-  ticks_++;
-
   if (hasHalted_) return;
+
+  ticks_++;
+  isa_.updateSystemTimerRegisters(&registerFileSet_, ticks_);
 
   if (exceptionHandler_ != nullptr) {
     processExceptionHandler();
@@ -104,7 +105,6 @@ void Core::tick() {
   }
 
   fetchUnit_.requestFromPC();
-  isa_.updateSystemTimerRegisters(&registerFileSet_, ticks_);
 }
 
 bool Core::hasHalted() const {

--- a/src/lib/models/outoforder/Core.cc
+++ b/src/lib/models/outoforder/Core.cc
@@ -101,9 +101,10 @@ Core::Core(memory::MemoryInterface& instructionMemory,
 }
 
 void Core::tick() {
-  ticks_++;
-
   if (hasHalted_) return;
+
+  ticks_++;
+  isa_.updateSystemTimerRegisters(&registerFileSet_, ticks_);
 
   if (exceptionHandler_ != nullptr) {
     processExceptionHandler();
@@ -156,7 +157,6 @@ void Core::tick() {
 
   flushIfNeeded();
   fetchUnit_.requestFromPC();
-  isa_.updateSystemTimerRegisters(&registerFileSet_, ticks_);
 }
 
 bool Core::hasHalted() const {


### PR DESCRIPTION
The previous emulation core implementation did not ensure that load instructions completed in a single cycle. Given we restrict emulation cores to only use Flat emmory interfaces (i.e. no cycle delay to update or access memory) there is no need for each load instruction to take 2 cycles.

This PR also simplifies some of the logic in the `tick()` function of the emulation core.