### PR TITLE
Fixing LoopBuffer bug

### DIFF
--- a/.jenkins/build_test_run.sh
+++ b/.jenkins/build_test_run.sh
@@ -71,7 +71,7 @@ run () {
     cat run
     echo ""
     compare_outputs "$(grep "retired:" run | rev | cut -d ' ' -f1 | rev)" "6724" "retired instructions"
-    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "8677" "simulated cycles"
+    compare_outputs "$(grep "cycles:" run | rev | cut -d ' ' -f1 | rev)" "8612" "simulated cycles"
     echo ""
 }
 

--- a/src/include/simeng/Instruction.hh
+++ b/src/include/simeng/Instruction.hh
@@ -157,7 +157,7 @@ class Instruction {
     // Flag as mispredicted if taken state was wrongly predicted, or taken and
     // predicted target is wrong
     return (branchTaken_ != prediction_.taken ||
-            (prediction_.target != branchAddress_));
+            (branchTaken_ && (prediction_.target != branchAddress_)));
   }
 
   /** Check whether an exception has been encountered while processing this

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -183,7 +183,7 @@ void FetchUnit::tick() {
         // therefore Loop Buffer stays idle
         loopBufferState_ = LoopBufferState::IDLE;
       } else {
-        // Otherwise, start to fill loop buffer
+        // Otherwise, start to fill Loop Buffer
         loopBufferState_ = LoopBufferState::FILLING;
       }
     }

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -179,7 +179,7 @@ void FetchUnit::tick() {
       // Now that the loopBoundaryAddress_ has been set, start filling Loop
       // Buffer is the branch predictor tells us to reenter the detected loop
       if (macroOp[0]->isBranch() && !macroOp[0]->getBranchPrediction().taken) {
-        // If branch is not taken then detected loop is not longer relevant,
+        // If branch is not taken then detected loop is no longer relevant,
         // therefore Loop Buffer stays idle
         loopBufferState_ = LoopBufferState::IDLE;
       } else {

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -177,7 +177,7 @@ void FetchUnit::tick() {
     } else if (loopBufferState_ == LoopBufferState::WAITING &&
                pc_ == loopBoundaryAddress_) {
       // Now that the loopBoundaryAddress_ has been set, start filling Loop
-      // Buffer is the branch predictor tells us to reenter the detected loop
+      // Buffer if the branch predictor tells us to reenter the detected loop
       if (macroOp[0]->isBranch() && !macroOp[0]->getBranchPrediction().taken) {
         // If branch is not taken then detected loop is no longer relevant,
         // therefore Loop Buffer stays idle

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -176,11 +176,12 @@ void FetchUnit::tick() {
       }
     } else if (loopBufferState_ == LoopBufferState::WAITING &&
                pc_ == loopBoundaryAddress_) {
-      // Now that the loopBoundaryAddress_ has been set, start filling Loop
-      // Buffer if the branch predictor tells us to reenter the detected loop
+      // loopBoundaryAddress_ has been fetched whilst loop buffer is waiting,
+      // start filling Loop Buffer if the branch predictor tells us to
+      // reenter the detected loop
       if (macroOp[0]->isBranch() && !macroOp[0]->getBranchPrediction().taken) {
-        // If branch is not taken then detected loop is no longer relevant,
-        // therefore Loop Buffer stays idle
+        // If branch is not taken then we aren't re-entering the detected
+        // loop, therefore Loop Buffer stays idle
         loopBufferState_ = LoopBufferState::IDLE;
       } else {
         // Otherwise, start to fill Loop Buffer

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -176,10 +176,14 @@ void FetchUnit::tick() {
       }
     } else if (loopBufferState_ == LoopBufferState::WAITING &&
                pc_ == loopBoundaryAddress_) {
+      // Now that the loopBoundaryAddress_ has been set, start filling Loop
+      // Buffer is the branch predictor tells us to reenter the detected loop
       if (macroOp[0]->isBranch() && !macroOp[0]->getBranchPrediction().taken) {
+        // If branch is not taken then detected loop is not longer relevant,
+        // therefore Loop Buffer stays idle
         loopBufferState_ = LoopBufferState::IDLE;
       } else {
-        // Once set loopBoundaryAddress_ is fetched, start to fill loop buffer
+        // Otherwise, start to fill loop buffer
         loopBufferState_ = LoopBufferState::FILLING;
       }
     }

--- a/src/lib/pipeline/FetchUnit.cc
+++ b/src/lib/pipeline/FetchUnit.cc
@@ -176,8 +176,12 @@ void FetchUnit::tick() {
       }
     } else if (loopBufferState_ == LoopBufferState::WAITING &&
                pc_ == loopBoundaryAddress_) {
-      // Once set loopBoundaryAddress_ is fetched, start to fill loop buffer
-      loopBufferState_ = LoopBufferState::FILLING;
+      if (macroOp[0]->isBranch() && !macroOp[0]->getBranchPrediction().taken) {
+        loopBufferState_ = LoopBufferState::IDLE;
+      } else {
+        // Once set loopBoundaryAddress_ is fetched, start to fill loop buffer
+        loopBufferState_ = LoopBufferState::FILLING;
+      }
     }
 
     assert(bytesRead <= bufferedBytes_ &&


### PR DESCRIPTION
Updates how a LoopBuffer is begun; and how branch mispredicts are determined by the execute units.

This was motivated by the incorrect misprediction calculation in the execute.  However, doing so resulted in a bug.  The changes to when the LoopBuffer is used by the Fetch Unit fixes this bug.