### PR TITLE
Fix shift.value

### DIFF
--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -1903,9 +1903,11 @@ void InstructionMetadata::revertAliasing() {
 
         operands[1].type = ARM64_OP_REG;
         operands[1].access = CS_AC_READ;
+        operands[1].shift.value = 0;
 
         operands[2].type = ARM64_OP_REG;
         operands[2].access = CS_AC_READ;
+        operands[2].shift.value = 0;
 
         if (opcode == Opcode::AArch64_CSINCWr) {
           operands[1].reg = ARM64_REG_WZR;

--- a/src/lib/arch/aarch64/InstructionMetadata.cc
+++ b/src/lib/arch/aarch64/InstructionMetadata.cc
@@ -1903,11 +1903,11 @@ void InstructionMetadata::revertAliasing() {
 
         operands[1].type = ARM64_OP_REG;
         operands[1].access = CS_AC_READ;
-        operands[1].shift.value = 0;
+        operands[1].shift = {ARM64_SFT_INVALID, 0};
 
         operands[2].type = ARM64_OP_REG;
         operands[2].access = CS_AC_READ;
-        operands[2].shift.value = 0;
+        operands[2].shift = {ARM64_SFT_INVALID, 0};
 
         if (opcode == Opcode::AArch64_CSINCWr) {
           operands[1].reg = ARM64_REG_WZR;

--- a/src/lib/arch/aarch64/Instruction_decode.cc
+++ b/src/lib/arch/aarch64/Instruction_decode.cc
@@ -277,8 +277,16 @@ void Instruction::decode() {
           sourceRegisterCount_++;
           sourceOperandsPending_++;
         }
-        if (op.shift.value > 0)
+        // TODO checking of the shift type is a temporary fix to help reduce the
+        // chance of incorrectly reverted aliases from being mis-classified as
+        // isShift when op.shift contains garbage data. This should be reviewed
+        // on the next capstone update which should remove the need to revert
+        // aliasing
+        if (op.shift.type > arm64_shifter::ARM64_SFT_INVALID &&
+            op.shift.type <= arm64_shifter::ARM64_SFT_ROR &&
+            op.shift.value > 0) {
           setInstructionType(InsnType::isShift);  // Identify shift operands
+        }
       }
     } else if (op.type == ARM64_OP_MEM) {  // Memory operand
       accessesMemory = true;


### PR DESCRIPTION
Set values for shift.value when resolving alias for CSET instruction. This was causing differing numbers of cycles and stall in the CI when compiling with armclang and gcc