### PR TITLE
Added cstdint header to Register.hh

### DIFF
--- a/src/include/simeng/Register.hh
+++ b/src/include/simeng/Register.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>
+#include <cstdint>
 
 namespace simeng {
 

--- a/src/include/simeng/Register.hh
+++ b/src/include/simeng/Register.hh
@@ -1,6 +1,6 @@
 #pragma once
-#include <iostream>
 #include <cstdint>
+#include <iostream>
 
 namespace simeng {
 


### PR DESCRIPTION
Adds the `cstdint` header to Register.hh, which has caused some compilers to not recognise the `uint8_t` etc types.
As per Issue #426 